### PR TITLE
fix: pin v9.1 Registry to tracked Git bytes

### DIFF
--- a/docs/PROJECT_OPERATING_DASHBOARD.html
+++ b/docs/PROJECT_OPERATING_DASHBOARD.html
@@ -21,10 +21,10 @@
     </div>
     <section aria-labelledby="release"><h2 id="release">Base release identity</h2><ul><li><strong>Repository</strong>: alsdmlals4-eng/Base</li><li><strong>Version</strong>: 9.1.0</li><li><strong>State</strong>: RELEASE_CANDIDATE</li><li><strong>Release pin</strong>: 3c158f52cfdad889970aef4d6ce6650a6fea0645</li><li><strong>Evidence pin</strong>: dd20ad3852e264d7e337e34d2cb963f71053a6cb</li></ul></section>
     <section aria-labelledby="routes"><h2 id="routes">Route counts</h2><ul><li>BASE_SHARED: 1</li><li>PROJECT_LOCAL: 2</li><li>INACTIVE: 0</li><li>EFFECTIVE: 3</li></ul></section>
-    <section aria-labelledby="provenance"><h2 id="provenance">Hashes and provenance</h2><ul><li><strong>Base Registry</strong>: skills/SKILL_REGISTRY.json @ e06003cb986e979aa46c06839de178c3fb9ff10bdf440e750712d90d6c5ae7bb</li><li><strong>Project Registry</strong>: skills/SKILL_REGISTRY.json @ 670e1fca4e984d55ce7ecbdd2f4832494c40caab21ae1253f98e9a4b6c8fa2b7</li><li><strong>Adapter</strong>: skills/PROJECT_BASE_ADAPTER.json @ f76845102a75af8a902f342b6870b44129dfec26780bb7aa37c27b3c06e39208</li></ul></section>
+    <section aria-labelledby="provenance"><h2 id="provenance">Hashes and provenance</h2><ul><li><strong>Base Registry</strong>: skills/SKILL_REGISTRY.json @ e06003cb986e979aa46c06839de178c3fb9ff10bdf440e750712d90d6c5ae7bb</li><li><strong>Project Registry</strong>: skills/SKILL_REGISTRY.json @ b5db44ceb940bd2da2c4d054aab07248f75f3a24a789fffbce6e58ecd24a38d7</li><li><strong>Adapter</strong>: skills/PROJECT_BASE_ADAPTER.json @ d172058670e05e92368fb1b1fb8512d2e7d7c50a619a6f51b5ce8c4f5f59287c</li></ul></section>
     <section id="critical-gates" aria-labelledby="gates"><h2 id="gates">Critical gates</h2><ul><li><strong>accessibility</strong>: NOT_RUN</li><li><strong>device</strong>: NOT_RUN</li><li><strong>human</strong>: NOT_RUN</li><li><strong>runtime</strong>: NOT_RUN</li><li><strong>static</strong>: NOT_RUN</li></ul></section>
     <section aria-labelledby="verdict"><h2 id="verdict">Integrity verdict</h2><strong>PASS_WITH_NOT_RUN_GATES</strong></section>
   </main>
-  <footer><small>adapter RAW_FILE_BYTES_SHA256: f76845102a75af8a902f342b6870b44129dfec26780bb7aa37c27b3c06e39208</small></footer>
+  <footer><small>adapter RAW_FILE_BYTES_SHA256: d172058670e05e92368fb1b1fb8512d2e7d7c50a619a6f51b5ce8c4f5f59287c</small></footer>
 </body>
 </html>

--- a/skills/BASE_V9_ADAPTER.json
+++ b/skills/BASE_V9_ADAPTER.json
@@ -17,7 +17,7 @@
     "version": "9.1.0"
   },
   "canonical_source": "skills/PROJECT_BASE_ADAPTER.json",
-  "canonical_source_sha256": "f76845102a75af8a902f342b6870b44129dfec26780bb7aa37c27b3c06e39208",
+  "canonical_source_sha256": "d172058670e05e92368fb1b1fb8512d2e7d7c50a619a6f51b5ce8c4f5f59287c",
   "generated": true,
   "hash_definition": "RAW_FILE_BYTES_SHA256",
   "legacy_source": "docs/archive/base-v9-legacy-inputs/BASE_V9_ADAPTER.json",

--- a/skills/PROJECT_BASE_ADAPTER.json
+++ b/skills/PROJECT_BASE_ADAPTER.json
@@ -109,7 +109,7 @@
     "project": {
       "hash_definition": "RAW_FILE_BYTES_SHA256",
       "path": "skills/SKILL_REGISTRY.json",
-      "sha256": "670e1fca4e984d55ce7ecbdd2f4832494c40caab21ae1253f98e9a4b6c8fa2b7"
+      "sha256": "b5db44ceb940bd2da2c4d054aab07248f75f3a24a789fffbce6e58ecd24a38d7"
     }
   },
   "validators": [

--- a/skills/PROJECT_BASE_SKILL_ADAPTER.json
+++ b/skills/PROJECT_BASE_SKILL_ADAPTER.json
@@ -43,7 +43,7 @@
     "docs/planning/DECISION_LOG.md"
   ],
   "canonical_source": "skills/PROJECT_BASE_ADAPTER.json",
-  "canonical_source_sha256": "f76845102a75af8a902f342b6870b44129dfec26780bb7aa37c27b3c06e39208",
+  "canonical_source_sha256": "d172058670e05e92368fb1b1fb8512d2e7d7c50a619a6f51b5ce8c4f5f59287c",
   "current_truth_sources": [
     "docs/ACTIVE_CONTEXT.md",
     "docs/UX_UI_SYSTEM.md",

--- a/skills/PROJECT_SKILL_SNAPSHOT.json
+++ b/skills/PROJECT_SKILL_SNAPSHOT.json
@@ -42,7 +42,7 @@
   "project_registry": {
     "hash_definition": "RAW_FILE_BYTES_SHA256",
     "path": "skills/SKILL_REGISTRY.json",
-    "sha256": "670e1fca4e984d55ce7ecbdd2f4832494c40caab21ae1253f98e9a4b6c8fa2b7"
+    "sha256": "b5db44ceb940bd2da2c4d054aab07248f75f3a24a789fffbce6e58ecd24a38d7"
   },
   "project_routes": [
     {
@@ -60,6 +60,6 @@
   "source_registry": {
     "hash_definition": "RAW_FILE_BYTES_SHA256",
     "path": "skills/PROJECT_BASE_ADAPTER.json",
-    "sha256": "f76845102a75af8a902f342b6870b44129dfec26780bb7aa37c27b3c06e39208"
+    "sha256": "d172058670e05e92368fb1b1fb8512d2e7d7c50a619a6f51b5ce8c4f5f59287c"
   }
 }


### PR DESCRIPTION
Closes #19`n`nCorrects only the adapter Registry provenance hash and regenerates derived adapter views after Base #98/#100. No project content, local Skill body, or protected planning source changed.