### PR TITLE
GRIMOIRE GDD Google Sheet 연결

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# GRIMOIRE: 세계를 다시 쓰는 법 
+# GRIMOIRE: 세계를 다시 쓰는 법
 
 모바일 터치 기반 마법 글자·회로 전투와 마법학교 생활을 결합한 Godot 프로젝트입니다.
 
-- 저장소: `https://github.com/alsdmlals4-eng/Spell`
+- 저장소: `https://github.com/alsdmlals4-eng/GRIMOIRE-`
 - 엔진: Godot
 - 목표 플랫폼: Android / Google Play
-- 제품 단계: `PROTOTYPE_AND_VERTICAL_SLICE`
+- 제품 단계: `DEMO_FIRST_VERTICAL_SLICE`
 - Gate 1: `APPROVED`
 - 프로젝트 코어: `CORE_CONFIRMED`
 - 실행 프로필: `PLANNING_ONLY_PROFILE`
@@ -26,6 +26,7 @@
 8. `docs/planning/GATE_2_SUMMON_GROWTH_AND_FORM_SYSTEM.md`
 9. `docs/DEVELOPMENT_GATES.md`
 10. `docs/DESIGN_DOCUMENT_REGISTRY.json`
+11. `docs/PROJECT_GOOGLE_SHEET_WORKBOOK.md`
 
 ## Vertical Slice
 
