### PR TITLE
docs: approve GRIMOIRE vertical-slice asset specification

### DIFF
--- a/docs/ASSET_LICENSE_LEDGER.md
+++ b/docs/ASSET_LICENSE_LEDGER.md
@@ -1,163 +1,216 @@
-# 스펠 Asset License Ledger
+# GRIMOIRE Asset·License Ledger
 
-- 프로젝트: `스펠` (임시)
-- 마지막 검토일: 2026-07-27
-- 제품 단계: `PROTOTYPE_AND_VERTICAL_SLICE`
-- Gate 1: `APPROVED`
-- 프로젝트 코어: `CORE_CONFIRMED`
-- 실행 프로필: `PLANNING_ONLY_PROFILE`
-- 시각 표현: `LANDSCAPE_HYBRID_2D_WITH_SEPARATE_TACTICAL_BATTLE_CONFIRMED`
-- 캐릭터 표현: `SD_FIELD_HALF_BODY_DIALOGUE_CONFIRMED`
-- 외부 런타임 자산: `NO_EXTERNAL_ASSETS_REGISTERED`
-- 생성·편집 런타임 자산: `NOT_STARTED`
-- 비교용 시각 참조: `REGISTERED_BELOW`
-- 대량 제작: `BLOCKED_BY_ART_STYLE_ART_BIBLE_ASSET_SPEC_AND_AUDIO_DIRECTION`
+## 1. 현재 상태
 
-> 출처·사용 권리·생성 이력·파생 관계·사용자 승인·적용 경로를 확인하지 않은 자산을 최종 런타임 자산으로 승인하지 않는다.
-
-## 1. 확정된 화면 전제
-
-```text
-가로형 16:9 기준
-→ 18:9~20:9 좌우 확장
-
-학교·자유일정·탐색
-= 고정·장면 기반 3/4 필드
-= 3.5~4등신 SD
-
-대화
-= 같은 장소 배경 위 반신 일러스트
-
-전투
-= 별도 고정 3/4 전술 전투장
-= 필드 SD 비율 재사용
-
-작성
-= 현재 화면 감속·암전 + 작성 오버레이
+```yaml
+project: "GRIMOIRE: 세계를 다시 쓰는 법"
+last_reviewed_at: 2026-08-01
+product_stage: DEMO_FIRST_VERTICAL_SLICE
+primary_platform: PC
+follow_up_platform: Mobile
+art_style_01: APPROVED_A_MODIFIED_LOCKED
+art_bible_01: APPROVED_DUAL_STANDARD_ART_BIBLE
+asset_spec_01: APPROVED_VERTICAL_SLICE_ASSET_SPEC
+asset_production: NOT_STARTED
+external_runtime_assets: NONE_REGISTERED
+fonts: NOT_SELECTED
+ui_kits: NONE_SELECTED
+plugins: NONE_ADOPTED
+audio_assets: NOT_STARTED
+runtime_validation: NOT_RUN
+human_validation: NOT_RUN
 ```
 
-세로형·자유 카메라·대형 자유 탐색·대형 전투장을 전제로 자산을 제작하지 않는다.
+책임 원본:
 
-## 2. 조달 순서
+- `docs/planning/ASSET_SPEC_01_APPROVAL_2026-08-01.md`.
+- `docs/planning/ASSET_MANIFEST_SCHEMA.json`.
+- `docs/planning/ART_BIBLE_01_APPROVAL_2026-08-01.md`.
+- `docs/planning/visual/ART_STYLE_01_LOCKED_REFERENCE_MANIFEST.json`.
+
+출처·권리·Source SHA·Export SHA·사용 화면·Approval·Runtime Evidence가 연결되지 않은 자산은 제품 자산으로 승인하지 않는다.
+
+## 2. 조달·승인 순서
 
 ```text
