### PR TITLE
docs: 마법 작성 합성 검증 마무리·인계

### DIFF
--- a/docs/DOCUMENTATION_MAP_ADDENDUM_2026-07-29_MAGIC_WRITING_SYNTHETIC_CLOSURE.md
+++ b/docs/DOCUMENTATION_MAP_ADDENDUM_2026-07-29_MAGIC_WRITING_SYNTHETIC_CLOSURE.md
@@ -1,0 +1,36 @@
+# GRIMOIRE Documentation Map Addendum — 마법 작성 합성 검증 종료
+
+```yaml
+applies_to: docs/DOCUMENTATION_MAP.md
+addendum_date: 2026-07-29
+addendum_scope: MAGIC_WRITING_SYNTHETIC_VALIDATION_CLOSURE
+canonical_map_replaced: false
+product_authority_changed: false
+blocking_product_decision: ART-STYLE-01
+```
+
+기존 Documentation Map의 `마법 글자 작성·인식 사람 검증 Artifact` 다음에 아래 책임 경로를 추가해 읽는다.
+
+| 책임 | 문서 | 상태 |
+|---|---|---|
+| 교정된 마법 작성 Artifact 합성 세션 | `docs/planning/GATE_2_MAGIC_WRITING_SYNTHETIC_SESSION_EXECUTION_2026-07-29.md` | `ADAPT / T6_AI_INFERENCE / HUMAN_AND_DEVICE_NOT_RUN` |
+| 합성 검증 전체 계보·종료·다음 진입점 | `docs/planning/GATE_2_MAGIC_WRITING_SYNTHETIC_VALIDATION_CLOSURE_2026-07-29.md` | `RESEARCH_HANDOFF / NO_IMPLEMENTATION_AUTHORITY` |
+
+## 상태 Addendum
+
+- 카드 UX 합성 판정: `ADAPT / RESEARCH_ONLY`
+- 사람 검증: `NOT_RUN`
+- Android touch: `NOT_RUN`
+- recognizer 정확도·latency·confidence calibration: `NOT_RUN`
+- recognizer 선정: `false`
+- `ART-STYLE-01`: 유지
+- Godot·Scene·Resource·Save Schema·룬 정본·알고리즘: 변경 없음
+
+## 다음 라우팅
+
+1. 제품 기획 차단 결정은 계속 `ART-STYLE-01`이다.
+2. 독립 연구 재개 시 종료 기록을 먼저 읽는다.
+3. 후보 정책·오류 힌트 수준을 문서 계약으로 정의한다.
+4. 실제 touch와 recognizer Prototype은 `ART-STYLE-01` 이후 별도 게이트로 분리한다.
+
+이 Addendum은 Gate 1·Gate 2 승인 정본이나 제품 구현 권한을 변경하지 않는다.