@@ -98,10 +99,20 @@ START_HERE
 → 주제별 책임 원본
 ```
 
+## GDD Google Sheets 운영
+
+- Base·Skill 기준 원본: `docs/BASE_RULES_VERSION.md`
+- Sheet 상태: `PROJECT_SHEET_CONFIGURED`
+- Workbook 계약: `docs/PROJECT_GOOGLE_SHEET_WORKBOOK.md`
+- Workbook 역할: `USER_FACING_GDD_WORKSPACE`
+- 사용자 Sheet 편집: `PROPOSED_SHEET_CHANGE`
+- GitHub에 없는 Sheet 변경은 자동 정본화하지 않는다.
+- 승인 후 GitHub와 Sheet를 모두 재조회한 경우에만 `SYNCED`로 판정한다.
+
 ## 다음 결정
 
 `ART-STYLE-01`
 
 승인된 필드 SD·대화 반신·별도 전투장·원소 정령 소환수 구성을 동일하게 사용해 그림체 후보를 예상 인게임 이미지로 비교합니다.
 
-현재는 대량 자산 제작, Godot 구현, Codex 실행, Draft PR 병합을 하지 않습니다.
+현재는 대량 자산 제작, Godot 구현, Codex 실행을 하지 않습니다.

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -1,4 +1,4 @@
-# 스펠 시작 지점
+# GRIMOIRE 시작 지점
 
 > 새 사용자·GPT·Codex·작업자가 현재 상태, 확정 결정과 다음 작업을 가장 먼저 확인하는 대시보드다.
 
@@ -6,7 +6,7 @@
 
 | 항목 | 현재 기준 |
 |---|---|
-| 제품 단계 | `PROTOTYPE_AND_VERTICAL_SLICE` |
+| 제품 단계 | `DEMO_FIRST_VERTICAL_SLICE` |
 | Gate 1 | `APPROVED` |
 | 프로젝트 코어 | `CORE_CONFIRMED` |
 | 실행 프로필 | `PLANNING_ONLY_PROFILE` |
@@ -19,8 +19,10 @@
 | 구현 | `NOT_STARTED` |
 | Codex | `NOT_RUN` |
 | 이미지·사운드 대량 제작 | `NOT_STARTED` |
+| Google Sheet | `PROJECT_SHEET_CONFIGURED` |
+| Workbook 역할 | `USER_FACING_GDD_WORKSPACE` |
 | 다음 차단 결정 | `ART-STYLE-01` |
-| 기준 브랜치 | `gpt/planning-spell-20260725` |
+| 기준 브랜치 | `main` |
 
 ## 먼저 읽을 문서
 
@@ -37,7 +39,8 @@
 11. `docs/DESIGN_DOCUMENT_REGISTRY.json`
 12. `docs/ASSET_LICENSE_LEDGER.md`
 13. `skills/SKILL_REGISTRY.json`
-14. `docs/DOCUMENTATION_MAP.md`
+14. `docs/PROJECT_GOOGLE_SHEET_WORKBOOK.md`
+15. `docs/DOCUMENTATION_MAP.md`
 
 ## 재질문 방지
 
@@ -117,6 +120,14 @@
 - 메인 2~4단계·형상 선택 UI·탑승은 후행
 - 전투 소환수 4역할 전체·성장·탑승은 미확정
 
+## GDD Google Sheets 규칙
+
+- Sheet는 독립 정본이 아니라 `USER_FACING_GDD_WORKSPACE`다.
+- GitHub에 없는 편집은 `PROPOSED_SHEET_CHANGE`로 보존한다.
+- 확정 결정·임시 값·미검증 상태를 같은 값으로 취급하지 않는다.
+- 승인 후 GitHub와 Sheet를 모두 재조회한 경우에만 `SYNCED`로 판정한다.
+- `05_GDD_요약`, `15_조작_게임규칙`, `51_미니게임`, `52_글쓰기_서사`를 포함한 검증 탭은 `docs/PROJECT_GOOGLE_SHEET_WORKBOOK.md`가 소유한다.
+
 ## 이미지 작업 규칙
 
 - 이미지 관련 선택은 가능한 경우 인게임 예상 이미지로 제시
@@ -144,7 +155,7 @@ ART-STYLE-01
 - 별도 CORE_POC 재도입
 - `VERTICAL_SLICE_FULL_PROFILE` 자동 전환
 - Godot 구현·Codex 실행
-- PR 병합
+- 사용자 명시적 요청과 검증 없는 PR 병합
 
 ## 다음 결정
 

--- a/docs/BASE_RULES_VERSION.md
+++ b/docs/BASE_RULES_VERSION.md
@@ -1,65 +1,69 @@
-# Spell Base 규칙 버전
+# GRIMOIRE Base 규칙 버전
 
 ## 현재 채택 기준
 
 | 항목 | 기준 |
 |---|---|
-| 프로젝트 | `alsdmlals4-eng/Spell` |
-| 프로젝트명 | `스펠` (임시) |
-| 적용 브랜치 | `gpt/planning-spell-20260725` |
+| 프로젝트 | `alsdmlals4-eng/GRIMOIRE-` |
+| 프로젝트명 | `GRIMOIRE: 세계를 다시 쓰는 법` |
+| 적용 브랜치 | `main` |
 | Base 저장소 | `alsdmlals4-eng/Base` |
-| Base 전체 운영체계 채택 Commit | `438f41afd510c827c3097341bd9e5f9c9b0e1dd0` |
-| Base 공용 Skill route Commit | `438f41afd510c827c3097341bd9e5f9c9b0e1dd0` |
-| 동기화 날짜 | 2026-07-27 |
-| v6 계약 | `VERTICAL_SLICE_MASTER_REFERENCE 6.0` |
-| 현재 제품 단계 | `CONCEPT_APPROVAL` |
+| GDD·운영체계 기준 Commit | `c987647d01ad2baa028a16e03d85ddfc1572a727` |
+| 동기화 날짜 | 2026-07-29 |
+| 통합 실행문 | `VERTICAL_SLICE_INTEGRATED_EXECUTION_PROMPT_v8.md` |
+| v6 계약 | 역사·호환 참고 자료 |
+| 현재 제품 단계 | `DEMO_FIRST_VERTICAL_SLICE` |
 | 실행 프로필 | `PLANNING_ONLY_PROFILE` |
 | Work Mode | `PLAN` |
+| Google Sheet | `PROJECT_SHEET_CONFIGURED` |
+| Workbook 역할 | `USER_FACING_GDD_WORKSPACE` |
 
-현재 전체 운영체계 채택 기준과 공용 Skill route 기준은 같다. 어느 한쪽만 갱신할 경우 범위·이유·검증 결과를 이 문서에 분리해서 기록한다.
+이 Commit은 5개 프로젝트에 동일한 GDD Google Sheets 의미 구조를 설치하기 위한 기준선이다. 이후 Base의 UX/UI·합성 테스터 추가 Commit은 프로젝트별 별도 채택·검증 대상으로 두며 자동 덮어쓰지 않는다.
 
 ## 저장소 계약 경로
 
-- 축약 실행문: `docs/contracts/VERTICAL_SLICE_EXECUTION_PROMPT_SHORT_v6.md`
-- 마스터 원본 Manifest: `docs/contracts/VERTICAL_SLICE_MASTER_REFERENCE_v6.md`
-- 원본 마스터 SHA-256: `005b330261e70a2f4f1f0a51c0729c21ee3bf55ca0a0be8178711691b35a6963`
 - 프로젝트 최상위 규칙: `AGENTS.md`
 - 프로젝트 시작점: `START_HERE.md`
+- 현재 결정: `docs/planning/CURRENT_CONFIRMED_DECISIONS.md`
+- 현재 상태: `docs/ACTIVE_CONTEXT.md`
 - 문서 지도: `docs/DOCUMENTATION_MAP.md`
 - 제품·작업 게이트: `docs/DEVELOPMENT_GATES.md`
 - Design Registry: `docs/DESIGN_DOCUMENT_REGISTRY.json`
 - Base Skill route: `skills/SKILL_REGISTRY.json`
 - 프로젝트 어댑터: `skills/PROJECT_BASE_SKILL_ADAPTER.json`
 - 전문 extension route: `skills/BASE_SHARED_SKILL_ROUTES.json`
-- 운영체계 검증: `docs/OPERATING_SYSTEM_HEALTH_REPORT.md`
+- GDD Workbook 계약: `docs/PROJECT_GOOGLE_SHEET_WORKBOOK.md`
+- 이미지 생성·검수: `docs/GPT_IMAGE_GENERATION_AND_REVIEW_WORKFLOW.md`
+- v6 축약 실행문: `docs/contracts/VERTICAL_SLICE_EXECUTION_PROMPT_SHORT_v6.md`
+- v6 마스터 Manifest: `docs/contracts/VERTICAL_SLICE_MASTER_REFERENCE_v6.md`
 
 ## 적용 우선순위
 
 ```text
 최신 사용자 요청·승인
 → AGENTS.md