-현재 확정 결정 확인
-→ ART-STYLE-01 그림체 기준 샷 비교
-→ Art Bible
-→ Asset Specification
-→ Audio Direction
-→ 보유·외부·Godot 후보 조사
-→ 라이선스·기술·스타일·성능 검토
-→ 사용자 승인
-→ 생성·편집·적용
-→ 런타임 검수
+현재 Decision·Art Bible·Asset Spec 확인
+→ 기존 보유·승인 Source Inventory
+→ 외부·생성 후보 조사
+→ License·Style·Technical·Removal Risk 검토
+→ Source Manifest
+→ Export Candidate
+→ Visual Review
+→ Runtime Import
+→ Runtime·Performance·Accessibility QA
+→ PROJECT_ASSET_APPROVED
 ```
 
-외부 Godot 자산·플러그인 조사에는 `evaluating-godot-assets-and-plugins-before-creation`을 사용한다.
+- 새로 만들기 전에 기존 승인 Source·Template·Godot 기본 기능을 조사한다.
+- Pinterest·검색 이미지·상용 게임 Screenshot은 Discovery Reference이며 Source Asset이 아니다.
+- 외부 Plugin·Asset Pack은 License와 제거 가능성 검증 전 설치하지 않는다.
+- 생성 성공만으로 Runtime Asset이 되지 않는다.
 
-## 3. 자산·참조 원장
+## 3. 승인된 비주얼 권위
 
-| Asset ID | 자산 | 용도 | 유형 | 출처 | 권리·라이선스 | 도구·날짜 | 파생 관계 | 사용자 승인 | 저장 상태 | 적용 경로 | 런타임 검증 | 상태 |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| REF-VISUAL-001 | 필드 SD·대화 반신·별도 전술 전투장 구성 이미지 | 화면·캐릭터·전투 구성 기준 | 사용자 대화 내 생성 이미지 | ChatGPT 대화 첨부 | 런타임 사용 아님, 프리프로덕션 참조 | OpenAI image generation / 2026-07-27 | 이전 A/B/C 비교 이미지에서 선택된 두 번째 구성 | `USER_APPROVED_VISUAL_REFERENCE` | `BINARY_PENDING_REPOSITORY_IMPORT` | 문서 참조만 | `NOT_APPLICABLE` | `REFERENCE_APPROVED` |
-| REF-SUMMON-001 | 신비한 늑대형 원소 정령수 레퍼런스 | 메인 동반 소환수 방향 | 사용자 제공 이미지 | 사용자 대화 첨부 | 런타임 사용 아님, 프리프로덕션 참조 | 사용자 제공 / 2026-07-27 | 메인 동반 원소 정령수 방향의 대표 참조 | `USER_APPROVED_DIRECTION_REFERENCE` | `BINARY_PENDING_REPOSITORY_IMPORT` | 문서 참조만 | `NOT_APPLICABLE` | `REFERENCE_APPROVED` |
-| REF-SUMMON-002 | 메인 소환수 성장 4단계 콘셉트 시트 | 성장·크기·탑승 방향 탐색 | 생성 이미지 | ChatGPT 대화 첨부 | 런타임 사용 아님, 콘셉트 탐색 | OpenAI image generation / 2026-07-27 | REF-SUMMON-001 기반 개념 확장 | 성장 프레임 방향 승인, 세부 디자인 미승인 | `BINARY_PENDING_REPOSITORY_IMPORT` | 문서 참조만 | `NOT_APPLICABLE` | `CONCEPT_REFERENCE` |
-| REF-SUMMON-003 | 전투 소환수 역할 콘셉트 이미지 시도 | 역할 실루엣 탐색 | 생성 시도·후보 이미지 | ChatGPT 대화 첨부 | 런타임 사용 아님 | OpenAI image generation / 2026-07-27 | 원소·정령·역할 분류 탐색 | 4역할 전체 시스템 미승인 | `NOT_CANONICAL_BINARY` | 없음 | `NOT_APPLICABLE` | `REFERENCE_CANDIDATE` |
+| Asset ID | 자산 | 역할 | 출처·보관 | 권리·상태 | SHA-256 | Runtime 사용 |
+|---|---|---|---|---|---|---|
+| `REF-ART-STYLE-LOCKED-01` | GRIMOIRE Art Style 잠긴 기준판 | Art·화면 구성 권위 | ChatGPT Library `/GRIMOIRE/Visual Authority/GRIMOIRE_ART_STYLE_01_LOCKED_REFERENCE.png` | `USER_APPROVED_REFERENCE / SOURCE_EDIT_PROHIBITED` | `b55ce1dec6c2521668602d1ce6547526e7f40b8c7c9b6f5276d9289a67f14f7a` | `NO / REFERENCE_ONLY` |
 
-현재 대화 첨부 바이너리는 GitHub 저장소에 직접 보관되지 않았다. 텍스트 결정은 정본에 반영했으며, 실제 파일을 저장소에 가져올 때 원본·파일명·해시·파생 관계를 추가한다.
+금지:
 
-## 4. 상태 정의
+- 원본 수정·재생성·리터치.
+- Crop·Upscale·Text 교체본으로 원본 대체.
+- Runtime Background·Character·UI로 직접 Import.
+- Image 안의 이름·수치·파티 수를 자동 정본화.
 
-- `CONCEPT_EXPLORATION`
-- `VISUAL_REFERENCE_CANDIDATE`
-- `USER_APPROVED_VISUAL_REFERENCE`
-- `USER_APPROVED_DIRECTION_REFERENCE`
-- `ART_BIBLE_APPROVED`
-- `ASSET_SPEC_APPROVED`
-- `RUNTIME_ASSET_CANDIDATE`
-- `RUNTIME_ASSET_APPROVED`
-- `REJECT_LICENSE`
-- `REJECT_STYLE`
-- `REJECT_TECHNICAL`
+## 4. 역사·Discovery Reference
 
-생성 성공만으로 `RUNTIME_ASSET_APPROVED`가 되지 않는다.
+| Asset ID | 자산 | 현재 역할 | 권리·상태 | 후속 |
+|---|---|---|---|---|
+| `REF-VISUAL-LEGACY-01` | 과거 Field SD·Half-body·Battle 구성 이미지 | Art Style 승인 이전 참고 | `HISTORICAL_REFERENCE / NOT_AUTHORITY` | 잠긴 기준판으로 대체 |
+| `REF-SUMMON-01` | 늑대형 원소 정령수 방향 이미지 | Companion Discovery Reference | `USER_PROVIDED_OR_GENERATED_REFERENCE / NOT_RUNTIME_ASSET` | Asset Spec 기반 Character Sheet 후보 |
+| `REF-SUMMON-GROWTH-01` | 성장 4단계 Concept Sheet | 장기 방향 참고 | `DEFERRED_BEYOND_SLICE` | Slice Asset 제작 금지 |
+| `REF-GUARDIAN-MULTIROLE-01` | 전투 소환수 다역할 Concept | 과거 탐색 | `REJECTED_FOR_SLICE / NOT_AUTHORITY` | Guardian 1역할 규칙만 유지 |
+| `REF-GENERIC-BOARD-REJECTED-01` | Generic Dark Fantasy·기술 Dashboard 이미지 | 실패 근거 | `REJECTED_NOT_AUTHORITY` | 재사용 금지 |
 
-## 5. 생성·편집 자산 필수 기록
+실제 Binary가 다시 필요하면 원본 File ID·SHA·Tool·날짜·권리·파생 관계를 먼저 복구한다.
 
-- 실제 화면 역할
-- 생성·편집 도구와 날짜
-- 브리프·프롬프트 저장 경로
-- 사용자 제공 참조와 외부 참조 출처
-- 원본→수정본→최종본 파생 관계
-- 상업 이용·수정 가능 여부
-- 사용자 승인 상태
-- Godot 적용 경로
-- 실제 화면·성능·접근성 검증
+## 5. Runtime Asset Manifest 상태
 
-## 6. 배경 자산 전제
+```yaml
+manifest_schema: docs/planning/ASSET_MANIFEST_SCHEMA.json
+runtime_asset_records: 0
+project_asset_approved: 0
+imported: 0
+runtime_verified: 0
+```
 
-- 가로형 3/4 고정 학교 필드
-- 기준 16:9, 좌우 확장 레이어
-- 학교 기본·시험·자유일정·축제 상태 변형
-- 현장 필드와 같은 장소 정체성을 가진 별도 전투장
-- 전투 결과의 손상·복구 상태를 필드에 반영
-- 캐릭터 기준선과 핫스폿 일관성
+첫 Runtime Asset Record는 다음을 모두 포함해야 한다.
 
-배경을 화면비마다 별도 제작하지 않는다.
+- Asset ID·역할·Decision ID.
+- Source File ID/Path·SHA·Tool·Owner.
+- Export Path·SHA·Format·Dimensions·Alpha·Import Profile.
+- License Status·Evidence·Credit·Modification·Redistribution 조건.
+- 사용 Screen.
+- Approval·Supersession.
+- Runtime Validation.
 
-## 7. 캐릭터 자산 전제
+## 6. Font Ledger
 
-- 필드·전투: 3.5~4등신 SD와 기본 골격 재사용
-- 대화: 반신 일러스트
-- 필드·전투 디자인 식별 요소 공유
-- 핵심 인물만 반신·표정 제작
-- 정확한 픽셀 규격·표정·애니메이션 수는 `ASSET-SPEC-01`
+| Font ID | 역할 | 후보 | License | 한글 Coverage | Runtime QA | 상태 |
+|---|---|---|---|---|---|---|
+| `FONT-BODY-01` | Body·UI Sans | 미선정 | `REVIEW_REQUIRED` | `REQUIRED` | `NOT_RUN` | `PLANNED` |
+| `FONT-TITLE-01` | 제한적 Title Serif | 미선정 | `REVIEW_REQUIRED` | `REQUIRED` | `NOT_RUN` | `PLANNED` |
 
-## 8. 메인 동반 소환수
+상한:
 
-- 세계관 역할: `CONFIRMED_BY_GM-MASCOT-01`
-- 시각 방향: `ELEMENTAL_SPIRIT_BEAST_DIRECTION_CONFIRMED`
-- 대표 레퍼런스: 늑대형 원소 정령수 계열
-- 장기 성장: 4단계
-- 이전 형상 선택: 가능
-- 장기 탑승: 확정 방향
-- Vertical Slice 런타임: 초기 형상 1개
-- 2~4단계 전체·형상 선택 UI·탑승: 후행
-- 정확한 이름·원소·색·최종 외형: `ART_STYLE_AND_ART_BIBLE_REQUIRED`
+- Body/UI Family 1.
+- Title Family 1.
+- System Font 의존 금지.
+- License Evidence 없는 Font Import 금지.
+- Body 전역 MSDF는 PC·Mobile Trial 전 금지.
 
-## 9. 전투 보조 소환수
+## 7. External Asset·Plugin Ledger
 
-- 원소·정령 중심 시각 언어
-- Vertical Slice: 수호 또는 견제 1체
-- 4역할 전체 체계: `REFERENCE_CANDIDATE`
-- 성장·형상 선택·탑승: `UNRESOLVED`
-- 대화 반신: 초기 Slice 제외
+현재 등록:
 
-## 10. 이미지 생성 실패 처리
+```yaml
+external_art_packs: 0
+ui_kits: 0
+font_packages: 0
+godot_plugins: 0
+audio_packs: 0
+```
 
-- 사용자에게 동일 요청 재입력을 기본 해결책으로 요구하지 않음
-- 기존 브리프와 승인 참조를 보존
-- 한글 장문·UI 복잡도·한 장의 요소 수를 줄여 단계적 재시도
-- 상세 서버 오류를 확인할 수 없으면 추정과 사실을 구분
-- 실패한 생성물을 완료로 주장하지 않음
+채택 전 필수:
 
-## 11. 대량 제작 전 차단 조건
+1. Need Gap.
+2. Current Godot 4.7 Compatibility.
+3. Commercial License.
+4. Modification·Redistribution·Credit.
+5. Project Ownership·Trust.
+6. Removal·Rollback Plan.
+7. Art Style·Performance·Accessibility Trial.
+8. 사용자 승인.
 
-- `ART-STYLE-01` 사용자 승인
-- Art Bible 승인
-- 내부 해상도·안전 영역·자산 예산 확정
-- 캐릭터·배경·UI·효과·사운드 규격 확정
-- Audio Direction 승인
-- 외부·생성 자산의 권리·출처 기록
+현재 Asset Pipeline은 Godot 기본 Import·Theme·SpriteFrames로 충분하므로 Add-on을 채택하지 않는다.
 
-스타일 비교용 소수 기준 이미지는 `ART-STYLE-01`에서 허용한다.
+## 8. Runtime Export 형식
 
-## 12. 현재 `NOT_RUN`
+| 역할 | 형식 | 상태 |
+|---|---|---|
+| Opaque Background | WebP Lossless 우선 | `SPEC_APPROVED / NOT_EXPORTED` |
+| Transparent Character·Portrait·VFX | PNG RGBA | `SPEC_APPROVED / NOT_EXPORTED` |
+| Simple UI·Icon·Glyph Source | SVG | `SPEC_APPROVED / NOT_CREATED` |
+| Font | Licensed TTF/OTF/WOFF2 | `SPEC_APPROVED / NOT_SELECTED` |
+| Audio | `AUDIO-DIRECTION-01` 후 확정 | `BLOCKED` |
 
-- Godot Asset Library 검색
-- 플러그인 기술 Trial
-- 제3자 라이선스 법률 검토
-- UI Kit·폰트·사운드 후보 조사
-- 그림체 기준 샷의 체계적 비교
-- 실제 런타임 적용·성능·접근성 검수
-- 사람 시각·청각 검수
+## 9. 수량 상한
+
+| 자산군 | Hard Cap |
+|---|---:|
+| Opaque Background Base | 3 |
+| Background State Overlay Set | 8 |
+| 핵심 Half-body Portrait | 12 |
+| 일반 NPC Half-body | 0 |
+| Protagonist Field Frame | 36 |
+| Professor Field Frame | 16 |
+| Peer Field Frame | 16 |
+| Companion Frame | 20 |
+| Guardian Full Battlefield Body Set | 0 |
+| Enemy Body Set | 1 |
+| Enemy Frame | 50 |
+| UI Component Family | 12 |
+| Base Icon | 24 |
+| Glyph Base | 3 |
+| Reusable VFX Module | 12 |
+| Font Family | 2 |
+
+초과는 Scope Change Decision·Benchmark·사용자 승인·Sheet 동기화를 요구한다.
+
+## 10. 생성·편집 자산 기록
+
+생성 후보마다 기록:
+
+- 목적과 실제 Screen Consumer.
+- Brief·Prompt Path.
+- 고정 Reference와 변경 축.
+- Tool·Model·Date.
+- Source File ID·SHA.
+- Rights·Similarity Review.
+- Revision History.
+- User Approval.
+- Export·Import·Runtime Evidence.
+
+한글 UI Text는 Editable Layer로 제작하고 이미지 생성 결과의 Text를 제품 Text로 사용하지 않는다.
+
+## 11. 대량 제작 차단
+
+현재:
+
+```yaml
+art_style: PASS
+art_bible: PASS
+asset_spec: PASS
+audio_direction: NOT_APPROVED
+derivative_screen_consumers: PARTIAL
+runtime_project: NOT_STARTED
+mass_asset_generation: BLOCKED
+```
+
+다음 전에는 대량 제작을 시작하지 않는다.
+
+- `BOSS-PHASE-01`.
+- `GRIMOIRE-SCREEN-01`.
+- `MAIN-SCREEN-01`.
+- `AUDIO-DIRECTION-01`.
+- 기획·아트 통합 검수.
+- Asset Manifest·License Workflow 준비.
+
+## 12. 현재 검증 경계
+
+- Godot Asset Import: `NOT_RUN`.
+- Texture Compression·Mipmap·MSDF 비교: `NOT_RUN`.
+- Memory·Load Time: `NOT_RUN`.
+- 720p·1080p·1440p·Ultrawide QA: `NOT_RUN`.
+- PC Input·Mobile·Accessibility·Human Visual/Audio QA: `NOT_RUN`.

--- a/docs/planning/ASSET_MANIFEST_SCHEMA.json
+++ b/docs/planning/ASSET_MANIFEST_SCHEMA.json
@@ -1,0 +1,215 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "grimoire-asset-manifest.schema.json",
+  "title": "GRIMOIRE Asset Manifest",
+  "description": "ASSET-SPEC-01 runtime asset traceability contract. A manifest record does not imply runtime approval.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "asset_id",
+    "role",
+    "decision_ids",
+    "source",
+    "export",
+    "license",
+    "status",
+    "used_in_screens",
+    "runtime_validation"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "asset_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9_\\-]*$"
+    },
+    "role": {
+      "type": "string",
+      "minLength": 1
+    },
+    "decision_ids": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string"
+      }
+    },
+    "source": {
+      "type": "object",
+      "required": [
+        "storage",
+        "file_id_or_path",
+        "sha256",
+        "tool",
+        "owner"
+      ],
+      "properties": {
+        "storage": {
+          "enum": [
+            "EXTERNAL_LIBRARY",
+            "GDIGNORE_SOURCE_ROOT",
+            "USER_PROVIDED_REFERENCE",
+            "GENERATED_CANDIDATE"
+          ]
+        },
+        "file_id_or_path": {
+          "type": "string"
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "tool": {
+          "type": "string"
+        },
+        "tool_version": {
+          "type": "string"
+        },
+        "owner": {
+          "type": "string"
+        },
+        "prompt_or_brief_path": {
+          "type": "string"
+        },
+        "parent_asset_ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "export": {
+      "type": "object",
+      "required": [
+        "file_path",
+        "sha256",
+        "format",
+        "width",
+        "height",
+        "alpha",
+        "import_profile"
+      ],
+      "properties": {
+        "file_path": {
+          "type": "string",
+          "pattern": "^assets/"
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "format": {
+          "enum": [
+            "PNG",
+            "WEBP",
+            "SVG",
+            "TTF",
+            "OTF",
+            "WOFF2"
+          ]
+        },
+        "width": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 4096
+        },
+        "height": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 4096
+        },
+        "alpha": {
+          "type": "boolean"
+        },
+        "import_profile": {
+          "type": "string"
+        },
+        "atlas_group": {
+          "type": "string"
+        },
+        "animation_clip": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "license": {
+      "type": "object",
+      "required": [
+        "status",
+        "evidence"
+      ],
+      "properties": {
+        "status": {
+          "enum": [
+            "PROJECT_ORIGINAL",
+            "USER_OWNED",
+            "COMMERCIAL_USE_APPROVED",
+            "REVIEW_REQUIRED",
+            "REJECTED"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "evidence": {
+          "type": "string"
+        },
+        "credit_required": {
+          "type": "boolean"
+        },
+        "modification_allowed": {
+          "type": "boolean"
+        },
+        "redistribution_allowed": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "enum": [
+        "PLANNED",
+        "SOURCE_READY",
+        "EXPORTED_CANDIDATE",
+        "IN_VISUAL_REVIEW",
+        "REVISION_REQUIRED",
+        "REJECTED",
+        "APPROVED_RUNTIME_CANDIDATE",
+        "IMPORTED",
+        "RUNTIME_VERIFIED",
+        "PROJECT_ASSET_APPROVED"
+      ]
+    },
+    "approved_by": {
+      "type": "string"
+    },
+    "approved_at": {
+      "type": "string"
+    },
+    "used_in_screens": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string"
+      }
+    },
+    "replacement_or_supersession": {
+      "type": "string"
+    },
+    "runtime_validation": {
+      "enum": [
+        "NOT_RUN",
+        "PASS",
+        "FAIL",
+        "PARTIAL"
+      ]
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/planning/ASSET_SPEC_01_APPROVAL_2026-08-01.md
+++ b/docs/planning/ASSET_SPEC_01_APPROVAL_2026-08-01.md
@@ -1,0 +1,729 @@
+# ASSET-SPEC-01 승인 — GRIMOIRE Vertical Slice Asset Specification
+
+## 1. 결정 상태
+
+```yaml
+decision_id: ASSET-SPEC-01
+status: APPROVED_VERTICAL_SLICE_ASSET_SPEC
+approved_at: 2026-08-01
+approved_by: USER_BATCH_APPROVAL_RECOMMENDED_OPTION
+benchmark_id: GR-BM-ASSET-SPEC-01
+project: "GRIMOIRE: 세계를 다시 쓰는 법"
+primary_platform: PC
+follow_up_platform: Mobile
+engine_candidate: Godot 4.7.1 stable
+implementation_authority: NONE
+asset_production_authority: SPEC_APPROVED_PRODUCTION_NOT_STARTED
+runtime_validation: NOT_RUN
+human_validation: NOT_RUN
+```
+
+사용자의 일괄 승인에 따라 공식 Godot 4.7 Asset Pipeline 근거와 현재 Art Bible·Battle Rules를 바탕으로 권장 규격을 기획 정본으로 확정한다.
+
+---
+
+# PART A. 화면·해상도 계약
+
+## 2. Logical Frame
+
+```yaml
+logical_design_frame: 1920x1080
+minimum_pc_readability: 1280x720
+primary_aspect_ratio: 16:9
+ultrawide_policy: EXPAND_BACKGROUND_AND_WORLD_KEEP_UI_IN_16_9_SAFE_FRAME
+portrait_orientation: NOT_SUPPORTED_IN_PC_SLICE
+mobile_layout: SEPARATE_FOLLOW_UP_DERIVATIVE
+```
+
+- UI·Layout·Text Token은 `1920×1080`에서 설계한다.
+- `1280×720`에서 Text·Attack Warning·Glyph·Button·Focus가 읽혀야 한다.
+- Ultrawide에서는 배경·World만 확장하고 핵심 UI는 중앙 16:9 Safe Frame 안에 유지한다.
+- Godot 구현 시 `canvas_items + expand`를 첫 기술 후보로 사용하되 실제 Project Setting은 기술 검수에서 확정한다.
+
+## 3. Safe Frame
+
+1920×1080 기준:
+
+```yaml
+safe_margin_left: 64
+safe_margin_right: 64
+safe_margin_top: 48
+safe_margin_bottom: 48
+```
+
+- Title·Subtitle·Button·Gauge·Glyph Canvas의 필수 정보는 Safe Frame 밖으로 나가지 않는다.
+- Decorative Background·Particle·World Prop만 Safe Frame 밖 확장을 허용한다.
+- Battle에서 Enemy Telegraph, Player Portrait, Writing Panel은 서로 겹치지 않는다.
+
+## 4. Battle Layout Asset Boundary
+
+```text
+상단·중앙 = Enemy·Environment·Attack Telegraph
+좌측 하단 = Protagonist Portrait·HP·Mana·Status
+좌측 보조 = Companion·Guardian Status Badge
+우측 = Collapsed Writing Rail → Expanded Writing Panel
+```
+
+- Collapsed Writing Rail: Logical Width `96 px` 기준.
+- Expanded Writing Panel: 화면 너비의 `30~34%` 범위.
+- Player Portrait Group: 화면 너비의 최대 `22%`.
+- 수치는 Layout 제작 기준이며 실제 Runtime Scale은 1280×720·Ultrawide QA에서 조정한다.
+- 아군·Guardian 몸체를 전장에 상시 배치하는 Asset Set은 만들지 않는다.
+
+---
+
+# PART B. 파일 형식·Source 관리
+
+## 5. 형식 계약
+
+| 자산군 | Source Master | Runtime Export | Alpha | 기본 Import |
+|---|---|---|---|---|
+| Painterly Background | Layered Source, 2560×1440 | WebP Lossless | 없음 | Linear, Mipmap Trial |
+| Character·Portrait·Enemy | Layered Source | PNG RGBA | 있음 | Lossless, Linear, Mipmap Off |
+| UI Panel·Frame·Badge | SVG 또는 Layered Source | SVG/PNG | 있음 | Linear |
+| Simple Icon·Glyph Reference | SVG Source | SVG | 있음 | Rasterize on Import |
+| Animated VFX | Layered Sequence | PNG RGBA Atlas/Frames | 있음 | Lossless, Linear |
+| Font | Licensed TTF/OTF/WOFF2 | Dynamic Font | 해당 없음 | Font Import |
+| Text·Label | Localization Data | Godot UI Text | 해당 없음 | Image Bake 금지 |
+
+### 금지
+
+- UI·Glyph·Character에 JPEG 사용.
+- 한글 Text를 이미지에 Bake.
+- SVG에 복잡한 Filter·Mask·Embedded Raster·Font Text 의존.
+- Source Layer File을 Runtime Texture로 직접 Import.
+- 같은 State를 색만 바꾼 PNG 복제본으로 증식.
+
+## 6. Source Master와 Runtime Export
+
+```text
+Layered Source
+→ Manifest·SHA·License·Owner
+→ Review Candidate Export
+→ User/Project Approval
+→ Runtime Export
+→ Godot Import
+→ Runtime QA
+```
+
+- Layered Source는 외부 Library·Drive 또는 `.gdignore` Source Folder에 둔다.
+- GitHub 제품 경로에는 Runtime Export·Manifest·License Ledger만 둔다.
+- Source를 외부 보관하면 File ID·SHA-256·Owner·Tool·Export Version을 Manifest에 기록한다.
+- 승인된 잠긴 기준판은 Source Asset이 아니라 Visual Authority Reference다.
+- Runtime Export는 Source와 다른 File ID·SHA·State를 가진다.
+
+## 7. 파일명·폴더명
+
+- 전부 lowercase `snake_case`.
+- 날짜·`final`·`final2`·`latest`를 활성 File Name에 사용하지 않는다.
+- State·Variant는 명시적 suffix를 사용한다.
+
+예:
+
+```text
+bg_school_common.webp
+bg_school_festival_overlay.webp
+chr_protagonist_portrait_neutral.png
+chr_protagonist_portrait_concerned.png
+enemy_greenhouse_spirit_attack_pressure_01.png
+ui_battle_writing_panel.svg
+vfx_glyph_flow_path_01.png
+```
+
+---
+
+# PART C. 목표 폴더 구조
+
+## 8. Runtime Asset Root
+
+```text
+assets/
+├─ art/
+│  ├─ backgrounds/
+│  │  ├─ school/
+│  │  ├─ greenhouse/
+│  │  └─ battle/
+│  ├─ characters/
+│  │  ├─ protagonist/
+│  │  ├─ professor/
+│  │  ├─ peer/
+│  │  ├─ companion/
+│  │  └─ guardian/
+│  ├─ enemies/
+│  │  └─ greenhouse_spirit/
+│  ├─ ui/
+│  │  ├─ common/
+│  │  ├─ field/
+│  │  ├─ dialogue/
+│  │  ├─ writing/
+│  │  ├─ battle/
+│  │  ├─ result/
+│  │  ├─ grimoire/
+│  │  └─ main/
+│  └─ vfx/
+│     ├─ glyph/
+│     ├─ battle/
+│     └─ result/
+├─ fonts/
+├─ audio/
+└─ manifests/
+```
+
+Audio는 Folder만 예약하고 실제 규격은 `AUDIO-DIRECTION-01`에서 확정한다.
+
+## 9. Source Root
+
+```text
+art_source/            # .gdignore 또는 외부 Library
+├─ backgrounds/
+├─ characters/
+├─ ui/
+├─ vfx/
+└─ exports/
+```
+
+- Source Root는 Godot Runtime Import 대상이 아니다.
+- Export Script·Preset을 사용하면 Tool Version과 Preset Hash를 기록한다.
+
+---
+
+# PART D. 배경 Asset 상한
+
+## 10. Opaque Background Master
+
+Vertical Slice 신규 Full Paint 상한:
+
+| ID | Asset | Master | Runtime | 역할 |
+|---|---|---:|---:|---|
+| BG-01 | School Common Base | 2560×1440 | 2560×1440 WebP | 수업·시험·축제 공용 |
+| BG-02 | Greenhouse Field Base | 2560×1440 | 2560×1440 WebP | 현장 관찰·복귀 |
+| BG-03 | Greenhouse Battle Arena | 2560×1440 | 2560×1440 WebP | 동일 사건 별도 전투장 |
+
+Hard Cap: `3 OPAQUE BASE MASTERS`.
+
+### 파생 정책
+
+- 수업·시험·축제는 BG-01의 Lighting·Prop·Crowd·Damage State로 변형한다.
+- Main은 BG-01을 기반으로 한 별도 Composite를 우선하고 신규 Full Paint 의무 없음.
+- Grimoire는 공용 UI Frame + 제한된 Illustration Slot으로 구성하며 전용 Full Paint 의무 없음.
+
+## 11. State Overlay
+
+Hard Cap: `8 STATE OVERLAY SETS`.
+
+권장 슬롯:
+
+1. class_practice.
+2. exam_crystal.
+3. festival_decoration.
+4. festival_light_thread_damage.
+5. greenhouse_pressure_warning.
+6. greenhouse_damage.
+7. greenhouse_resolved.
+8. field_return_result_variant.
+
+- Lighting·Color Grade·Particle만 다른 경우 Texture Duplicate보다 Material·Modulate·Light를 우선한다.
+- 완전 다른 Perspective·Camera로 재제작하면 새 Base Master로 계산한다.
+
+---
+
+# PART E. Character·Creature Asset 상한
+
+## 12. Half-body Portrait
+
+Runtime Export 기준:
+
+```yaml
+portrait_canvas: 1024x1536_rgba
+source_master_recommended_height: 2048_to_3072
+crop_contract: waist_or_mid_thigh_with_headroom
+```
+
+### 핵심 인물
+
+| Character | Expression | 수량 |
+|---|---|---:|
+| Protagonist | neutral / focused / concerned / relieved | 4 |
+| Professor | neutral / instructive / stern / approving | 4 |
+| Peer | neutral / confident / frustrated / respectful | 4 |
+
+Hard Cap: `12 HALF-BODY EXPORTS`.
+
+- Expression은 얼굴·눈썹·입·작은 손동작 변화 중심.
+- 의상 Variant·Festival Costume·Battle Costume는 Slice에서 제외.
+- 일반 NPC Half-body는 `0`.
+
+## 13. Protagonist Field SD
+
+```yaml
+runtime_frame_canvas: 384x384_rgba
+source_frame_canvas: 768x768_recommended
+side_direction: MIRROR_ALLOWED
+hard_frame_cap: 36
+```
+
+Clip 상한:
+
+| Clip | Direction | Frame |
+|---|---:|---:|
+| idle | front / back / side | 4 each = 12 |
+| move | front / back / side | 6 each = 18 |
+| interact_cast | shared or context variant | max 6 |
+
+- Battle에 Protagonist Full-body Animation을 상시 표시하지 않는다.
+- Dialogue·Portrait·Field SD는 같은 Hair·Face·Uniform Key를 공유한다.
+- 고프레임 Emote·Cutscene Animation은 Slice 제외.
+
+## 14. Professor·Peer Field SD
+
+각 Character:
+
+```yaml
+runtime_frame_canvas: 384x384_rgba
+hard_frame_cap_per_character: 16
+```
+
+권장:
+
+- idle front/side: 4×2 = 8.
+- talk/reaction shared clip: 최대 8.
+- Full directional Move Set은 필요 Scene이 승인되기 전 제작하지 않는다.
+
+Hard Cap: `32 FRAMES TOTAL`.
+
+## 15. Main Companion
+
+```yaml
+runtime_frame_canvas: 256x256_rgba
+hard_frame_cap: 20
+```
+
+- idle 6.
+- move 6.
+- reaction 4 states ×2 = 8.
+- 성장 2~4단계·탑승·대형 Battle Form은 Slice 제외.
+- Dialogue에서는 별도 Full-body Portrait보다 Reaction Icon·Field Reaction을 우선한다.
+
+## 16. Companion Reaction Icon
+
+```yaml
+runtime_canvas: 256x256_rgba
+count_cap: 4
+states: neutral / curious / alarmed / pleased
+```
+
+## 17. Guardian Support
+
+Vertical Slice 필수:
+
+- Status Badge `1`.
+- Short Cut-in `1`.
+- Protection FX Sequence `1`, 최대 `8 Frames`.
+
+```yaml
+guardian_full_battlefield_body_set: 0
+multi_role_variants: 0
+```
+
+- Timer Stop·Automatic Cast·Permanent Shield를 암시하는 Visual은 금지.
+- 정확한 사용 횟수·완화율은 Prototype Tuning 후 State Mark를 추가한다.
+
+## 18. Greenhouse Spirit Enemy
+
+```yaml
+runtime_frame_canvas: 512x512_rgba
+source_frame_canvas: 1024x1024_recommended
+hard_frame_cap: 50
+normal_phase_count: 1
+```
+
+권장 Clip 상한:
+
+| Clip | Frame Cap |
+|---|---:|
+| idle_unstable | 8 |
+| telegraph_pressure | 4 |
+| attack_pressure | 6 |
+| telegraph_surge | 4 |
+| attack_surge | 6 |
+| telegraph_environment | 4 |
+| attack_environment | 6 |
+| instability_reaction | 4 |
+| calm_resolve | 8 |
+
+합계: `50`.
+
+- 적당한 Spell이 불안정도를 낮추는 상태 변화를 Texture 전체 교체보다 Overlay·Material·VFX로 우선 표현한다.
+- 일반 적 Multi-phase Full Body Variant는 `0`.
+- Boss Phase 파생은 `BOSS-PHASE-01` 승인 전 제작하지 않는다.
+
+---
+
+# PART F. UI·Icon·Glyph·VFX 상한
+
+## 19. UI Component Family
+
+Hard Cap: `12 COMPONENT FAMILIES`.
+
+1. panel.
+2. button.
+3. tab.
+4. badge.
+5. gauge.
+6. icon_slot.
+7. tooltip.
+8. modal.
+9. scrollbar.
+10. divider.
+11. focus_ring.
+12. cursor_pointer.
+
+- Field·Dialogue·Writing·Battle·Result·Grimoire·Main은 동일 Family를 Theme·Size·Content로 변형한다.
+- Screen마다 독립 Frame Set을 만들지 않는다.
+- Hover·Pressed·Disabled·Selected는 Theme·Tint·Outline을 우선한다.
+
+## 20. Base Icon
+
+Hard Cap: `24 BASE ICONS`.
+
+필수 후보:
+
+- HP, Mana, Instability, Environment, Attack Timer, Slow, Pause, Warning.
+- Flow, Focus, Disperse.
+- Calm, Prepared, Connected.
+- Companion, Guardian.
+- Undo, Clear, Cancel, Confirm.
+- Grimoire, Result, Save, Settings.
+
+- 같은 Icon의 색 Variant는 수량에 포함하지 않지만 Texture Duplicate는 만들지 않는다.
+- Icon은 색 외 Shape·Interior Mark로 구분한다.
+
+## 21. Glyph
+
+```yaml
+base_glyph_count: 3
+base_canvas: 512x512_vector_or_rgba
+states_by_material_or_outline: true
+```
+
+Base:
+
+- flow.
+- focus.
+- disperse.
+
+State:
+
+- raw_stroke.
+- recognized.
+- selected.
+- invalid_grammar.
+- insufficient_condition.
+- committed.
+
+State는 Base Texture 복제보다 Line Style·Outline·Color·Icon Mark로 표현한다.
+
+## 22. Reusable VFX Module
+
+Hard Cap: `12 MODULES`.
+
+1. raw_glyph_stroke.
+2. recognition_confirm.
+3. target_lock.
+4. flow_path.
+5. focus_core.
+6. disperse_wave.
+7. enemy_attack_warning.
+8. instability_reduction.
+9. environment_change.
+10. guardian_protection.
+11. result_success_partial.
+12. failure_reason.
+
+- 한 Situation 전용 VFX는 기존 Module 조합으로 먼저 해결한다.
+- 전 화면 Bloom·긴 Flash·Glyph 가림 금지.
+
+## 23. Screen-specific Full-frame UI Art
+
+Hard Cap: `2`.
+
+- Grimoire Screen supporting illustration/frame.
+- Main Screen supporting composite.
+
+둘 다 공용 Component·Background Base 재사용이 우선이며 신규 Full Paint를 자동 의무화하지 않는다.
+
+---
+
+# PART G. Typography 계약
+
+## 24. Font Family 상한
+
+```yaml
+body_ui_family_count: 1
+limited_title_family_count: 1
+system_font_dependency: PROHIBITED
+licensed_korean_glyph_coverage: REQUIRED
+```
+
+- Body/UI: Sans Family 1개.
+- Title/Chapter/Grimoire Heading: Serif 또는 Decorative Family 1개.
+- Fallback Chain은 숫자·기호·한글이 끊기지 않도록 License와 함께 기록한다.
+- 정확한 Family 채택 전 License Ledger와 PC Runtime Rendering을 확인한다.
+
+## 25. 1920×1080 Typography Token
+
+| Token | Size | 용도 |
+|---|---:|---|
+| display | 56 px | Main Title·Major Result |
+| h1 | 40 px | Screen Title |
+| h2 | 32 px | Section·Modal Title |
+| body | 24 px | Dialogue·Description |
+| label | 20 px | Button·Gauge·Status |
+| small | 18 px | Auxiliary Text, 최소 상한 |
+
+- Body Line Height 목표 `1.35~1.45`.
+- 1280×720 비례 축소에서 Small이 약 12 px가 되므로, 실제 최소 해상도에서는 UI Scale·Font Override로 가독성을 보정한다.
+- 필수 정보는 1280×720에서 실측 최소 `16 px`를 목표로 한다.
+- Text Overflow·Long Korean·Keyboard Focus를 Runtime에서 검증한다.
+
+## 26. Font Rendering
+
+- Body는 기본 Grayscale Anti-aliasing을 우선한다.
+- MSDF는 큰 Scale 변화가 있는 Heading·World Label에서만 Trial한다.
+- Mobile 비용과 작은 Font 선명도가 검증되지 않으면 MSDF를 전역 적용하지 않는다.
+
+---
+
+# PART H. Import·Atlas·Memory 정책
+
+## 27. Filter
+
+- 프로젝트는 Pixel Art가 아니므로 기본 `Linear`.
+- Nearest는 의도적으로 Pixel-snapped Icon을 설계한 예외에서만 승인한다.
+- UI Line·Glyph가 흐려지면 Source Stroke·Export Resolution·Scale을 먼저 교정한다.
+
+## 28. Mipmap
+
+기본:
+
+- UI·Portrait·Glyph·Field SD: Off.
+- Background·Enemy가 실제로 큰 폭 Downscale되면 On Trial.
+- Final은 1080p·720p·1440p 비교 후 확정.
+
+## 29. Compression
+
+### 제작 초기
+
+- PNG·WebP Lossless.
+- Visual Artifact 비교 기준을 먼저 확보.
+
+### 최적화 단계
+
+- Opaque Background만 WebP Lossy 또는 VRAM Compression Trial.
+- Character·Glyph·UI는 Edge·Alpha Artifact가 없을 때만 변경.
+- 품질 비교 Capture와 Memory 결과 없이 일괄 압축 금지.
+
+## 30. Atlas
+
+- Actor/Action 단위로 분리한다.
+- One Giant Atlas 금지.
+- 최대 Texture Dimension 목표 `4096×4096` 이하.
+- Clip 교체가 다른 Clip Hash를 불필요하게 바꾸지 않도록 분리한다.
+
+예:
+
+```text
+chr_protagonist_idle.png
+chr_protagonist_move.png
+chr_protagonist_interact_cast.png
+enemy_greenhouse_spirit_pressure.png
+enemy_greenhouse_spirit_surge.png
+```
+
+---
+
+# PART I. Manifest·License·Approval
+
+## 31. Asset Manifest 필수 Field
+
+```yaml
+asset_id:
+role:
+decision_ids:
+source_file_id:
+source_sha256:
+source_tool:
+source_owner:
+license:
+license_evidence:
+export_file:
+export_sha256:
+dimensions:
+format:
+alpha:
+import_profile:
+status:
+approved_by:
+approved_at:
+used_in_screens:
+replacement_or_supersession:
+runtime_validation:
+```
+
+## 32. Asset 상태
+
+```text
+PLANNED
+→ SOURCE_READY
+→ EXPORTED_CANDIDATE
+→ IN_VISUAL_REVIEW
+├─ REVISION_REQUIRED
+├─ REJECTED
+└─ APPROVED_RUNTIME_CANDIDATE
+   → IMPORTED
+   → RUNTIME_VERIFIED
+   → PROJECT_ASSET_APPROVED
+```
+
+- Art Bible 승인만으로 개별 Asset이 `PROJECT_ASSET_APPROVED`가 되지 않는다.
+- Generated Image는 `EXPORTED_CANDIDATE` 또는 `IN_VISUAL_REVIEW`다.
+- Runtime Capture·Performance·Readability Evidence 전에는 `RUNTIME_VERIFIED`를 사용하지 않는다.
+
+## 33. License Gate
+
+- Font·Texture·Icon·Brush·Audio·Plugin의 상업 사용·수정·재배포·Credit 의무를 기록한다.
+- License가 불명확한 Pinterest·검색 Image는 Discovery Reference이며 Source Asset이 아니다.
+- 외부 Asset 설치·구매·계정 연결은 별도 사용자 승인과 Removal Plan이 필요하다.
+- 현재 Asset Pipeline에 Add-on은 채택하지 않는다.
+
+---
+
+# PART J. 화면별 최소 Asset Checklist
+
+## 34. Main
+
+- School Base Composite.
+- Logo/Text는 Editable UI.
+- New Game / Continue / Settings Button State.
+- Continue Locked/No Save State.
+- Companion 또는 Grimoire Symbol 1개.
+
+## 35. Field·Schedule
+
+- School/Greenhouse Background.
+- Protagonist SD.
+- Professor·Peer SD.
+- Companion SD.
+- Goal Marker·Interaction Badge.
+- Schedule Card는 공용 UI Component.
+
+## 36. Dialogue
+
+- 핵심 인물 Half-body 12.
+- Speaker Name·Dialogue Text는 Editable UI.
+- Log·Auto/Manual·Skip는 실제 필요성 검토 후 Common Icon에서 사용.
+
+## 37. Writing
+
+- Glyph 3 Base.
+- Raw/Recognized/Selected/Invalid/Committed State.
+- Candidate Slot·Undo·Clear·Cancel·Confirm.
+- Target·Condition·Cost·Risk Indicator.
+- Background Dim은 Shader/Overlay, 별도 Full-screen Texture 금지.
+
+## 38. Battle
+
+- Greenhouse Battle Arena.
+- Enemy 1 Body Set.
+- Protagonist Portrait 1 Active Set.
+- Companion·Guardian Badge.
+- HP·Mana·Instability·Environment·Attack Timer Gauge/Icon.
+- Collapsed/Expanded Writing Panel.
+- Time State `1.0× / Slow / Pause`.
+- Guardian Cut-in·Protection FX.
+
+## 39. Result·Field Return
+
+- Result Common Panel.
+- Success/Partial/Failure Reason Icon.
+- Environment Before/After State.
+- Reward보다 Cause·Change가 먼저 보이는 Text Layout.
+
+## 40. Grimoire
+
+- Common Navy/Gold Frame.
+- Situation List·Entry Detail·Glyph·Intent·Result·Side Effect·Discovery Slot.
+- Empty·Selected·New Entry·Unavailable State.
+- 자동 최적 조합·Click Auto-cast Asset 금지.
+
+---
+
+# PART K. QA·통과 조건
+
+## 41. Static QA
+
+- lowercase snake_case.
+- 허용 Format.
+- Dimension·Alpha·Color Space 확인.
+- Source·Export SHA 연결.
+- Decision ID·Screen Consumer 연결.
+- License Evidence 존재.
+- Duplicate·Supersession 확인.
+- 수량 Hard Cap 초과 없음.
+
+## 42. Visual QA
+
+- Locked Art Style과 같은 게임으로 보임.
+- SD·Portrait·Cut-in의 동일 인물성.
+- Glyph·Target·Attack Warning이 가장 먼저 읽힘.
+- Navy/Gold UI가 Background와 Character를 가리지 않음.
+- 1280×720에서 필수 Text·Button·Gauge 판독.
+- Ultrawide에서 UI가 중앙 Safe Frame을 유지.
+- Color 없이 Icon·Shape·Text로 상태 구분.
+- Long Korean Text·Focus Ring·Reduced Motion 대체 가능.
+
+## 43. Runtime QA — 후행
+
+```text
+1080p / 720p / 1440p / Ultrawide
+→ Import Texture Quality
+→ Memory·Load Time
+→ UI Scale·Font Rendering
+→ Atlas·Animation Playback
+→ Glyph·Attack Warning Readability
+→ Scene Transition·Resource Reuse
+```
+
+현재는 `NOT_RUN`.
+
+## 44. Stop Conditions
+
+- Background Base 3개 또는 Overlay Set 8개 초과.
+- 핵심 Half-body 12개 초과.
+- 일반 NPC Portrait 제작 시작.
+- 일반 적 Full-body Multi-phase Variant 제작.
+- Screen마다 독립 UI Frame Set 제작.
+- Font Family 2개 초과.
+- Base Icon 24개·VFX Module 12개 초과.
+- Source·License·Manifest 없는 Asset Import.
+- 잠긴 기준판을 Runtime Asset으로 가공.
+- Asset Spec 승인만으로 대량 생성 시작.
+
+초과가 필요하면 Scope Change Decision·Benchmark·사용자 승인·Sheet 동기화를 선행한다.
+
+---
+
+## 45. 다음 Gate
+
+```text
+ASSET-SPEC-01 — 승인 완료
+→ BOSS-PHASE-01
+→ GRIMOIRE-SCREEN-01
+→ MAIN-SCREEN-01
+→ AUDIO-DIRECTION-01
+→ 기획·아트 통합 검수
+→ Codex Plan 승인·기술 검수
+→ 구현
+```
+
+Asset Production은 아직 시작하지 않는다. 다음 작업은 보스 규칙과 파생 화면 구조를 먼저 닫고, 필요한 Asset Consumer를 확정하는 것이다.

--- a/docs/planning/ASSET_SPEC_01_STATE.json
+++ b/docs/planning/ASSET_SPEC_01_STATE.json
@@ -1,0 +1,102 @@
+{
+  "schema_version": 1,
+  "decision_id": "ASSET-SPEC-01",
+  "project": "GRIMOIRE: 세계를 다시 쓰는 법",
+  "status": "APPROVED_VERTICAL_SLICE_ASSET_SPEC",
+  "approved_at": "2026-08-01T11:00:00+09:00",
+  "approved_by": "USER_BATCH_APPROVAL_RECOMMENDED_OPTION",
+  "benchmark": {
+    "id": "GR-BM-ASSET-SPEC-01",
+    "scale": "STANDARD",
+    "status": "COMPLETE",
+    "source_path": "docs/planning/benchmarks/ASSET_SPEC_01_STANDARD_BENCHMARK_2026-08-01.md",
+    "commit": "f194c448632d2fa0da1428a69407a4459c5b6607"
+  },
+  "authority": {
+    "source_path": "docs/planning/ASSET_SPEC_01_APPROVAL_2026-08-01.md",
+    "commit": "e9b4ae583c2e660c99689edcb29e0b3db9e379c9"
+  },
+  "display_contract": {
+    "logical_design_frame": "1920x1080",
+    "minimum_pc_readability": "1280x720",
+    "primary_aspect_ratio": "16:9",
+    "safe_margin_px_1080p": {
+      "left": 64,
+      "right": 64,
+      "top": 48,
+      "bottom": 48
+    },
+    "ultrawide": "EXPAND_BACKGROUND_AND_WORLD_KEEP_UI_IN_16_9_SAFE_FRAME",
+    "mobile": "SEPARATE_FOLLOW_UP_DERIVATIVE"
+  },
+  "formats": {
+    "opaque_background_runtime": "WEBP_LOSSLESS_FIRST",
+    "transparent_runtime": "PNG_RGBA",
+    "simple_vector_source": "SVG",
+    "font": "LICENSED_TTF_OTF_OR_WOFF2",
+    "baked_korean_text": false,
+    "default_filter": "LINEAR",
+    "default_mipmap": "OFF_EXCEPT_BACKGROUND_TRIAL"
+  },
+  "production_caps": {
+    "opaque_background_base_masters": 3,
+    "background_state_overlay_sets": 8,
+    "half_body_portraits": 12,
+    "general_npc_half_body_portraits": 0,
+    "protagonist_field_frames": 36,
+    "professor_field_frames": 16,
+    "peer_field_frames": 16,
+    "companion_frames": 20,
+    "companion_reaction_icons": 4,
+    "guardian_status_badges": 1,
+    "guardian_cutins": 1,
+    "guardian_fx_frames": 8,
+    "guardian_full_battlefield_body_sets": 0,
+    "enemy_body_sets": 1,
+    "enemy_frames": 50,
+    "normal_enemy_phase_variants": 0,
+    "ui_component_families": 12,
+    "base_icons": 24,
+    "base_glyphs": 3,
+    "reusable_vfx_modules": 12,
+    "screen_specific_full_frame_ui_art": 2,
+    "font_families": 2,
+    "max_texture_dimension": 4096
+  },
+  "runtime_canvas": {
+    "background_master": "2560x1440",
+    "half_body_portrait": "1024x1536",
+    "protagonist_and_npc_sd_frame": "384x384",
+    "companion_frame": "256x256",
+    "enemy_frame": "512x512",
+    "glyph_base": "512x512"
+  },
+  "folder_contract": {
+    "runtime_root": "assets/",
+    "source_root": "art_source/ OR EXTERNAL_LIBRARY",
+    "source_import": "PROHIBITED_USE_GDIGNORE_OR_EXTERNAL_STORAGE",
+    "manifest_root": "assets/manifests/",
+    "naming": "LOWERCASE_SNAKE_CASE"
+  },
+  "asset_pipeline": {
+    "addons": "NONE_ADOPTED",
+    "native_godot_import_first": true,
+    "source_runtime_boundary": "REQUIRED",
+    "manifest_and_sha": "REQUIRED",
+    "license_ledger": "docs/ASSET_LICENSE_LEDGER.md",
+    "generated_image_auto_approval": false
+  },
+  "next_product_gates": [
+    "BOSS-PHASE-01",
+    "GRIMOIRE-SCREEN-01",
+    "MAIN-SCREEN-01",
+    "AUDIO-DIRECTION-01"
+  ],
+  "implementation_authority": "NONE",
+  "asset_production": "NOT_STARTED",
+  "godot": "NOT_STARTED",
+  "runtime_validation": "NOT_RUN",
+  "human_validation": "NOT_RUN",
+  "sync_status": "GITHUB_AUTHORITY_CREATED_SHEET_PENDING",
+  "main_sync": "PENDING_PR_MERGE"
+}

--- a/docs/planning/DECISION_LOG_ADDENDUM_2026-08-01G.md
+++ b/docs/planning/DECISION_LOG_ADDENDUM_2026-08-01G.md
@@ -1,0 +1,83 @@
+# GRIMOIRE Decision Log Addendum — 2026-08-01G
+
+## ASSET-SPEC-01
+
+```yaml
+decision_id: ASSET-SPEC-01
+status: APPROVED_VERTICAL_SLICE_ASSET_SPEC
+approved_at: 2026-08-01
+approved_by: USER_BATCH_APPROVAL_RECOMMENDED_OPTION
+benchmark: GR-BM-ASSET-SPEC-01 / STANDARD_COMPLETE
+```
+
+사용자의 권장안 일괄 승인에 따라 GRIMOIRE Solo Vertical Slice Asset Specification을 승인한다.
+
+### 화면·해상도
+
+- Logical Design Frame `1920×1080`.
+- 최소 PC 판독 기준 `1280×720`.
+- Ultrawide는 Background·World를 확장하고 UI는 중앙 16:9 Safe Frame 유지.
+- 1080p Safe Margin: 좌우 `64 px`, 상하 `48 px`.
+
+### 형식
+
+- Opaque Painterly Background: `2560×1440 WebP Lossless` 우선.
+- Transparent Character·Portrait·Enemy·VFX: `PNG RGBA`.
+- Simple UI Shape·Icon·Glyph Reference: `SVG`.
+- Font: 상업 이용·한글 Coverage가 확인된 Dynamic Font.
+- 한글 Text Image Bake 금지.
+
+### Solo 제작 상한
+
+- Opaque Background Base `3`.
+- Background State Overlay Set `8`.
+- 핵심 Half-body Portrait `12`, 일반 NPC Portrait `0`.
+- Protagonist Field Frame `36`.
+- Professor·Peer Field Frame 각 `16`.
+- Companion Frame `20`, Reaction Icon `4`.
+- Guardian Full Battlefield Body Set `0`; Badge 1, Cut-in 1, FX 최대 8 Frame.
+- Enemy Body Set `1`, 최대 `50 Frame`, 일반 Multi-phase Variant `0`.
+- UI Component Family `12`.
+- Base Icon `24`.
+- Glyph Base `3`.
+- Reusable VFX Module `12`.
+- Font Family `2`.
+
+### Source·Manifest·License
+
+- Layered Source와 Runtime Export를 분리한다.
+- Source는 외부 Library 또는 `.gdignore` Root에 보관한다.
+- Runtime Export·SHA·License·사용 Screen·Approval·Runtime Validation을 Manifest로 추적한다.
+- `docs/planning/ASSET_MANIFEST_SCHEMA.json`을 사용한다.
+- 현재 Godot Asset Pipeline Add-on은 채택하지 않는다.
+
+### 승인 경계
+
+```text
+ASSET SPEC = APPROVED
+ASSET PRODUCTION = NOT_STARTED
+GODOT IMPORT = NOT_RUN
+RUNTIME·PERFORMANCE·HUMAN QA = NOT_RUN
+```
+
+정확한 Compression·Mipmap·MSDF·Memory·Load Time은 PC Runtime에서 검증한다.
+
+## 다음 Gate
+
+```text
+BOSS-PHASE-01
+→ GRIMOIRE-SCREEN-01
+→ MAIN-SCREEN-01
+→ AUDIO-DIRECTION-01
+→ 기획·아트 통합 검수
+→ Codex Plan 승인·기술 검수
+→ 구현
+```
+
+권위:
+
+- `docs/planning/ASSET_SPEC_01_APPROVAL_2026-08-01.md`.
+- `docs/planning/ASSET_SPEC_01_STATE.json`.
+- `docs/planning/benchmarks/ASSET_SPEC_01_STANDARD_BENCHMARK_2026-08-01.md`.
+- `docs/planning/ASSET_MANIFEST_SCHEMA.json`.
+- `docs/ASSET_LICENSE_LEDGER.md`.

--- a/docs/planning/benchmarks/ASSET_SPEC_01_STANDARD_BENCHMARK_2026-08-01.md
+++ b/docs/planning/benchmarks/ASSET_SPEC_01_STANDARD_BENCHMARK_2026-08-01.md
@@ -1,0 +1,212 @@
+# ASSET-SPEC-01 STANDARD Benchmark — 2026-08-01
+
+## 1. 질문
+
+> 승인된 GRIMOIRE Art Bible을 보존하면서 PC 우선 Solo Vertical Slice에 필요한 이미지·UI·Font·Animation·파일 구조를 어떤 해상도·형식·수량 상한으로 고정해야 하는가?
+
+```yaml
+benchmark_id: GR-BM-ASSET-SPEC-01
+scale: STANDARD
+status: COMPLETE
+project: "GRIMOIRE: 세계를 다시 쓰는 법"
+engine_candidate: Godot 4.7.1 stable
+primary_platform: PC
+follow_up_platform: Mobile
+implementation: NOT_STARTED
+runtime_validation: NOT_RUN
+```
+
+## 2. 고정된 프로젝트 제약
+
+- 잠긴 Art Style 원본을 수정·재생성하지 않는다.
+- 16:9 고정 3/4 Field, 같은 장소 Half-body Dialogue, 별도 Battle, Result 후 Field 복귀.
+- Soft Storybook 배경 + Clean Anime Cel 캐릭터.
+- Navy/Gold UI + High-contrast Blue Glyph.
+- 전투 상시 주인공 초상 1개, 동반 정령·수호 소환수 상태 배지.
+- 일반 전투는 강한 적 1개체·단일 페이즈.
+- Grimoire 파생 화면을 Main보다 먼저 설계.
+- 제품 Godot 프로젝트와 Runtime Asset은 아직 없다.
+
+## 3. 공식 Godot 근거
+
+### 3.1 Multiple resolutions
+
+Godot 4.7 공식 문서는 기준 Window Size와 Stretch Mode·Aspect 정책을 조합해 여러 해상도를 처리하고, `canvas_items`와 `expand`를 2D 프로젝트의 일반적인 출발점으로 설명한다. `expand`는 화면비가 넓어질 때 기준 영역 바깥의 World가 보일 수 있으므로, UI Anchor와 배경 확장 경계를 별도로 설계해야 한다.
+
+- Source: https://docs.godotengine.org/en/4.7/tutorials/rendering/multiple_resolutions.html
+- 적용: 1920×1080 Logical Frame + 1280×720 최소 판독 기준 + 16:9 UI Safe Frame.
+- 판정: `ADOPT_WITH_SAFE_FRAME`.
+
+### 3.2 Image·Texture import
+
+Godot 4.7은 PNG·WebP·SVG 등 일반 이미지 형식을 Import해 `CompressedTexture2D`로 사용한다. SVG는 Import 과정에서 Rasterize되므로 단순 UI Shape·Icon에 적합하고, 실제 Pixel 수정이 필요한 경우에는 `Image`를 별도로 사용한다.
+
+- Source: https://docs.godotengine.org/en/4.7/tutorials/assets_pipeline/importing_images.html
+- 적용: Transparent Character·Portrait·UI·VFX는 PNG, Opaque Painterly Background는 WebP 후보, 단순 Icon Source는 SVG.
+- 판정: `ADOPT`.
+
+### 3.3 Texture compression·filtering
+
+공식 Texture Import 문서는 Lossless·Lossy·VRAM Compressed 목적을 구분한다. 선명한 투명 UI·Glyph·Character는 Lossless가 안전하며, 큰 Opaque Background는 시각 비교 후 WebP Lossy 또는 VRAM Compression을 검토할 수 있다. Mipmap은 실제 축소·Camera Scale이 있는 자산에만 켠다.
+
+- Source: https://docs.godotengine.org/en/4.7/tutorials/assets_pipeline/importing_images.html#compress-mode
+- 적용: 제작 초기에는 Lossless를 기본으로 하고 Memory·Load Test 후 큰 Background만 단계적으로 압축.
+- 판정: `ADAPT_AFTER_VISUAL_QA`.
+
+### 3.4 Fonts
+
+Godot 4.7 공식 문서는 TTF·OTF·WOFF·WOFF2의 Dynamic Font 사용과 Font License 확인을 요구한다. MSDF는 큰 Scale 변화에 유용하지만 작은 본문·Mobile 비용과 품질을 별도로 검증해야 한다.
+
+- Source: https://docs.godotengine.org/en/4.7/tutorials/ui/gui_using_fonts.html
+- 적용: 한글 지원 본문 Sans 1 Family + 제목용 제한적 Serif 1 Family. 정확한 Family는 License Ledger 후 확정.
+- 판정: `ADOPT_WITH_LICENSE_GATE`.
+
+### 3.5 Project organization·naming
+
+Godot 공식 Project Organization 권장안은 관련 Scene·Script·Asset을 책임 단위로 묶고, Import하지 않을 Source Folder에는 `.gdignore`를 사용할 수 있음을 설명한다. File·Folder는 lowercase `snake_case`로 고정해 Case-sensitive Export 오류를 줄인다.
+
+- Source: https://docs.godotengine.org/en/4.7/tutorials/best_practices/project_organization.html
+- Source: https://docs.godotengine.org/en/4.7/tutorials/scripting/gdscript/gdscript_styleguide.html#file-names
+- 적용: Domain-first Asset Folder, lowercase snake_case, Layered Source와 Runtime Export 분리.
+- 판정: `ADOPT`.
+
+### 3.6 Sprite animation
+
+Godot의 `AnimatedSprite2D`와 `SpriteFrames`는 Clip별 Frame Animation을 관리할 수 있다. 한 Actor의 모든 Frame을 하나의 거대한 Atlas로 강제하지 않고 Action 단위로 분리하면 Import·Diff·Memory·교체 위험을 줄일 수 있다.
+
+- Source: https://docs.godotengine.org/en/4.7/classes/class_animatedsprite2d.html
+- Source: https://docs.godotengine.org/en/4.7/classes/class_spriteframes.html
+- 적용: Actor/Action 단위 Atlas, 최대 Texture Size를 보수적으로 유지.
+- 판정: `ADOPT`.
+
+## 4. 세 가지 제작 모델 비교
+
+| 안 | 계약 | 장점 | 위험 | 판정 |
+|---|---|---|---|---|
+| A. 1920×1080 Full-resolution All-master | 모든 배경·캐릭터·UI를 화면 최종 크기로 직접 제작 | 이해가 간단함 | 1440p·Ultrawide 품질 부족, Source/Runtime 혼합, 수정 비용 증가 | `REJECT` |
+| B. 4K Source-first | 모든 자산을 4K 이상 Layered Master로 제작 | 확대·홍보 재사용 여유 | Solo 제작·Storage·Import·Revision 비용 과대, Slice 범위 팽창 | `REJECT_FOR_SLICE` |
+| C. Logical Frame + Role-based Masters | 1920×1080 UI 기준, 2560×1440 Background Master, Actor별 제한된 Runtime Canvas, Vector UI Source | 가독성·품질·제작량·교체 가능성 균형 | Manifest·Export Rule이 없으면 Source Drift 발생 | `ADOPT_WITH_MANIFEST` |
+
+## 5. 권장 해상도 모델
+
+```text
+Logical UI / Design Frame = 1920×1080
+Minimum PC Readability Check = 1280×720
+Ultrawide = Background·World 확장, UI는 중앙 16:9 Safe Frame 유지
+```
+
+### Safe Frame
+
+- 1920×1080 기준 기본 Margin: 좌우 `64 px`, 상하 `48 px`.
+- 1280×720에서는 비례 축소 후 Body Text가 최소 약 `16 px`에 해당하도록 Token을 설계한다.
+- Writing Panel·Portrait·Attack Warning은 Safe Frame 안에서 겹침 없이 작동해야 한다.
+
+## 6. 권장 Asset 역할별 형식
+
+| 자산 | Source | Runtime Export | 기본 Import 방향 |
+|---|---|---|---|
+| Opaque Painterly Background | Layered Source, 2560×1440 | WebP Lossless 우선 | Linear Filter, 실제 축소 시 Mipmap 검토 |
+| Character·Portrait·Enemy·Transparent VFX | Layered Source | PNG RGBA | Lossless, Linear Filter, Mipmap 기본 Off |
+| Simple UI Shape·Icon·Glyph Reference | SVG Source | SVG 또는 Import Raster | 복잡 Filter·Baked Text 금지 |
+| Font | Licensed TTF/OTF/WOFF2 | Dynamic Font | Body Raster AA 우선, MSDF 별도 Trial |
+| Text | Editable Localization Data | Godot UI Text | Image에 한글 Bake 금지 |
+
+## 7. Source와 Runtime 분리
+
+```text
+External or .gdignore Layered Source
+→ Asset Manifest·SHA·License
+→ Approved Runtime Export
+→ Godot Import
+→ Visual·Memory·Readability QA
+```
+
+- PSD·KRA·Clip 등 Layered Source는 Godot Import Root에서 제외한다.
+- GitHub에는 실제 Runtime Export와 Manifest를 둔다.
+- 외부 Library·Drive Source는 File ID·SHA·Owner·License·Export Version을 기록한다.
+- 원본과 Runtime Export를 같은 이름으로 덮어쓰지 않는다.
+
+## 8. Solo Vertical Slice 수량 비교
+
+### 배경
+
+- 학교 공용 Base 1.
+- 현장 Greenhouse Field Base 1.
+- 동일 사건 Battle Arena Base 1.
+- 수업·시험·축제·손상·복구는 Overlay·Lighting·Prop State로 변형.
+- Main은 학교 Base의 별도 Composite로 만들고 신규 Full Paint를 의무화하지 않는다.
+- Grimoire는 공용 UI Component와 제한된 Illustration Slot으로 구성한다.
+
+판정: `3 OPAQUE BASE MASTERS + MAX 8 STATE OVERLAYS`.
+
+### 인물·존재
+
+- Protagonist·Professor·Peer Half-body: 각 4 Expression, 총 12.
+- Companion Reaction Icon: 최대 4.
+- 일반 NPC Half-body: 0.
+- Guardian: Badge 1 + Cut-in 1 + Protection FX 1 Set.
+- Enemy: 1 Body Set, 일반 Multi-phase Variant 없음.
+
+### UI·FX
+
+- 공용 UI Component Family 최대 12.
+- Base Icon 최대 24.
+- Glyph Base 3; 상태 차이는 Tint·Outline·Material 우선.
+- Reusable VFX Module 최대 12.
+- Screen-specific Full-frame UI Art는 Grimoire·Main 합계 최대 2개지만, 기존 Base 재사용을 우선한다.
+
+## 9. 위험 공격
+
+### 과잉 해상도
+
+4K Source를 모든 Asset에 의무화하면 Solo Slice가 Rendering 품질이 아니라 Source 관리 비용으로 막힌다.
+
+### Frame 과잉
+
+고프레임 Character Animation은 현재 고정 장면·초상 중심 화면에서 체감 대비 비용이 낮다. 핵심은 Glyph·Attack Warning·Enemy State 변화다.
+
+### Font 과잉
+
+서체 Family를 늘리면 한글 Glyph Coverage·License·Fallback·Font Memory 문제가 증가한다. Body 1 + Title 1을 상한으로 둔다.
+
+### Duplicate State Asset
+
+색·활성·잠김·선택 상태를 PNG 복제본으로 늘리면 UI 유지보수가 붕괴한다. Theme·Tint·Outline·Shader로 처리 가능한 상태는 Texture를 복제하지 않는다.
+
+### Add-on 조기 도입
+
+현재 Asset Pipeline은 Godot 기본 Import·Theme·SpriteFrames로 설계 가능하다. Asset Manager·Dialogue UI·Inventory UI Add-on은 필요성·License·제거 가능성이 증명되기 전 채택하지 않는다.
+
+## 10. 최종 적용 판정
+
+```yaml
+ADOPT:
+  - 1920x1080_logical_frame
+  - 1280x720_minimum_readability
+  - central_16_9_safe_frame
+  - 2560x1440_background_master
+  - png_for_transparency
+  - webp_lossless_first_for_opaque_background
+  - svg_for_simple_shapes_only
+  - dynamic_licensed_fonts
+  - lowercase_snake_case_paths
+  - source_runtime_manifest_boundary
+  - action_split_sprite_atlases
+ADAPT_AFTER_QA:
+  - lossy_or_vram_background_compression
+  - mipmaps
+  - msdf_fonts
+REJECT:
+  - universal_4k_source_requirement
+  - baked_korean_text
+  - one_giant_actor_atlas
+  - duplicate_texture_per_ui_state
+  - early_asset_pipeline_addons
+```
+
+## 11. 검증 경계
+
+- 해상도·수량은 승인된 Production Contract이며 실제 Runtime 품질 증거가 아니다.
+- Import Compression·MSDF·Mipmap 최종값은 Godot PC Build에서 비교한다.
+- Mobile은 PC Runtime 검증 후 별도 Texture·Layout·Memory Budget을 만든다.
+- 생성 이미지·외부 Asset·Font는 Source·License·유사성 검수 전 제품 자산이 아니다.


### PR DESCRIPTION
## 목적

승인된 Art Bible·Battle Rules를 실제 Solo Vertical Slice 제작 상한으로 변환하는 `ASSET-SPEC-01`을 확정하고, Base v9.3 Adapter·Generated View·CI·Google Sheet를 현재 Gate에 맞춥니다.

## 승인 규격

- Logical Frame `1920×1080`, 최소 PC 판독 `1280×720`
- Opaque Background Master `2560×1440`
- Background Base 3, State Overlay Set 8
- 핵심 Half-body 12, 일반 NPC Portrait 0
- Protagonist Field Frame 36
- Enemy Body Set 1, Frame 50, 일반 Multi-phase Variant 0
- UI Component Family 12, Base Icon 24, Glyph 3, VFX Module 12
- Font Family 2
- Layered Source와 Runtime Export 분리
- Manifest·SHA·License·Screen Consumer·Runtime Validation 추적
- Asset Pipeline Add-on 미채택

## 주요 문서

- `docs/planning/benchmarks/ASSET_SPEC_01_STANDARD_BENCHMARK_2026-08-01.md`
- `docs/planning/ASSET_SPEC_01_APPROVAL_2026-08-01.md`
- `docs/planning/ASSET_SPEC_01_STATE.json`
- `docs/planning/ASSET_MANIFEST_SCHEMA.json`
- `docs/ASSET_LICENSE_LEDGER.md`
- `docs/planning/DECISION_LOG_ADDENDUM_2026-08-01G.md`

## 현재 Gate

```text
ASSET-SPEC-01 = APPROVED_VERTICAL_SLICE_ASSET_SPEC
NEXT = BOSS-PHASE-01
PARALLEL = GRIMOIRE-SCREEN-01
MAIN-SCREEN-01 = PENDING_AFTER_GRIMOIRE
AUDIO-DIRECTION-01 = PENDING_AFTER_DERIVATIVE_SCREENS
ASSET PRODUCTION = NOT_STARTED
GODOT PRODUCT IMPLEMENTATION = NOT_STARTED
```

## 검증

- `python tools/generate_project_operating_views.py --check`
- `python -m unittest tests.test_base_v9_adoption`
- 전체 JSON Parse
- `git diff --check`
- 핵심 콜드 스타트의 구형 `NEXT ASSET-SPEC-01` 참조 제거

## 경계

- 잠긴 Art Style 원본 변경 없음
- Product Asset 생성 없음
- Godot Import·Runtime·Memory·Performance·PC·Mobile·Accessibility·Human QA `NOT_RUN`
- 정확한 Compression·Mipmap·MSDF와 Animation Playback은 Runtime 후행

사용자는 작업 중 권장안 일괄 승인을 부여했습니다. CI·Sheet Readback·Mergeability 실패 시 병합하지 않습니다.