--- a/docs/planning/GATE_2_MAGIC_WRITING_SYNTHETIC_VALIDATION_CLOSURE_2026-07-29.md
+++ b/docs/planning/GATE_2_MAGIC_WRITING_SYNTHETIC_VALIDATION_CLOSURE_2026-07-29.md
@@ -1,0 +1,85 @@
+# GRIMOIRE 마법 글자 작성·인식 합성 검증 종료·인계
+
+```yaml
+closure_id: GRIMOIRE-SYNTH-CLOSURE-001
+closed_at: 2026-07-29
+validation_method: SYNTHETIC_TESTER_SIMULATION
+evidence_tier: T6_AI_INFERENCE
+synthetic_session_result: ADAPT
+human_validation: NOT_RUN
+android_touch_validation: NOT_RUN
+recognizer_validation: NOT_RUN
+actual_latency: NOT_RUN
+confidence_calibration: NOT_RUN
+recognizer_selected: false
+art_style_gate_changed: false
+product_code_changed: false
+canon_changed: false
+implementation_authority: NONE
+```
+
+## 1. 완료된 계보
+
+1. Evidence Pilot: `docs/planning/GATE_2_MAGIC_WRITING_INPUT_EVIDENCE_PACK_2026-07-29.md`
+2. 사람 검증 Artifact: `docs/superpowers/plans/2026-07-29-magic-writing-input-validation-artifact.md`
+3. 합성 구조 분석: `docs/planning/GATE_2_SYNTHETIC_TESTER_STRUCTURE_ANALYSIS_2026-07-29.md`
+4. 1차 합성 위험 검토: `docs/planning/GATE_2_MAGIC_WRITING_SYNTHETIC_TESTER_REPORT_2026-07-29.md`
+5. 교정된 Artifact 합성 세션: `docs/planning/GATE_2_MAGIC_WRITING_SYNTHETIC_SESSION_EXECUTION_2026-07-29.md`
+
+## 2. 최종 잠정 판정
+
+유지할 방향:
+
+- 의도 후보 포함과 미포함 시나리오 분리.
+- 입력 성공과 순수 주문 설계 실패 분리.
+- 마지막 획 정답 직접 공개 제거.
+- 낮은 확신 상태에서 시전 잠금.
+- 카드 UX와 실제 recognizer 기술 검증 분리.
+
+수정이 필요한 위험:
+
+- 후보 목록이 직접 쓰기보다 빠른 대체 입력이 될 가능성.
+- 애매한 입력을 반복해 원하는 후보 pool을 탐색하는 전략.
+- 의도 후보가 없을 때 비대상 후보를 억지 선택.
+- 중립 오류 정보만으로 부분 수정 위치를 찾기 어려움.
+- 실제 recognizer가 부분 수정에 필요한 안정적 근거를 제공하지 못할 가능성.
+- UI 외 입력 경로를 통한 시전 잠금 우회 가능성.
+
+따라서 최종 판정은 `ADAPT`이며 인식 알고리즘·룬·세계관·아트·Android 사용성을 확정하지 않는다.
+
+## 3. 다음 진입점
+
+문서 계약으로 먼저 확정할 항목:
+
+- 후보 개수 상한.
+- 원본 stroke와 후보 사이의 유사도 하한.
+- 후보 반복 생성 비용 또는 제한.
+- 오류 힌트의 단계적 범위.
+- 모든 입력 경로에 적용되는 시전 잠금.
+- ground-truth dataset과 recognizer Prototype의 분리.
+
+```yaml
+next_gate: DEFINE_CANDIDATE_POLICY_AND_ERROR_HINT_LEVEL
+technical_followup: BUILD_SEPARATE_TOUCH_AND_RECOGNIZER_PROTOTYPES_AFTER_ART_STYLE_DECISION
+blocking_product_decision: ART-STYLE-01
+```
+
+`ART-STYLE-01`을 통과하기 전에는 룬 정본·대량 아트·Godot 제품 구현을 시작하지 않는다.
+
+## 4. 검증·통합 기록
+
+- 실행 PR: #13
+- PR HEAD 연결 Actions run: 없음
+- 수동 범위 검증: 계획·보고서 두 파일만 변경
+- 수동 경계 검증: `T6_AI_INFERENCE`, 실제 검증 `NOT_RUN`, `ART-STYLE-01` 유지, 제품·정본 비변경
+- squash merge: `85ac0f6a50021df8262ec61274bf288400b4718c`
+- 최종 권한 branch: `main`
+- 미해결 리뷰 스레드: 0
+
+## 5. 재개 시 금지
+
+- simulated 후보를 실제 recognizer 정확도·latency 증거로 사용하지 않는다.
+- 가상 터치 경로를 실제 Android 조작성으로 기록하지 않는다.
+- 후보 카드를 최종 룬 목록이나 세계관 정본으로 승격하지 않는다.
+- `ART-STYLE-01`을 우회해 Art Bible·Asset Specification·제품 구현을 시작하지 않는다.
+- 사용자 승인 없이 Godot·Scene·Resource·Save Schema·알고리즘을 변경하지 않는다.


### PR DESCRIPTION
## 목표
마법 작성·인식 합성 검증의 전체 계보·최종 `ADAPT` 판정·ART-STYLE-01 이후 기술 Prototype 경계를 종료 기록으로 정리합니다.

## 변경
- 합성 검증 종료·인계 기록
- Documentation Map Addendum

## 상태
- `ADAPT / T6_AI_INFERENCE`
- 사람·Android touch·recognizer·latency `NOT_RUN`
- `ART-STYLE-01` 유지
- `implementation_authority: NONE`
- Godot·Scene·Resource·Save Schema·룬 정본·알고리즘 변경 없음

## 다음 게이트
`DEFINE_CANDIDATE_POLICY_AND_ERROR_HINT_LEVEL`