-→ 이 BASE_RULES_VERSION.md와 v6 계약
-→ START_HERE.md
-→ docs/ACTIVE_CONTEXT.md
-→ docs/DOCUMENTATION_MAP.md·docs/DEVELOPMENT_GATES.md
-→ docs/DESIGN_DOCUMENT_REGISTRY.json의 책임 원본
-→ skills/SKILL_REGISTRY.json과 프로젝트 어댑터
-→ 현재 Issue·Goal·Plan·PR
-→ 실제 파일·테스트
-→ 고정된 Base 원격 Commit
+→ CURRENT_CONFIRMED_DECISIONS.md
+→ ACTIVE_CONTEXT.md
+→ 주제별 책임 원본
+→ DEVELOPMENT_GATES.md·DESIGN_DOCUMENT_REGISTRY.json
+→ SKILL_REGISTRY.json·프로젝트 어댑터
+→ PROJECT_GOOGLE_SHEET_WORKBOOK.md와 실제 Sheet
+→ 실제 코드·Scene·Resource·데이터·자산·테스트
+→ 고정된 Base Commit
 → 과거 대화·외부 AI 결과·추정
 ```
 
 ## Base 적용 방식
 
-Base Skill 본문을 Spell 저장소에 복제하지 않는다.
+Base Skill 본문을 GRIMOIRE 저장소에 복제하거나 전부 기본 로드하지 않는다.
 
 ```text
-Base skills/SKILL_REGISTRY.json의 자동 Trigger 선택
+Base skills/SKILL_REGISTRY.json 자동 Trigger 선택
 → skills/PROJECT_BASE_SKILL_ADAPTER.json
 → skills/BASE_SHARED_SKILL_ROUTES.json
 → 필요한 전문 extension
-→ Spell 고유 책임만 프로젝트 로컬 Skill
+→ GRIMOIRE 고유 책임
+→ GitHub 정본·Google Sheet·실제 구현 대조
 ```
 
 현재 필수 extension route:
@@ -72,32 +76,27 @@ Base skills/SKILL_REGISTRY.json의 자동 Trigger 선택
 | 책임 | Base Skill | 현재 상태 |
 |---|---|---|
 | 요청 접수·실행 계약 | `managing-project-intake-and-work-contract` | route·contract 적용 |
-| 운영체계 | `managing-game-project-operating-system` | audit→승인→Governance foundation 설치→verify 완료, 일부 검사 `NOT_RUN` |
-| 프로젝트 코어 조사 | `identifying-project-core` | 읽기 전용 기준선 확인 |
-| 콘셉트·CORE_POC | `analyzing-and-refining-game-concepts` | 다음 기획 단계에서 순차 실행 |
-| 코어 승인 | `establishing-project-core` | 사용자 승인 전 미실행 |
-| 기획 문서 | `managing-design-documents` | Registry·정본 연결 적용 |
-| 버티컬 슬라이스 | `designing-vertical-slices` | 코어 승인·CORE_POC 이후 실행 |
-| 적대적 검토 | `running-adversarial-review-and-refinement` | 주요 Gate에서 실행 |
-| 통합 검증 | `reviewing-and-validating-project-changes` | 문서 참조 검증 적용, 런타임은 `NOT_RUN` |
-| 컨텍스트·인계 | `maintaining-project-context-and-handoff` | Active Context 갱신 적용 |
+| 운영체계 | `managing-game-project-operating-system` | 프로젝트 정본·Sheet·Registry 연결 |
+| 프로젝트 코어 조사 | `identifying-project-core` | `CORE_CONFIRMED` 보호 |
+| 콘셉트·방향 | `analyzing-and-refining-game-concepts` | Gate 1 승인, 명시적 근거 없이 재개방 금지 |
+| 기획 문서 | `managing-design-documents` | 정본·결정 원장·Sheet 동기화 책임 |
+| Vertical Slice | `designing-vertical-slices` | `DEMO_FIRST_VERTICAL_SLICE`, 구현 전 계획 단계 |
+| 적대적 검토 | `running-adversarial-review-and-refinement` | `repository-wide-audit` 포함 |
+| 통합 검증 | `reviewing-and-validating-project-changes` | 문서·Sheet 정적 검증, 런타임 `NOT_RUN` |
+| 컨텍스트·인계 | `maintaining-project-context-and-handoff` | 승인 결정 후 Active Context 갱신 |
+| 이미지 계획·검수 | `designing-art-prompts-and-technique-cards` | 생성 후보와 최종 자산 상태 분리 |
 
-## 동기화 규칙
+## Sheet 동기화 규칙
 
-Base pin을 변경할 때 다음을 함께 확인한다.
-
-1. Base `START_HERE.md`, `AGENTS.md`, `docs/OPERATING_MODEL.md`, `docs/DOCUMENTATION_MAP.md`
-2. Base `skills/SKILL_REGISTRY.json`과 `skills/BASE_SHARED_SKILL_ROUTES.json`
-3. Spell `AGENTS.md`, Documentation Map, Development Gates
-4. Spell Skill Registry와 프로젝트 어댑터
-5. v6 계약과 충돌 여부
-6. 기존 프로젝트 결정·보호 경로·정상 동작 보존
-7. 실행한 검증과 `NOT_RUN` 항목
-
-Base commit 변경만으로 Godot 구현·CI·발행·Codex 인수를 자동 승인하지 않는다.
+1. Sheet는 독립 정본이 아니라 `USER_FACING_GDD_WORKSPACE`다.
+2. GitHub에 없는 편집은 `PROPOSED_SHEET_CHANGE`로 보존한다.
+3. 승인된 변경은 GitHub 책임 원본·Registry·Sheet에 반영한다.
+4. 양쪽을 재조회해 값·상태·책임 경로가 일치할 때만 `SYNCED`로 판정한다.
+5. 구현·런타임·사람 검증을 실행하지 않았다면 `NOT_RUN` 또는 `BLOCKED_UNVERIFIED`로 남긴다.
 
 ## 변경 기록
 
 | 날짜 | 이전 기준 | 새 기준 | 범위 | 검증 | 결과 |
 |---|---|---|---|---|---|
 | 2026-07-27 | 없음 | `438f41afd510c827c3097341bd9e5f9c9b0e1dd0` | Governance foundation·v6 계약·Skill route | 원격 경로·정본·콜드 스타트·Git 비교 | `PASS_WITH_NOT_RUN` |
+| 2026-07-29 | `438f41afd510c827c3097341bd9e5f9c9b0e1dd0` | `c987647d01ad2baa028a16e03d85ddfc1572a727` | GDD Sheet 의미 구조·Demo-First·이미지 검수·Registry 연결 | Sheet 재조회·JSON 정적 검증·책임 경로 비교 | `PASS_WITH_RUNTIME_NOT_RUN` |

--- a/docs/PROJECT_GOOGLE_SHEET_WORKBOOK.md
+++ b/docs/PROJECT_GOOGLE_SHEET_WORKBOOK.md
@@ -1,0 +1,61 @@
+# GRIMOIRE 프로젝트 Google Sheets Workbook
+
+```yaml
+project: GRIMOIRE: 세계를 다시 쓰는 법
+sheet_status: PROJECT_SHEET_CONFIGURED
+spreadsheet_url: https://docs.google.com/spreadsheets/d/19FftrZ4WzB-CXa9Q-y25iKMhmEs1Ip4Ea3ramf2xKqM/edit
+spreadsheet_id: 19FftrZ4WzB-CXa9Q-y25iKMhmEs1Ip4Ea3ramf2xKqM
+workbook_role: USER_FACING_GDD_WORKSPACE
+sheet_edit_policy: PROPOSED_SHEET_CHANGE
+base_commit: c987647d01ad2baa028a16e03d85ddfc1572a727
+last_verified_at: 2026-07-29
+```
+
+Google Sheets는 마법 작성·학교 일정·전술 전투·소환수·미니게임·서사의 전체 흐름을 사용자가 확인·수정하고, AI가 GitHub 정본·실제 구현과 함께 읽는 GDD 작업면이다. Sheet 단독 값으로 승인·구현·검증 완료를 확정하지 않는다.
+
+## 검증된 탭
+
+- `00_프로젝트_허브`
+- `01_작업순서`
+- `02_현재_확정결정`
+- `03_근거_라이브러리`
+- `04_누락_충돌_감사`
+- `05_GDD_요약`
+- `10_제품방향`
+- `11_세계관`
+- `12_핵심루프`
+- `13_주요인물`
+- `14_조연_세력_관계`
+- `15_조작_게임규칙`
+- `20_코어경험_데모목표`
+- `30_데모범위_품질기준_제작기반`
+- `40_핵심시스템_메인콘텐츠`
+- `41_성장_경제`
+- `50_메인콘텐츠`
+- `51_미니게임`
+- `52_글쓰기_서사`
+- `60_UX_UI_접근성`
+- `70_아트_오디오_에셋`
+- `71_이미지기획_생성목록`
+- `72_이미지검수_승인로그`
+- `80_데모_버티컬슬라이스_플레이테스트`
+- `90_본제작_출시_사업`
+- `98_Base_반영후보`
+- `99_변경이력`
+
+## 프로젝트 책임 매핑
+
+| 의미 구조 | 프로젝트 책임 원본 |
+|---|---|
+| 핵심루프 | 학교 일정 → 마법 작성·확인 → 의미 조합 → 상황 검증 → 세계 변화 → 마도서 기록 |
+| Vertical Slice | Gate 1 승인 정본과 Gate 2 시각·전투·소환수 문서 |
+| 미니게임·서사 | `51_미니게임`, `52_글쓰기_서사`와 Situation Challenge 정본 |
+| 아트·이미지 | `ART-STYLE-01`, `docs/GPT_IMAGE_GENERATION_AND_REVIEW_WORKFLOW.md` |
+| 구현 상태 | `IMPLEMENTATION_NOT_STARTED`; 실제 인식 알고리즘 미선택 |
+
+## 동기화 규칙
+
+- GitHub 정본에 없는 사용자 수정은 `PROPOSED_SHEET_CHANGE`로 보존한다.
+- 승인된 변경은 GitHub 책임 원본과 Sheet에 반영한 뒤 양쪽을 재조회한다.
+- 생성 이미지나 simulated 후보는 실제 인식 정확도·지연·런타임 증거가 아니다.
+- `SYNCED`는 GitHub와 Sheet의 값·상태·책임 경로가 모두 일치할 때만 사용한다.

--- a/skills/SKILL_REGISTRY.json
+++ b/skills/SKILL_REGISTRY.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 2,
-  "registry_role": "spell-project-skill-router",
+  "registry_role": "grimoire-project-skill-router",
   "project": {
-    "repository": "alsdmlals4-eng/Spell",
-    "name": "스펠",
-    "product_stage": "PROTOTYPE_AND_VERTICAL_SLICE",
+    "repository": "alsdmlals4-eng/GRIMOIRE-",
+    "name": "GRIMOIRE: 세계를 다시 쓰는 법",
+    "product_stage": "DEMO_FIRST_VERTICAL_SLICE",
     "gate_1_status": "APPROVED",
     "project_core_status": "CORE_CONFIRMED",
     "execution_profile": "PLANNING_ONLY_PROFILE",
@@ -18,7 +18,7 @@
   },
   "base_registry_route": {
     "repository": "alsdmlals4-eng/Base",
-    "commit": "438f41afd510c827c3097341bd9e5f9c9b0e1dd0",
+    "commit": "c987647d01ad2baa028a16e03d85ddfc1572a727",
     "source_registry": "skills/SKILL_REGISTRY.json",
     "selection": "automatic-trigger-match",
     "automatic_selection": true,
@@ -26,11 +26,16 @@
     "adapter": "skills/PROJECT_BASE_SKILL_ADAPTER.json",
     "extension_routes": "skills/BASE_SHARED_SKILL_ROUTES.json",
     "copy_skill_bodies_to_project": false,
-    "load_all_skills": false
+    "load_all_skills": false,
+    "integrated_execution_prompt": "templates/prompts/VERTICAL_SLICE_INTEGRATED_EXECUTION_PROMPT_v8.md",
+    "project_sheet_status": "PROJECT_SHEET_CONFIGURED",
+    "project_sheet_url": "https://docs.google.com/spreadsheets/d/19FftrZ4WzB-CXa9Q-y25iKMhmEs1Ip4Ea3ramf2xKqM/edit",
+    "project_sheet_id": "19FftrZ4WzB-CXa9Q-y25iKMhmEs1Ip4Ea3ramf2xKqM",
+    "project_sheet_role": "USER_FACING_GDD_WORKSPACE",
+    "project_sheet_edit_policy": "PROPOSED_SHEET_CHANGE",
+    "project_sheet_last_verified_at": "2026-07-29"
   },
   "execution_contracts": {
-    "short_v6": "docs/contracts/VERTICAL_SLICE_EXECUTION_PROMPT_SHORT_v6.md",
-    "master_v6_manifest": "docs/contracts/VERTICAL_SLICE_MASTER_REFERENCE_v6.md",
     "project_agents": "AGENTS.md",
     "start_here": "START_HERE.md",
     "active_context": "docs/ACTIVE_CONTEXT.md",
@@ -43,7 +48,12 @@
     "latest_adversarial_review": "docs/planning/GATE_2_ADVERSARIAL_REVIEW_LOOP_2026-07-27B.md",
     "visual_presentation": "docs/planning/GATE_2_VISUAL_PRESENTATION_SYSTEM.md",
     "character_presentation": "docs/planning/GATE_2_CHARACTER_PRESENTATION_SYSTEM.md",
-    "summon_growth_and_form": "docs/planning/GATE_2_SUMMON_GROWTH_AND_FORM_SYSTEM.md"
+    "summon_growth_and_form": "docs/planning/GATE_2_SUMMON_GROWTH_AND_FORM_SYSTEM.md",
+    "integrated_v8": "Base:templates/prompts/VERTICAL_SLICE_INTEGRATED_EXECUTION_PROMPT_v8.md",
+    "project_sheet": "docs/PROJECT_GOOGLE_SHEET_WORKBOOK.md",
+    "image_workflow": "docs/GPT_IMAGE_GENERATION_AND_REVIEW_WORKFLOW.md",
+    "short_v6_legacy": "docs/contracts/VERTICAL_SLICE_EXECUTION_PROMPT_SHORT_v6.md",
+    "master_v6_manifest_legacy": "docs/contracts/VERTICAL_SLICE_MASTER_REFERENCE_v6.md"
   },
   "routing_policy": {
     "minimum_sufficient_skill_per_subtask": true,
@@ -94,53 +104,109 @@
   "active_base_routes": [
     {
       "skill_id": "managing-project-intake-and-work-contract",
-      "modes": ["route", "clarify", "contract", "decompose-and-sequence", "execution-report"],
+      "modes": [
+        "route",
+        "clarify",
+        "contract",
+        "decompose-and-sequence",
+        "execution-report"
+      ],
       "current_use": "Every non-trivial planning, review, workflow, asset, or implementation request"
     },
     {
       "skill_id": "managing-game-project-operating-system",
-      "modes": ["audit", "reconcile-legacy", "verify"],
+      "modes": [
+        "audit",
+        "reconcile-legacy",
+        "verify"
+      ],
       "current_use": "State reconciliation, canonical routing, and cold-start verification"
     },
     {
       "skill_id": "maintaining-project-context-and-handoff",
-      "modes": ["context-refresh", "session-handoff", "implementation-package-handoff"],
+      "modes": [
+        "context-refresh",
+        "session-handoff",
+        "implementation-package-handoff"
+      ],
       "current_use": "Refresh current decision snapshot and Active Context after every approved decision"
     },
     {
       "skill_id": "analyzing-and-refining-game-concepts",
-      "modes": ["recalibrate", "production-gate"],
+      "modes": [
+        "recalibrate",
+        "production-gate"
+      ],
       "current_use": "Gate 1 is approved; reopen core only with explicit evidence and user decision"
     },
     {
       "skill_id": "identifying-project-core",
-      "modes": ["read-only-core-identification"],
+      "modes": [
+        "read-only-core-identification"
+      ],
       "current_use": "Protect CORE_CONFIRMED and distinguish support, shell, removed, and unverified elements"
     },
     {
       "skill_id": "managing-design-documents",
-      "modes": ["author", "update", "restructure", "validate"],
-      "current_use": "Maintain current snapshot, decision ledger, art and audio preproduction sources"
+      "modes": [
+        "author",
+        "update",
+        "restructure",
+        "validate"
+      ],
+      "current_use": "Maintain current snapshot, decision ledger, Sheet semantic structure, art and audio preproduction sources"
     },
     {
       "skill_id": "designing-vertical-slices",
-      "modes": ["quality-bar", "pipeline-proof", "playtest-evidence", "decision-gate"],
+      "modes": [
+        "quality-bar",
+        "pipeline-proof",
+        "playtest-evidence",
+        "decision-gate"
+      ],
       "current_use": "Approved Slice quality and pipeline planning; implementation blocked by profile transition"
     },
     {
       "skill_id": "running-adversarial-review-and-refinement",
-      "modes": ["review-scope-map", "attack", "validate-critique", "route-findings", "refine-approved-findings", "regression-recheck", "decision-report"],
-      "current_use": "Review loop 02 completed; repeat after Art Bible, Asset Specification, Audio Direction, and major changes"
+      "modes": [
+        "review-scope-map",
+        "attack",
+        "validate-critique",
+        "route-findings",
+        "refine-approved-findings",
+        "regression-recheck",
+        "decision-report",
+        "repository-wide-audit"
+      ],
+      "current_use": "Repeat after Art Bible, Asset Specification, Audio Direction, Sheet contract changes, and major decisions"
     },
     {
       "skill_id": "reviewing-and-validating-project-changes",
-      "modes": ["contract-check", "reference-freshness", "static-validation", "accessibility-review", "regression", "evidence-report"],
-      "current_use": "Documentation and visual-reference validation now; runtime validation after implementation"
+      "modes": [
+        "contract-check",
+        "reference-freshness",
+        "static-validation",
+        "accessibility-review",
+        "regression",
+        "evidence-report"
+      ],
+      "current_use": "Documentation, Sheet, and visual-reference validation now; runtime validation after implementation"
     },
     {
       "skill_id": "auditing-canonical-reference-freshness",
-      "modes": ["reference-freshness"],
-      "current_use": "Required whenever decisions, canonical paths, Registry, asset ledger, or generated references change"
+      "modes": [
+        "reference-freshness"
+      ],
+      "current_use": "Required whenever decisions, canonical paths, Registry, Sheet contract, asset ledger, or generated references change"
+    },
+    {
+      "skill_id": "designing-art-prompts-and-technique-cards",
+      "modes": [
+        "planning-visualization",
+        "final-visual-candidate",
+        "visual-qa-and-approval"
+      ],
+      "current_use": "Generate planning and final-candidate images and review them before asset approval"
     }
   ],
   "required_extension_routes": [
@@ -162,7 +228,7 @@
     "gate_1_concept": {
       "status": "APPROVED"
     },
-    "gate_2_prototype_vertical_slice": {
+    "gate_2_demo_first_vertical_slice": {
       "status": "ENTERED_PLANNING_ONLY",
       "current_substage": "ART_STYLE_SELECTION",
       "completed_preproduction_decisions": [
@@ -179,7 +245,59 @@
         "codex": "BLOCKED_BY_PROFILE_TRANSITION",
         "godot_implementation": "BLOCKED_BY_PROFILE_TRANSITION",
         "runtime_validation": "BLOCKED_BY_IMPLEMENTATION"
-      }
+      },
+      "legacy_gate_alias": "PROTOTYPE_AND_VERTICAL_SLICE"
     }
+  },
+  "bca_visual_sheet": {
+    "status": "ADOPTED",
+    "sheet_status": "PROJECT_SHEET_CONFIGURED",
+    "spreadsheet_url": "https://docs.google.com/spreadsheets/d/19FftrZ4WzB-CXa9Q-y25iKMhmEs1Ip4Ea3ramf2xKqM/edit",
+    "spreadsheet_id": "19FftrZ4WzB-CXa9Q-y25iKMhmEs1Ip4Ea3ramf2xKqM",
+    "workbook_role": "USER_FACING_GDD_WORKSPACE",
+    "sheet_edit_policy": "PROPOSED_SHEET_CHANGE",
+    "last_verified_at": "2026-07-29",
+    "required_tabs": [
+      "00_프로젝트_허브",
+      "01_작업순서",
+      "02_현재_확정결정",
+      "03_근거_라이브러리",
+      "04_누락_충돌_감사",
+      "05_GDD_요약",
+      "10_제품방향",
+      "11_세계관",
+      "12_핵심루프",
+      "13_주요인물",
+      "14_조연_세력_관계",
+      "15_조작_게임규칙",
+      "20_코어경험_데모목표",
+      "30_데모범위_품질기준_제작기반",
+      "40_핵심시스템_메인콘텐츠",
+      "41_성장_경제",
+      "50_메인콘텐츠",
+      "51_미니게임",
+      "52_글쓰기_서사",
+      "60_UX_UI_접근성",
+      "70_아트_오디오_에셋",
+      "71_이미지기획_생성목록",
+      "72_이미지검수_승인로그",
+      "80_데모_버티컬슬라이스_플레이테스트",
+      "90_본제작_출시_사업",
+      "98_Base_반영후보",
+      "99_변경이력"
+    ],
+    "image_modes": [
+      "planning-visualization",
+      "final-visual-candidate",
+      "visual-qa-and-approval"
+    ],
+    "image_state_aliases": {
+      "CONCEPT_EXPLORATION": "GENERATED_EXPLORATION",
+      "VISUAL_REFERENCE_CANDIDATE": "IN_REVIEW_OR_APPROVED_CANDIDATE",
+      "USER_APPROVED_VISUAL_REFERENCE": "APPROVED_CANDIDATE",
+      "ART_BIBLE_APPROVED": "DIRECTION_CANON_APPROVED",
+      "RUNTIME_ASSET_APPROVED": "PROJECT_ASSET_APPROVED_OR_APPLIED_AND_RUNTIME_VERIFIED"
+    },
+    "adversarial_mode": "repository-wide-audit"
   }
 }

--- a/tests/test_project_gdd_sheet_contract.py
+++ b/tests/test_project_gdd_sheet_contract.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BASE_SHA = "c987647d01ad2baa028a16e03d85ddfc1572a727"
+SHEET_ID = "19FftrZ4WzB-CXa9Q-y25iKMhmEs1Ip4Ea3ramf2xKqM"
+REQUIRED_TABS = {
+    "00_프로젝트_허브",
+    "05_GDD_요약",
+    "15_조작_게임규칙",
+    "51_미니게임",
+    "52_글쓰기_서사",
+    "99_변경이력",
+}
+
+
+class ProjectGddSheetContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.registry = json.loads(
+            (ROOT / "skills/SKILL_REGISTRY.json").read_text(encoding="utf-8")
+        )
+        self.workbook = (ROOT / "docs/PROJECT_GOOGLE_SHEET_WORKBOOK.md").read_text(
+            encoding="utf-8"
+        )
+
+    def test_registry_contract(self) -> None:
+        route = self.registry["base_registry_route"]
+        sheet = self.registry["bca_visual_sheet"]
+        self.assertEqual(route["commit"], BASE_SHA)
+        self.assertEqual(route["project_sheet_status"], "PROJECT_SHEET_CONFIGURED")
+        self.assertEqual(route["project_sheet_id"], SHEET_ID)
+        self.assertEqual(route["project_sheet_role"], "USER_FACING_GDD_WORKSPACE")
+        self.assertEqual(route["project_sheet_edit_policy"], "PROPOSED_SHEET_CHANGE")
+        self.assertEqual(sheet["spreadsheet_id"], SHEET_ID)
+        self.assertTrue(REQUIRED_TABS <= set(sheet["required_tabs"]))
+
+    def test_workbook_contract(self) -> None:
+        for token in (
+            "PROJECT_SHEET_CONFIGURED",
+            SHEET_ID,
+            "USER_FACING_GDD_WORKSPACE",
+            "PROPOSED_SHEET_CHANGE",
+            BASE_SHA,
+            *sorted(REQUIRED_TABS),
+        ):
+            self.assertIn(token, self.workbook)
+
+    def test_project_state_is_not_overclaimed(self) -> None:
+        project = self.registry["project"]
+        self.assertEqual(project["product_stage"], "DEMO_FIRST_VERTICAL_SLICE")
+        self.assertEqual(project["implementation_status"], "NOT_STARTED")
+        self.assertEqual(project["work_mode"], "PLAN")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목표

최신 GRIMOIRE `main`의 승인된 코어·UX/UI·마법 작성 검증 계획을 보존하면서, 이미 구성하고 재조회한 Google Sheets를 사용자용 GDD 작업면으로 연결합니다.

## 적용 상태

- GDD Sheet 기준 Base: `c987647d01ad2baa028a16e03d85ddfc1572a727`
- 별도 UX/UI 계약 기준: `docs/UX_UI_SYSTEM.md`의 최신 Base content commit 유지
- Google Sheet: `PROJECT_SHEET_CONFIGURED`
- Spreadsheet ID: `19FftrZ4WzB-CXa9Q-y25iKMhmEs1Ip4Ea3ramf2xKqM`
- Workbook 역할: `USER_FACING_GDD_WORKSPACE`
- 사용자 Sheet 편집 정책: `PROPOSED_SHEET_CHANGE`
- 확인일: `2026-07-29`

## 변경 범위

- `docs/PROJECT_GOOGLE_SHEET_WORKBOOK.md` 추가
- `skills/SKILL_REGISTRY.json`에 Sheet URL·ID·역할·27개 탭·이미지 lifecycle 연결
- `README.md`, `START_HERE.md`, `docs/BASE_RULES_VERSION.md` 진입 경로 정리
- `tests/test_project_gdd_sheet_contract.py` 추가
- 제품 코드·Godot Scene·Resource·게임 데이터·자산 변경 없음

## 검증 경계

- Google Sheet 구조·내용·서식·날짜·Asia/Seoul 시간대 재조회: PASS
- GitHub 브랜치 Registry·Workbook·진입 문서 재조회: PASS
- JSON은 `json.dumps` 기반으로 생성하고 GitHub에서 재조회함
- 저장소 PR용 Actions workflow: 없음
- Godot 런타임·실기기·사람 검증: `NOT_RUN`
