### PR TITLE
docs: approve landscape orientation and continue total-planning audit

### DIFF
--- a/docs/DEVELOPMENT_GATES.md
+++ b/docs/DEVELOPMENT_GATES.md
@@ -10,6 +10,8 @@ execution_profile: PLANNING_ONLY_PROFILE
 primary_platform: Mobile
 follow_up_platform: PC
 platform_decision: GM-PLATFORM-02
+mobile_orientation_decision: GM-MOBILE-ORIENTATION-01
+mobile_orientation: LANDSCAPE_FIXED
 planning: APPROVED
 art_style_01: APPROVED_A_MODIFIED_LOCKED
 art_bible_01: APPROVED_DUAL_STANDARD_ART_BIBLE
@@ -25,7 +27,7 @@ implementation_ready: false
 codex: BLOCKED
 ```
 
-현재 승인은 기획·시각 규칙·전투 구조·Asset 제작 계약을 확정한다. Mobile 실기기 구현·성능·접근성·사람 플레이 통과를 의미하지 않는다.
+현재 승인은 기획·시각 규칙·전투 구조·Asset 제작 계약과 Mobile Landscape 방향을 확정한다. Mobile 실기기 구현·성능·접근성·사람 플레이 통과를 의미하지 않는다.
 
 ## 1. 전체 경로
 
@@ -37,6 +39,7 @@ Gate 1 콘셉트·Vertical Slice — 완료
 → 전투 화면·단일 강적·Active Timer·Time Flow·Battle Rules — 완료
 → ASSET-SPEC-01 — 완료
 → GM-PLATFORM-02 — Mobile 우선 승인
+→ GM-MOBILE-ORIENTATION-01 — Landscape 고정 승인
 → MOBILE-FOUNDATION-01 — 현재 Gate
 → BOSS-PHASE-01·Grimoire/Main 파생 화면 영향 재검토
 → AUDIO-DIRECTION-01
@@ -148,11 +151,23 @@ Gate 1 콘셉트·Vertical Slice — 완료
 - 승인 코어·Slice·Art·Battle·Asset Spec은 보존한다.
 - PC 전용 입력·해상도·테스트·출시 순서는 Mobile 기준으로 재검토한다.
 
-## 5. MOBILE-FOUNDATION-01
+## 5. GM-MOBILE-ORIENTATION-01
+
+상태: `USER_APPROVED_ACTIVE`.
+
+책임 원본: `docs/planning/MOBILE_ORIENTATION_01_APPROVAL_2026-08-02.md`.
+
+- Mobile Vertical Slice의 Main·Field·Dialogue·Schedule·Writing·Battle·Result·Grimoire·Settings는 Landscape 고정.
+- Portrait Gameplay와 Runtime 자동 회전은 Vertical Slice 범위에서 제외.
+- 기존 16:9 자료는 Landscape 파생 기준으로 보존하지만 Mobile 실기기 품질 통과 증거로 자동 승격하지 않음.
+- 한손 Portrait 편의보다 직접 작성 Canvas와 적 위험·상태·작성 정보의 동시 판독을 우선.
+- Landscape 고정의 진입 마찰과 작은 기기 피로는 Resume Anchor·실기기 테스트·접근성 검증으로 다룸.
+
+## 6. MOBILE-FOUNDATION-01
 
 상태: `CURRENT_RECONCILIATION_GATE`.
 
-목표: 승인된 직접 작성·상황 해결 코어가 Mobile에서 입력·화면·중단·성능 문제로 약화되지 않는 최소 기반을 확정한다.
+목표: 승인된 직접 작성·상황 해결 코어가 Landscape Mobile에서 입력·화면·중단·성능 문제로 약화되지 않는 최소 기반을 확정한다.
 
 확정·검증 대상:
 
@@ -160,29 +175,31 @@ Gate 1 콘셉트·Vertical Slice — 완료
 2. 화면 내 Undo·부분 삭제·전체 초기화·취소·확정·`[구현]`.
 3. interrupted stroke·multi-touch·system gesture·stale recognition·중복 Commit 방어.
 4. App pause/resume·background/foreground·focus loss 상태 유지.
-5. 화면 방향·지원 비율·Safe Area·Notch·최소 Touch target 후보.
+5. Landscape 지원 Aspect Ratio·Safe Area·Notch·최소 Touch target 후보.
 6. 작은 화면에서 적 위험·목표·주인공 상태·작성 Panel의 가림 방지.
-7. Memory·Texture·load·frame pacing·battery·thermal 측정 계획.
-8. Android/iOS·Store·최소 기기·성능 목표 결정을 위한 사용자 패킷.
-9. 후속 PC Mouse/Pen/Keyboard 적응 원칙.
+7. Resume Anchor·자동 저장·이어하기·Draft 저장 소유권.
+8. Memory·Texture·load·frame pacing·battery·thermal 측정 계획.
+9. Android/iOS·Store·최소 기기·성능 목표 결정을 위한 사용자 패킷.
+10. 후속 PC Mouse/Pen/Keyboard 적응 원칙.
 
 통과 조건:
 
 - 입력 실패·문법 실패·상황 설계 실패·비용 부족을 구분한다.
 - 낮은 확신 후보 자동 선택과 자동 시전을 하지 않는다.
 - 앱 중단·복귀와 입력 재진입에서 중복 시전·보상·기록·손상 상태가 없다.
-- Mobile 기준 화면 후보가 적·위험·작성 정보를 동시에 가리지 않는다.
-- OS·방향·성능 수치는 근거 또는 사용자 승인 없이 확정하지 않는다.
+- Landscape 화면 후보가 적·위험·작성 정보를 동시에 가리지 않는다.
+- Portrait·자동 회전을 Vertical Slice 필수 지원으로 조용히 확장하지 않는다.
+- Aspect Ratio·Safe Area·성능 수치는 근거 또는 사용자 승인 없이 최종 확정하지 않는다.
 - 사용자가 Mobile Foundation 계약을 승인한다.
 
-## 6. 후속 설계 Gate
+## 7. 후속 설계 Gate
 
 ### BOSS-PHASE-01
 
 상태: `QUEUED_REVIEW_AFTER_MOBILE_FOUNDATION`.
 
 - 보스 페이즈 수·전환 상태·Attack Timer·작성 Draft·환경 변화·반복 악용 방지.
-- Mobile 화면과 중단·복귀 계약에 맞는지 재검토 후 확정.
+- Landscape 화면과 중단·복귀 계약에 맞는지 재검토 후 확정.
 
 ### GRIMOIRE-SCREEN-01
 
@@ -190,7 +207,7 @@ Gate 1 콘셉트·Vertical Slice — 완료
 
 - 상황·글자·의도·결과·부작용·발견 관리.
 - 자동 최적 추천·자동 시전 금지.
-- 작은 화면 탐색·텍스트·Touch 조작 검증 필요.
+- Landscape 작은 화면 탐색·텍스트·Touch 조작 검증 필요.
 
 ### MAIN-SCREEN-01
 
@@ -198,6 +215,7 @@ Gate 1 콘셉트·Vertical Slice — 완료
 
 - `새 게임 / 이어하기 / 설정` 중심 최소 구조.
 - 수집형 로비 UI 금지.
+- Portrait 별도 Main을 Vertical Slice 범위에 추가하지 않음.
 
 ### NAMING-PASS-01
 
@@ -206,7 +224,7 @@ Gate 1 콘셉트·Vertical Slice — 완료
 - 세계 명명 규칙과 주요 이름.
 - Mobile Foundation을 차단하지 않음.
 
-## 7. AUDIO-DIRECTION-01
+## 8. AUDIO-DIRECTION-01
 
 상태: `QUEUED`.
 
@@ -215,22 +233,22 @@ Gate 1 콘셉트·Vertical Slice — 완료
 - 적 공격 예고·Time State·Instability·Result 피드백.
 - 무음 대체·haptic-off·Mobile speaker/headphone 환경과 License 우선순위.
 
-## 8. 통합 검수
+## 9. 통합 검수
 
 상태: `BLOCKED_BY_MOBILE_FOUNDATION_DERIVATIVE_SCREENS_AND_AUDIO`.
 
 확인:
 
 - Glyph·대상·위험 판독성.
-- Art Bible·Asset Spec과 Mobile 화면 소비자 일치.
-- 45~50/53/60분 시간 계약.
+- Art Bible·Asset Spec과 Landscape Mobile 화면 소비자 일치.
+- 45~50/53/60분 시간 계약과 Resume Anchor.
 - Touch·Stylus 입력과 UI 일치.
 - 작은 화면·Safe Area·중단/복귀·성능·접근성.
 - 단일 강적이 HP 스펀지로 변질되지 않음.
 - 수호 소환수가 주문 설계보다 복잡하지 않음.
 - Grimoire가 자동 주문 Stock으로 변질되지 않음.
 
-## 9. Codex Plan 진입
+## 10. Codex Plan 진입
 
 상태: `BLOCKED`.
 
@@ -240,22 +258,23 @@ Gate 1 콘셉트·Vertical Slice — 완료
 2. `BOSS-PHASE-01`, `GRIMOIRE-SCREEN-01`, `AUDIO-DIRECTION-01`의 Mobile 영향 검수.
 3. 기획·아트·UX 통합 검수 통과.
 4. Base v9.4 Adapter·Snapshot·CI 정합화.
-5. Godot 버전·Renderer·Mobile OS·방향·최소 기기 범위 재확인.
+5. Godot 버전·Renderer·Mobile OS·Landscape Aspect·최소 기기 범위 재확인.
 6. 사용자의 Codex Plan 승인.
 
 그 뒤에만 Codex read-only Plan을 작성한다.
 
-## 10. PLAYTEST_TUNING_REQUIRED
+## 11. PLAYTEST_TUNING_REQUIRED
 
 - 공격 간격·피해·HP·마나.
 - 불안정도 변화량.
 - 수호 완화율·사용 횟수.
 - 환경 결과 임계값.
 - 작성 감속 최종값·복귀 유예.
-- Touch target·Canvas 크기·Gesture·인식 허용치·보정·Latency.
+- Landscape Touch target·Canvas 크기·Gesture·인식 허용치·보정·Latency.
+- 지원 Aspect Ratio·Text scale·Safe Area 세부값.
 - Memory·Texture·load·frame pacing·battery·thermal.
 
-## 11. 검증 경계
+## 12. 검증 경계
 
 ```text
 GODOT_PROJECT = NOT_STARTED

--- a/docs/UX_UI_SYSTEM.md
+++ b/docs/UX_UI_SYSTEM.md
@@ -3,6 +3,7 @@
 > Base 공용 기준: `alsdmlals4-eng/Base`의 `auditing-and-refining-ui-art`  
 > Base content commit: `a728712cb776ec98f4875914a580fcf7d0156593`
 > 프로젝트 상태: `DESIGN_CONTRACT_ADOPTED`  
+> Mobile 방향: `GM-MOBILE-ORIENTATION-01 / LANDSCAPE_FIXED`  
 > 런타임·실기기·사람 검증: `NOT_RUN`
 
 ## 1. 플레이어 경험 약속
@@ -28,14 +29,16 @@
 - 인식 오류와 마법 문법/설계 오류의 분리
 - 점진적 학습과 재열람
 - 주문 후보·비용·위험·효과 비교
-- 모바일 입력과 긴 한국어 설명
+- Landscape Mobile 입력과 긴 한국어 설명
 - 발동 결과의 인과·복기
+- 중단·복귀·Resume Anchor의 UI 상태
 
 ### 제외
 
 - 실제 인식 알고리즘·주문 문법·마나·피해 수치 변경
 - 저장·전투·진행 규칙 재계산
 - 제품 Scene·script·data·asset 수정
+- Portrait Gameplay·자동 회전 지원
 - HTML 기획 대시보드
 
 UI는 입력 stroke와 권위 있는 인식/주문 판정 결과를 표시하며, 규칙을 자체 판정하지 않는다.
@@ -49,6 +52,7 @@ UI는 입력 stroke와 권위 있는 인식/주문 판정 결과를 표시하며
 | 주문 조립 | 조합이 문법적으로 유효한가 | 유효/충돌/누락 위치 | 문제 글자 강조·수정 |
 | 실행 전 | 비용과 위험을 감수할 가치가 있는가 | 예상 효과·불확실성 | 취소·구성 변경 |
 | 결과/복기 | 왜 이 결과가 발생했는가 | 인식→문법→비용→효과 순서 | 다시 설계·도감/규칙 재열람 |
+| 이어하기 | 어디까지 안전하게 확정됐는가 | 마지막 Anchor·현재 Draft·폐기 이유 | Anchor 재개·Draft 복구/재작성 |
 
 ## 4. 공용 패턴 적용
 
@@ -62,7 +66,7 @@ UI는 입력 stroke와 권위 있는 인식/주문 판정 결과를 표시하며
 | `UXP-SAFE-REVERSAL` | ADOPT | stroke·글자·조립 단계별 실행 취소와 초기화 구분 |
 | `UXP-ERROR-RECOVERY` | ADOPT | 인식 실패, 문법 오류, 비용 부족, 대상 부적합을 서로 다른 원인으로 표시 |
 | `UXP-MULTI-CHANNEL-CUES` | ADOPT | 색 외에 글자 위치·형태·문구·아이콘·로그 사용 |
-| `UXP-RETURNING-PLAYER-MEMORY` | ADAPT | 최근 주문과 현재 학습 단계, 해금 규칙 요약 |
+| `UXP-RETURNING-PLAYER-MEMORY` | ADAPT | 최근 주문·현재 학습 단계·마지막 Resume Anchor 요약 |
 | `UXP-CAUSAL-RECAP` | ADOPT | 입력→인식→문법→비용→효과의 인과 로그 |
 | `UXP-EMPTY-LOCKED-FALLBACK` | ADOPT | 미해금 글자·빈 슬롯·누락 자산에서 조건과 다음 행동 표시 |
 
@@ -75,6 +79,8 @@ UI는 입력 stroke와 권위 있는 인식/주문 판정 결과를 표시하며
 | 문법 오류 | 글자 관계가 규칙에 맞지 않음 | 충돌 위치·필요 조건·수정 방향 | 인식기를 다시 실행 |
 | 비용 부족 | 유효하지만 실행 자원 부족 | 부족량·확보 경로 | 주문 자체를 잘못됐다고 표시 |
 | 효과 실패/저항 | 실행됐지만 결과가 제한됨 | 대상 상태·저항·소비 자원 | 입력 실패로 되돌림 |
+| 중단된 획 | App 중단·system gesture로 stroke가 완결되지 않음 | 보존/폐기 상태와 다시 쓰기 | 임의로 글자 확정 |
+| 오래된 요청 | 복귀 뒤 이전 recognition 결과가 도착 | 요청 무효화와 현재 Draft 상태 | 중복 Candidate·Commit 생성 |
 
 ## 6. 모바일 입력·접근성
 
@@ -82,9 +88,49 @@ UI는 입력 stroke와 권위 있는 인식/주문 판정 결과를 표시하며
 - stroke 입력 중 화면 이동·버튼 오입력을 방지한다.
 - undo는 마지막 stroke, 글자 삭제, 전체 초기화를 서로 다르게 표시한다.
 - 인식 후보는 색만이 아니라 이름·형태·순위·확신 문구로 구분한다.
-- 시간 제한이 있다면 일시정지·연장·대체 입력을 검토한다.
+- 선택형 작성 감속을 제공하고 사용에 보상 불이익을 두지 않는다.
+- App background·OS interruption·blocking tutorial 동안 시간은 정지한다.
 - 음향·진동·모션을 꺼도 인식과 오류 상태가 유지된다.
 - 긴 한국어 설명은 핵심 규칙과 상세 예시를 점진 공개한다.
+- 같은 문제에서 확인한 글자는 Token 재선택을 허용해 반복 필기 피로를 줄인다.
+
+## 6A. GM-MOBILE-ORIENTATION-01
+
+Mobile Vertical Slice의 핵심 화면은 `Landscape 고정`이다.
+
+```text
+Landscape Main
+→ Landscape Field / Dialogue / Schedule
+→ Landscape Writing Overlay
+→ Landscape Battle
+→ Landscape Result
+→ Landscape Field Return
+→ Landscape Grimoire
+```
+
+적용 규칙:
+
+- Portrait Gameplay와 자동 회전은 Vertical Slice 범위에서 제외한다.
+- Portrait 상태 진입 시 Landscape 전환 안내를 제공한다.
+- 회전·창 크기 변경은 시전·보상·저장 Event의 권위 시점이 아니다.
+- 기존 16:9 화면은 Landscape 파생 기준이지만 Mobile 실기기 적합성 통과 증거가 아니다.
+- 필수 목표·적 위험·자원·Timer·확정 버튼은 Safe Area 안에서 동시에 판독돼야 한다.
+- 우측 Writing Panel은 적과 경고를 가리지 않아야 하며, 축소 Rail과 확장 Canvas의 상태 차이를 명시한다.
+- 지원 Aspect Ratio·logical Canvas·Text scale·Touch target·letterbox/crop은 `TEST_VALUE`로 작성 후 기기 검증한다.
+- Portrait Grimoire나 혼합 방향은 후속 별도 Decision 없이는 추가하지 않는다.
+
+## 6B. Resume·Save UI 계약
+
+```text
+Draft → Recognizing → Candidate → Committed → Resolved → Recorded
+```
+
+- 마지막 완료 Resume Anchor와 현재 임시 상태를 구분해 표시한다.
+- `Committed` 이후 시전·마나 소모는 한 번만 발생한다.
+- `Resolved` 이후 보상·Result는 한 번만 발생한다.
+- `Recorded` 이후 마도서 기록은 한 번만 저장한다.
+- 중단된 stroke와 오래된 recognition은 안전하게 폐기하고 이유를 표시한다.
+- 복구 불가능한 Draft는 마지막 Anchor로 되돌리되 이미 확정된 결과를 되감지 않는다.
 
 ## 7. Godot 구현 경계
 
@@ -105,6 +151,7 @@ UI는 입력 stroke와 권위 있는 인식/주문 판정 결과를 표시하며
 - UI가 인식 점수나 주문 문법을 별도로 계산
 - 애니메이션 종료 시점에 마나·피해를 지급
 - 인식 실패와 주문 설계 실패를 같은 오류 상태로 합침
+- 화면 회전 이벤트로 시전·보상·저장 확정
 - 프로젝트의 기존 입력·Theme 구조 조사 없이 범용 필기 프레임워크 추가
 
 ## 7A. UI 모션·중단·반복 계약
@@ -117,18 +164,20 @@ UI는 입력 stroke와 권위 있는 인식/주문 판정 결과를 표시하며
 - 빠른 반복·재진입에서 stroke·후보·비용·불안정도·결과·기록이 중복되지 않아야 한다.
 - `AnimationPlayer`·`Tween` 완료 signal은 인식·문법·비용·전투·저장·기록 결과의 권위 시점이 아니다.
 - `Reduced Motion`, `mute`, `haptic-off`에서도 인식 상태·오류 종류·비용·위험·결과 원인·다음 행동을 보존한다.
-- 실제 입력·인식·PC/Mobile 성능·사람 이해는 `NOT_RUN` / `HUMAN_NOT_RUN`으로 유지한다.
+- 실제 입력·인식·Mobile 성능·사람 이해는 `NOT_RUN` / `HUMAN_NOT_RUN`으로 유지한다.
 
 ## 8. 검증 매트릭스
 
 | 증거 | 상태 | 통과 기준 |
 |---|---|---|
-| 문서·책임 경계 | PASS | 인식·문법·실행 오류 분리 |
+| 문서·책임 경계 | PASS | 인식·문법·실행·중단 오류 분리 |
+| 방향 Decision | USER_APPROVED | Landscape 고정과 Portrait 제외가 명시됨 |
 | 제품 diff | PASS | 코드·Scene·data·asset 변경 없음 |
-| Godot runtime | NOT_RUN | 실제 작성·후보·발동 흐름 실행 필요 |
-| 모바일 실기기 | NOT_RUN | 손가락 가림·오입력·지연 확인 필요 |
-| 사람 이해 | HUMAN_NOT_RUN | 오류 종류와 수정 행동을 도움 없이 설명 |
-| 접근성 사용자 | HUMAN_NOT_RUN | 실제 대체 입력·시각·청각 폴백 검증 필요 |
+| Godot runtime | NOT_RUN | 실제 작성·후보·발동·Resume 흐름 실행 필요 |
+| 모바일 실기기 | NOT_RUN | Safe Area·손가락 가림·오입력·지연 확인 필요 |
+| Aspect·Text·Touch | NOT_RUN | 최소 기기군에서 목표·위험·작성 동시 판독 |
+| 사람 이해 | HUMAN_NOT_RUN | 오류 종류와 수정·재개 행동을 도움 없이 설명 |
+| 접근성 사용자 | HUMAN_NOT_RUN | 감속·대체 입력·시각·청각 폴백 검증 필요 |
 
 ## 9. 공용 승격과 프로젝트 전용
 
@@ -137,16 +186,19 @@ UI는 입력 stroke와 권위 있는 인식/주문 판정 결과를 표시하며
 - 입력 인식과 도메인 유효성의 분리
 - 점진 공개·오류 복구·결과 인과·다중 채널
 - UI가 권위 규칙을 소유하지 않는 계약
+- 중단·재개에서 Commit·Reward·Save 중복 금지
 
 ### GRIMOIRE 전용
 
 - 마법 글자 형태·stroke·문법·주문 조합
+- Landscape Writing/Battle 정보 위계
 - 실제 인식 알고리즘·신뢰도·마나·효과 수치
 - 모바일 필기 영역과 학습 단계
 
 ## 10. 다음 게이트
 
-1. 실제 입력·인식·주문 판정 소유자를 읽어 View Data와 Signal 계약 확정.
-2. 정상·애매한 입력·오인식·문법 오류·비용 부족 fixture 작성.
-3. 첫 글자→첫 유효 주문→첫 실패 복기의 Vertical Slice 검증.
-4. 실제 플레이 전 점진 공개 단계와 수치는 `TEST` 유지.
+1. Landscape 지원 Aspect·Safe Area·Touch 정보 위계 후보 작성.
+2. Resume Anchor·Draft 저장 소유권 명세.
+3. 정상·애매한 입력·오인식·문법 오류·비용 부족·중단 fixture 작성.
+4. 첫 글자→첫 유효 주문→첫 실패 복기의 Vertical Slice 검증.
+5. 실제 플레이 전 점진 공개·Touch target·Canvas·감속 수치는 `TEST_VALUE` 유지.

--- a/docs/planning/CURRENT_CONFIRMED_DECISIONS.md
+++ b/docs/planning/CURRENT_CONFIRMED_DECISIONS.md
@@ -12,6 +12,8 @@ work_mode: PLAN
 primary_platform: Mobile
 follow_up_platform: PC
 platform_decision: GM-PLATFORM-02
+mobile_orientation_decision: GM-MOBILE-ORIENTATION-01
+mobile_orientation: LANDSCAPE_FIXED
 planning: APPROVED
 art_style_01: APPROVED_A_MODIFIED_LOCKED
 art_bible_01: APPROVED_DUAL_STANDARD_ART_BIBLE
@@ -35,6 +37,8 @@ main_sync: SYNCED_TO_MAIN
 ```
 
 최신 플랫폼 승인: `docs/planning/PLATFORM_MOBILE_FIRST_02_2026-08-02.md`.
+최신 화면 방향 승인: `docs/planning/MOBILE_ORIENTATION_01_APPROVAL_2026-08-02.md`.
+현재 총기획 감사: `docs/planning/TOTAL_PLANNING_ADVERSARIAL_AUDIT_2026-08-02.md`.
 현재 적대적 감사: `docs/planning/PROJECT_ADVERSARIAL_AUDIT_2026-08-02.md`.
 Main Sync 영수증: `docs/planning/sync/GR-SYNC-20260802-07-MAIN.md`.
 
@@ -95,8 +99,25 @@ next_reconciliation_gate: MOBILE-FOUNDATION-01
 - 기존 `GM-PLATFORM-01 / PC 우선·Mobile 후속`은 역사로 보존하고 활성 방향에서는 대체한다.
 - Mobile에서는 Touch·Stylus 직접 작성과 화면 내 명시적 Undo·부분 삭제·전체 초기화·취소·후보 확정·`[구현]`을 기본 입력 후보로 검증한다.
 - Mouse/Pen/Keyboard는 후속 PC 적응 계약이다.
-- Android/iOS, Store, Landscape/Portrait, 최소 기기, 성능·메모리·배터리 수치, 인식 처리 방식은 미확정이다.
+- Mobile Vertical Slice 화면 방향은 `GM-MOBILE-ORIENTATION-01 / Landscape 고정`이다. Android/iOS, Store, 최소 기기, 성능·메모리·배터리 수치, 인식 처리 방식은 미확정이다.
 - 기존 16:9·1280×720·1920×1080·Ultrawide 자료는 승인 Asset/PC 참고 규격이며 Mobile 적합성을 자동 증명하지 않는다.
+
+## 5A. GM-MOBILE-ORIENTATION-01
+
+```yaml
+status: USER_APPROVED_ACTIVE
+orientation: LANDSCAPE_FIXED
+portrait_gameplay: NOT_SUPPORTED_IN_VERTICAL_SLICE
+runtime_rotation: DISABLED_IN_VERTICAL_SLICE
+authority: docs/planning/MOBILE_ORIENTATION_01_APPROVAL_2026-08-02.md
+```
+
+- Main·Field·Dialogue·Schedule·Writing·Battle·Result·Grimoire·Settings는 Landscape 고정.
+- 기존 16:9 자료는 Landscape 파생 기준으로 보존하지만 Mobile 실기기 적합성 증거로 자동 승격하지 않음.
+- Portrait Gameplay·화면별 혼합 방향·자동 회전은 Vertical Slice 범위에서 제외.
+- Landscape 고정의 진입 마찰은 Resume Anchor·자동 저장·이어하기로 보완.
+- 지원 Aspect Ratio·Safe Area·Touch target·Canvas·Text scale은 `MOBILE-FOUNDATION-01`에서 시험값과 검증 계획으로 작성.
+- Portrait 지원은 별도 Decision과 제작·QA 근거 없이는 추가하지 않음.
 
 ## 6. 마도서·입력 의미
 
@@ -218,6 +239,7 @@ generated_views: CURRENT
 | Art Bible | `APPROVED_DUAL_STANDARD_ART_BIBLE` |
 | Battle Rules | `APPROVED_SITUATION_RESOLUTION_RULES` |
 | Asset Spec | `APPROVED_SPEC` |
+| Mobile Orientation | `APPROVED_LANDSCAPE_FIXED` |
 | Mobile Foundation | `CURRENT_RECONCILIATION_GATE` |
 | Boss Phase | `QUEUED_REVIEW_AFTER_MOBILE_FOUNDATION` |
 | Grimoire/Main 파생 화면 | `QUEUED_REVIEW_AFTER_MOBILE_FOUNDATION` |
@@ -253,9 +275,9 @@ main_sync: SYNCED_TO_MAIN
 ## 14. 다음 작업
 
 ```text
-적대적 총기획 감사
-→ 중요 기획 충돌 Grill Me
-→ 승인 정본·Sheet 즉시 동기화
+GM-MOBILE-ORIENTATION-01 승인·동기화
+→ Resume Anchor·Save Ownership
+→ Landscape Safe Area·Aspect·Touch 정보 위계
 → MOBILE-FOUNDATION-01
 → BOSS-PHASE-01·GRIMOIRE-SCREEN-01 영향 재검토
 → AUDIO-DIRECTION-01
@@ -267,7 +289,7 @@ main_sync: SYNCED_TO_MAIN
 
 ## 15. PLAYTEST_TUNING_REQUIRED / NOT_RUN
 
-- Mobile OS·Store·방향·최소 기기.
+- Mobile OS·Store·지원 Aspect Ratio·최소 기기.
 - Touch target·Canvas 크기·gesture·인식 알고리즘·허용치·Latency.
 - 적 공격 간격·피해량·플레이어 HP·마나.
 - 불안정도 변화량.

--- a/docs/planning/MOBILE_ORIENTATION_01_APPROVAL_2026-08-02.md
+++ b/docs/planning/MOBILE_ORIENTATION_01_APPROVAL_2026-08-02.md
@@ -1,0 +1,137 @@
+# GRIMOIRE Mobile 화면 방향 승인 — GM-MOBILE-ORIENTATION-01
+
+```yaml
+decision_id: GM-MOBILE-ORIENTATION-01
+status: USER_APPROVED_ACTIVE
+approved_at: 2026-08-02 KST
+approval_source: user_approved_recommended_option
+primary_platform: Mobile
+orientation: LANDSCAPE_FIXED
+portrait_gameplay: NOT_SUPPORTED_IN_VERTICAL_SLICE
+runtime_rotation: DISABLED_IN_VERTICAL_SLICE
+follow_up_platform: PC
+current_gate: MOBILE-FOUNDATION-01
+implementation: NOT_STARTED
+runtime_validation: NOT_RUN
+mobile_device_validation: NOT_RUN
+human_playtest: NOT_RUN
+```
+
+## 1. 승인 결정
+
+GRIMOIRE Mobile 버티컬 슬라이스의 모든 핵심 화면은 `Landscape 고정`을 기본 계약으로 사용한다.
+
+적용 화면:
+
+- Main.
+- Field.
+- Half-body Dialogue.
+- 자유일정·선택 화면.
+- Writing Overlay.
+- Battle.
+- Result.
+- Grimoire.
+- Settings·Pause·Resume.
+
+Vertical Slice에서는 화면별 Portrait 전환, 플레이 중 자동 회전, Landscape·Portrait 동시 완전 대응을 지원 범위에 포함하지 않는다.
+
+## 2. 선택 이유
+
+이 결정은 다음 비타협 코어를 가장 적은 재작업으로 보존한다.
+
+1. 직접 작성 Canvas의 유효 면적.
+2. 적 위험·상황 목표·주인공 상태·작성 Panel의 동시 판독.
+3. 승인된 16:9 시각 기준과 Asset의 최대 재사용.
+4. 화면 전환·중단·복귀 상태 계약의 단순화.
+5. Solo 제작·QA·접근성 검증 조합의 제한.
+6. 후속 PC Mouse·Pen·Keyboard 적응과의 구조적 연속성.
+
+한손 Portrait 편의보다 직접 작성과 상황 판단의 품질을 우선한다. Mobile 사용 맥락의 중단 가능성은 화면 방향을 혼합하지 않고 Resume Anchor·자동 저장·안전한 복귀 계약으로 해결한다.
+
+## 3. 화면 계약
+
+```text
+Landscape Main
+→ Landscape Field / Dialogue / Schedule
+→ Landscape Writing Overlay
+→ Landscape Battle
+→ Landscape Result
+→ Landscape Field Return
+→ Landscape Grimoire
+```
+
+- OS가 Portrait 상태에서 게임을 열면 Landscape 전환 안내를 제공한다.
+- 플레이 중 기기 회전은 게임 논리·시전·보상·저장 Event를 발생시키지 않는다.
+- 회전·창 크기 변경·앱 중단 시 진행 중 stroke와 인식 요청은 `MOBILE-FOUNDATION-01` 상태 계약에 따라 보존 또는 폐기한다.
+- 시스템 제스처 영역·Notch·카메라 홀을 포함한 Safe Area 안에 필수 목표·위험·자원·확정 버튼을 둔다.
+- 우측 Writing Panel 방향은 유지하되 작은 화면에서 적과 경고를 가리는지는 별도 레이아웃 검증을 통과해야 한다.
+
+## 4. 기존 16:9 자료의 지위
+
+기존 16:9·1280×720·1920×1080·Ultrawide 자료는 다음과 같이 취급한다.
+
+- 승인된 시각·구성 참고 기준으로 보존.
+- Landscape-first 파생의 출발점으로 사용.
+- Mobile 실기기 품질·Safe Area·Touch 판독·성능 통과 증거로 자동 승격하지 않음.
+- Mobile 지원 비율, logical Canvas, Touch target, Text scale, crop·letterbox 정책은 `MOBILE-FOUNDATION-01`에서 후보와 시험값으로 작성.
+- Ultrawide는 후속 PC 적응 범위이며 Mobile Vertical Slice 통과 조건이 아님.
+
+## 5. Portrait와 회전 지원 경계
+
+Vertical Slice 제외:
+
+- Portrait 전용 전투·Writing 레이아웃.
+- 화면별 Landscape↔Portrait 전환.
+- 자동 회전 중 실시간 레이아웃 재배치.
+- Landscape·Portrait 양쪽의 동일 기능·동일 품질 보장.
+
+후속 검토 조건:
+
+- 실기기 플레이에서 Landscape 고정이 주요 이탈 원인으로 확인됨.
+- Grimoire 열람처럼 독립적인 비전투 소비자가 Portrait에서 명백한 이득을 보임.
+- 추가 제작·QA 비용을 감당할 제품 단계와 기기 자료가 확보됨.
+
+Portrait 지원을 추가할 경우 별도 Decision으로 승인하며 이번 결정을 조용히 확장하지 않는다.
+
+## 6. Mobile Foundation에 남는 검증
+
+방향 승인으로 다음 항목이 자동 확정되지는 않는다.
+
+- Android/iOS·Store 우선순위.
+- 지원 Aspect Ratio와 최소 화면 크기.
+- Safe Area inset·Notch·system gesture 처리 수치.
+- Writing Canvas 크기와 Touch target.
+- Text scale·UI scale·접근성 대체 입력.
+- Frame rate·Memory·Texture·Load·Battery·Thermal 목표.
+- 인식 알고리즘·Latency·허용치.
+
+위 항목은 `RECOMMENDED_DEFAULT / TEST_VALUE / USER_DECISION_REQUIRED`를 구분해 작성한다.
+
+## 7. 적대적 검토 결과
+
+기각한 대안:
+
+- `게임플레이 가로 + 메뉴·Grimoire 세로`: 방향 전환·Resume·Focus·Safe Area·QA 조합을 늘려 Vertical Slice 범위를 불필요하게 확대한다.
+- `모든 화면 양방향 대응`: 직접 작성·전투 정보 위계를 두 번 설계하게 되어 Solo 제작 조건과 충돌한다.
+- `전체 Portrait`: 작성 Canvas와 적 위험·상태의 동시 판독을 약화시켜 프로젝트 코어를 훼손할 가능성이 높다.
+
+남은 위험:
+
+- Landscape 고정의 진입 마찰.
+- 작은 휴대폰에서 양손 사용 피로.
+- 우측 Writing Panel의 손가락 가림.
+- 긴 한국어 Text와 Timer·상태 정보의 과밀.
+
+이 위험은 실기기·접근성·사람 검증 전까지 `NOT_RUN`으로 유지한다.
+
+## 8. 후속 작업
+
+```text
+GM-MOBILE-ORIENTATION-01
+→ Mobile Resume Anchor·Save Ownership 명세
+→ Landscape Safe Area·Aspect·Touch 정보 위계
+→ Writing/Battle 작은 화면 레이아웃 후보
+→ Grimoire/Main Landscape 파생
+→ Device·Performance·Accessibility 검증 계획
+→ MOBILE-FOUNDATION-01 사용자 승인
+```

--- a/docs/planning/TOTAL_PLANNING_ADVERSARIAL_AUDIT_2026-08-02.md
+++ b/docs/planning/TOTAL_PLANNING_ADVERSARIAL_AUDIT_2026-08-02.md
@@ -1,0 +1,127 @@
+# GRIMOIRE 적대적 총기획 감사 — 2026-08-02
+
+```yaml
+audit_id: GR-TOTAL-PLANNING-AUDIT-20260802-01
+status: AUDIT_IN_PROGRESS_GRILL_ME_REQUIRED
+mode: TOTAL_PLANNING
+baseline_main: 92c77e7fdeafb92a15efc868f962a0a12f78861e
+primary_platform: Mobile
+follow_up_platform: PC
+current_gate: MOBILE-FOUNDATION-01
+product_implementation: NOT_STARTED
+runtime_validation: NOT_RUN
+mobile_device_validation: NOT_RUN
+human_playtest: NOT_RUN
+```
+
+## 1. 감사 목적
+
+승인된 프로젝트 코어·Vertical Slice·전투·아트·Asset Spec을 보호하면서 Mobile-first 전환 이후 생긴 기획 충돌, 빠진 상태 계약, 제작·접근성 위험을 찾는다.
+
+분류:
+
+- `AUTO_FIX_ELIGIBLE`: 사용자 방향을 바꾸지 않는 누락·명확화.
+- `USER_DECISION_REQUIRED`: 화면·경험·범위를 다르게 만드는 핵심 선택.
+- `RESEARCH_OR_TEST_REQUIRED`: 수치·피로·성능·재미처럼 실행 증거가 필요한 항목.
+
+## 2. 보호할 강점
+
+- 플레이어 약속: 글자의 의미를 배우고 직접 설계한 주문으로 세계를 바꾸는 마법학교 RPG.
+- `흐름 / 집중 / 분산`과 복수 해법·설명 가능한 결과.
+- 수업→시험→축제→현장→귀환의 성장·응용 구조.
+- 적 HP 처치보다 불안정도 0 진정·상황 해결을 우선하는 전투.
+- 입력 실패·문법 실패·상황 설계 실패·비용 부족의 분리.
+- Soft Storybook 배경·Anime Cel 캐릭터·Navy/Gold UI·Blue Glyph.
+- 목표 45~50분, 콘텐츠 상한 53분, 하드 상한 60분.
+- 제품 구현 `NOT_STARTED`; 미실행 검증을 완료로 올리지 않는 경계.
+
+## 3. Finding Ledger
+
+| ID | 유형 | 확인된 문제 | 분류 | 심각도 | 권장 처리 | 상태 |
+|---|---|---|---|---|---|---|
+| GR-TPA-01 | PLANNING_CONFLICT | Mobile 방향은 미확정인데 Sheet `GR-UX-01`은 `가로형 3/4 필드`, 승인 화면·Asset은 16:9를 활성 전제로 사용 | USER_DECISION_REQUIRED | P0 | Mobile Demo 지원 방향을 먼저 확정하고 모든 화면 소비자를 재검증 | GRILL_ME_REQUIRED |
+| GR-TPA-02 | UNDERDESIGN | 46분 전체 흐름은 확정됐지만 Mobile 중단·재개를 위한 세션 구획·자동 저장 지점·이어하기 계약이 없음 | AUTO_FIX_ELIGIBLE | P1 | 전체 콘텐츠·시간은 유지하고 주요 콘텐츠 경계마다 Resume Anchor와 원자적 자동 저장 추가 | RECOMMENDED_DEFAULT |
+| GR-TPA-03 | DATA_COMPATIBILITY_RISK | 작성 Draft·후보·시전·보상·마도서 기록의 중단 시 소유권은 원칙만 있고 저장 단위·폐기 기준이 없음 | AUTO_FIX_ELIGIBLE | P1 | `Draft / Recognizing / Candidate / Committed / Resolved / Recorded` 상태와 재개·폐기 규칙 작성 | RECOMMENDED_DEFAULT |
+| GR-TPA-04 | ACCESSIBILITY_RISK | Active Timer와 직접 필기가 결합되어 손가락 가림·운동 능력·인지 부하가 전투 난이도로 잘못 전이될 수 있음 | RESEARCH_OR_TEST_REQUIRED | P1 | 승인된 시간 흐름은 유지하되 선택형 감속·배경 중단 정지·무패널티 접근성 옵션을 시험값으로 검증 | TEST_REQUIRED |
+| GR-TPA-05 | PLAYER_EXPERIENCE_RISK | 필수 성공 작성 7회·복구 포함 10회가 Mobile에서 손 피로와 반복감으로 변할 가능성 | RESEARCH_OR_TEST_REQUIRED | P1 | 신규·중요 글자만 직접 작성하고 같은 문제의 확인 Token 재선택을 적극 사용; 실제 피로 측정 | TEST_REQUIRED |
+| GR-TPA-06 | UNDERDESIGN | 자유일정의 `CALM / PREPARED / CONNECTED` 목적은 있으나 다음 Challenge에 적용되는 정확한 효과·소멸·중복 규칙이 없음 | AUTO_FIX_ELIGIBLE | P2 | 다음 핵심 Challenge 1회에만 적용되는 동등 가치의 보조 효과로 명세; 유일 해법·영구 누적 금지 | RECOMMENDED_DEFAULT |
+| GR-TPA-07 | PRODUCTION_RISK | Grimoire 우선 파생·Main 후속 원칙은 있으나 방향 결정 전 화면 구조를 확정하면 재작업 가능성이 큼 | AUTO_FIX_ELIGIBLE | P1 | GR-TPA-01 확정 전 상세 레이아웃 잠금 금지; 정보 구조·상태 계약만 작성 | BLOCKED_BY_GR_TPA_01 |
+| GR-TPA-08 | UNDERDESIGN | Android/iOS·Store·최소 기기·성능 목표가 미확정 | RESEARCH_OR_TEST_REQUIRED | P2 | 기획 작성은 계속하되 Build·성능 Gate 전 사용자 패킷과 기기 Matrix로 확정 | DEFERRED_WITH_BOUNDARY |
+| GR-TPA-09 | STALE_REFERENCE | 과거 PC 입력 정본이 역사 자료로 남아 있어 신규 기획에서 다시 기본값으로 복사될 위험 | AUTO_FIX_ELIGIBLE | P2 | 활성 입력 표에는 Touch·Stylus만 두고 PC 입력은 후속 호환 부록으로 명시 | SHOULD_FIX |
+
+## 4. 자동 적용할 권장 기본안
+
+다음은 프로젝트 방향을 바꾸지 않으므로 이후 기획 문서에 `RECOMMENDED_DEFAULT` 또는 `TEST_VALUE`로 작성한다.
+
+### 4.1 Mobile 세션·Resume Anchor
+
+전체 46분 목표와 콘텐츠 순서는 유지한다.
+
+```text
+첫 수업·교내 연습
+→ Resume Anchor A
+→ 자유일정 A·실기시험
+→ Resume Anchor B
+→ 자유일정 B·학교축제
+→ Resume Anchor C
+→ 자유일정 C·현장 전투
+→ Resume Anchor D
+→ 현장 환경 해결·귀환·마도서 기록
+```
+
+- 핵심 장면 경계에서 자동 저장.
+- 진행 중 작성 Draft는 별도 임시 상태로 저장하거나 안전하게 폐기하고 이유를 표시.
+- Commit·Reward·Result·Record는 각각 한 번만 확정되는 idempotent 처리 계약.
+- 이어하기는 마지막 완료 Anchor 또는 복구 가능한 현재 단계에서 시작.
+- 전투 중단 시 적 공격과 입력 인식의 선후 관계를 복원 가능한 Event 순서로 기록.
+
+### 4.2 자유일정
+
+- `CALM`: 다음 Challenge에서 입력 복구·감속 보조 접근성을 강화.
+- `PREPARED`: 다음 Challenge의 조건·위험 미리보기 정보를 강화.
+- `CONNECTED`: 다음 Challenge 전후 인물 반응·대안 관점을 강화.
+- 효과는 다음 핵심 Challenge 1회 후 소멸.
+- 유일 해법, 필수 정보, 영구 능력, 장기 최적 루트를 독점하지 않음.
+- 세 선택의 제작량과 효용 규모를 동등하게 유지.
+
+### 4.3 직접 작성·전투 시험값
+
+- 승인된 `판단·작성 중 진행 / 시스템 해결 중 정지`는 유지.
+- 일반 작성 `1.0×`, 선택형 감속 초기 후보 `0.5×`는 `TEST_VALUE`.
+- App background·OS interruption·blocking tutorial에서는 `0×`.
+- 감속 사용에 보상 불이익을 두지 않음.
+- 같은 문제에서 확인한 글자는 Token 재선택 허용.
+- 신규·미숙·중요 결정만 직접 작성 우선.
+
+## 5. 분야 간 충돌 판정
+
+| 대조 | 판정 | 이유 |
+|---|---|---|
+| 플레이어 약속 ↔ Core Loop | NO_CONFLICT | 직접 작성→의미 조합→세계 변화→기록이 일치 |
+| Core Loop ↔ 전투 | NO_CONFLICT_WITH_TEST_RISK | 상황 해결형 전투는 코어와 일치하나 Mobile 필기 피로 검증 필요 |
+| Mobile 우선 ↔ 승인 16:9 화면 | USER_DECISION_REQUIRED | 방향 미확정과 가로형 활성 소비자가 충돌 |
+| 46분 Slice ↔ Mobile 사용 맥락 | SHOULD_FIX | 콘텐츠 축소보다 Resume Anchor로 중단 가능 구조를 보완하는 것이 적합 |
+| 자유일정 ↔ Challenge | NEEDS_IMPROVEMENT | 태그 의도는 있으나 정확한 적용 계약이 없음 |
+| Grimoire/Main ↔ Mobile 방향 | BLOCKED_BY_DECISION | 방향 확정 전에 상세 레이아웃 잠금 시 재작업 |
+| Active Timer ↔ 접근성 | TEST_IN_VERTICAL_SLICE | 승인 방향은 유지하되 감속·중단·피로를 실기기로 검증 |
+| 기획 ↔ 구현 | NO_IMPLEMENTATION_YET | 제품 구현이 없으므로 불일치가 아니라 구현 전 계약 단계 |
+
+## 6. Grill Me 순서
+
+한 번에 하나의 독립 결정만 묻는다.
+
+1. `GM-MOBILE-ORIENTATION-01` — Mobile Demo 화면 방향.
+2. OS·Store 우선순위는 방향과 기획 화면 계약이 닫힌 뒤 별도 질문.
+3. 핵심 경험을 바꾸지 않는 수치·Touch target·Canvas·감속·저장 지점은 권장 시험값으로 작성하고 플레이테스트로 조정.
+
+## 7. 현재 판정
+
+```text
+AUTO_FIX_ELIGIBLE = GR-TPA-02 / 03 / 06 / 07 / 09
+USER_DECISION_REQUIRED = GR-TPA-01
+RESEARCH_OR_TEST_REQUIRED = GR-TPA-04 / 05 / 08
+CODEX = BLOCKED
+PRODUCT_IMPLEMENTATION = NOT_STARTED
+```
+
+첫 Grill Me 결정 전에는 Mobile 화면 상세 레이아웃을 확정하지 않는다. 승인 답변을 받으면 같은 Decision ID로 현재 결정·Mobile Foundation·UX·Sheet에 즉시 동기화한다.

--- a/docs/planning/TOTAL_PLANNING_ADVERSARIAL_AUDIT_2026-08-02.md
+++ b/docs/planning/TOTAL_PLANNING_ADVERSARIAL_AUDIT_2026-08-02.md
@@ -2,11 +2,13 @@
 
 ```yaml
 audit_id: GR-TOTAL-PLANNING-AUDIT-20260802-01
-status: AUDIT_IN_PROGRESS_GRILL_ME_REQUIRED
+status: AUDIT_IN_PROGRESS_FIRST_GRILL_ME_RESOLVED
 mode: TOTAL_PLANNING
 baseline_main: 92c77e7fdeafb92a15efc868f962a0a12f78861e
 primary_platform: Mobile
 follow_up_platform: PC
+mobile_orientation_decision: GM-MOBILE-ORIENTATION-01
+mobile_orientation: LANDSCAPE_FIXED
 current_gate: MOBILE-FOUNDATION-01
 product_implementation: NOT_STARTED
 runtime_validation: NOT_RUN
@@ -37,23 +39,36 @@ human_playtest: NOT_RUN
 
 ## 3. Finding Ledger
 
-| ID | 유형 | 확인된 문제 | 분류 | 심각도 | 권장 처리 | 상태 |
+| ID | 유형 | 확인된 문제 | 분류 | 심각도 | 처리 | 상태 |
 |---|---|---|---|---|---|---|
-| GR-TPA-01 | PLANNING_CONFLICT | Mobile 방향은 미확정인데 Sheet `GR-UX-01`은 `가로형 3/4 필드`, 승인 화면·Asset은 16:9를 활성 전제로 사용 | USER_DECISION_REQUIRED | P0 | Mobile Demo 지원 방향을 먼저 확정하고 모든 화면 소비자를 재검증 | GRILL_ME_REQUIRED |
-| GR-TPA-02 | UNDERDESIGN | 46분 전체 흐름은 확정됐지만 Mobile 중단·재개를 위한 세션 구획·자동 저장 지점·이어하기 계약이 없음 | AUTO_FIX_ELIGIBLE | P1 | 전체 콘텐츠·시간은 유지하고 주요 콘텐츠 경계마다 Resume Anchor와 원자적 자동 저장 추가 | RECOMMENDED_DEFAULT |
-| GR-TPA-03 | DATA_COMPATIBILITY_RISK | 작성 Draft·후보·시전·보상·마도서 기록의 중단 시 소유권은 원칙만 있고 저장 단위·폐기 기준이 없음 | AUTO_FIX_ELIGIBLE | P1 | `Draft / Recognizing / Candidate / Committed / Resolved / Recorded` 상태와 재개·폐기 규칙 작성 | RECOMMENDED_DEFAULT |
-| GR-TPA-04 | ACCESSIBILITY_RISK | Active Timer와 직접 필기가 결합되어 손가락 가림·운동 능력·인지 부하가 전투 난이도로 잘못 전이될 수 있음 | RESEARCH_OR_TEST_REQUIRED | P1 | 승인된 시간 흐름은 유지하되 선택형 감속·배경 중단 정지·무패널티 접근성 옵션을 시험값으로 검증 | TEST_REQUIRED |
-| GR-TPA-05 | PLAYER_EXPERIENCE_RISK | 필수 성공 작성 7회·복구 포함 10회가 Mobile에서 손 피로와 반복감으로 변할 가능성 | RESEARCH_OR_TEST_REQUIRED | P1 | 신규·중요 글자만 직접 작성하고 같은 문제의 확인 Token 재선택을 적극 사용; 실제 피로 측정 | TEST_REQUIRED |
-| GR-TPA-06 | UNDERDESIGN | 자유일정의 `CALM / PREPARED / CONNECTED` 목적은 있으나 다음 Challenge에 적용되는 정확한 효과·소멸·중복 규칙이 없음 | AUTO_FIX_ELIGIBLE | P2 | 다음 핵심 Challenge 1회에만 적용되는 동등 가치의 보조 효과로 명세; 유일 해법·영구 누적 금지 | RECOMMENDED_DEFAULT |
-| GR-TPA-07 | PRODUCTION_RISK | Grimoire 우선 파생·Main 후속 원칙은 있으나 방향 결정 전 화면 구조를 확정하면 재작업 가능성이 큼 | AUTO_FIX_ELIGIBLE | P1 | GR-TPA-01 확정 전 상세 레이아웃 잠금 금지; 정보 구조·상태 계약만 작성 | BLOCKED_BY_GR_TPA_01 |
-| GR-TPA-08 | UNDERDESIGN | Android/iOS·Store·최소 기기·성능 목표가 미확정 | RESEARCH_OR_TEST_REQUIRED | P2 | 기획 작성은 계속하되 Build·성능 Gate 전 사용자 패킷과 기기 Matrix로 확정 | DEFERRED_WITH_BOUNDARY |
-| GR-TPA-09 | STALE_REFERENCE | 과거 PC 입력 정본이 역사 자료로 남아 있어 신규 기획에서 다시 기본값으로 복사될 위험 | AUTO_FIX_ELIGIBLE | P2 | 활성 입력 표에는 Touch·Stylus만 두고 PC 입력은 후속 호환 부록으로 명시 | SHOULD_FIX |
+| GR-TPA-01 | PLANNING_CONFLICT | Mobile 방향 미확정과 `가로형 3/4·16:9` 활성 소비자 충돌 | USER_DECISION_REQUIRED | P0 | `GM-MOBILE-ORIENTATION-01 / LANDSCAPE_FIXED` 승인 | RESOLVED_BY_USER_APPROVAL |
+| GR-TPA-02 | UNDERDESIGN | 46분 흐름에 Mobile 중단·재개용 세션 구획·자동 저장 지점·이어하기 계약 없음 | AUTO_FIX_ELIGIBLE | P1 | 주요 콘텐츠 경계 Resume Anchor와 원자적 자동 저장 | RECOMMENDED_DEFAULT |
+| GR-TPA-03 | DATA_COMPATIBILITY_RISK | Draft·후보·시전·보상·마도서 기록의 중단 시 저장 단위·폐기 기준 부족 | AUTO_FIX_ELIGIBLE | P1 | `Draft / Recognizing / Candidate / Committed / Resolved / Recorded` 상태 계약 | RECOMMENDED_DEFAULT |
+| GR-TPA-04 | ACCESSIBILITY_RISK | Active Timer와 직접 필기가 운동·인지 부하를 전투 난이도로 전이할 위험 | RESEARCH_OR_TEST_REQUIRED | P1 | 선택형 감속·중단 정지·무패널티 접근성 옵션 검증 | TEST_REQUIRED |
+| GR-TPA-05 | PLAYER_EXPERIENCE_RISK | 성공 7회·복구 포함 10회가 Mobile 손 피로와 반복감으로 변할 가능성 | RESEARCH_OR_TEST_REQUIRED | P1 | 확인 Token 재선택과 실제 피로 측정 | TEST_REQUIRED |
+| GR-TPA-06 | UNDERDESIGN | `CALM / PREPARED / CONNECTED`의 적용·소멸·중복 규칙 없음 | AUTO_FIX_ELIGIBLE | P2 | 다음 Challenge 1회 한정 동등 가치 효과 | RECOMMENDED_DEFAULT |
+| GR-TPA-07 | PRODUCTION_RISK | 방향 결정 전 Grimoire/Main 상세 레이아웃 잠금 시 재작업 가능성 | AUTO_FIX_ELIGIBLE | P1 | Landscape 기준 파생 재개, 세부 비율은 Mobile Foundation에서 검증 | UNBLOCKED_WITH_BOUNDARY |
+| GR-TPA-08 | UNDERDESIGN | Android/iOS·Store·최소 기기·성능 목표 미확정 | RESEARCH_OR_TEST_REQUIRED | P2 | Build·성능 Gate 전 사용자 패킷과 기기 Matrix | DEFERRED_WITH_BOUNDARY |
+| GR-TPA-09 | STALE_REFERENCE | 과거 PC 입력 정본이 신규 기획에서 기본값으로 복사될 위험 | AUTO_FIX_ELIGIBLE | P2 | 활성 입력은 Touch·Stylus, PC는 후속 호환 부록 | SHOULD_FIX |
 
-## 4. 자동 적용할 권장 기본안
+## 4. 승인된 첫 Grill Me
+
+### GM-MOBILE-ORIENTATION-01
+
+- Mobile Vertical Slice 핵심 화면: `Landscape 고정`.
+- Portrait Gameplay: Vertical Slice 제외.
+- Runtime 자동 회전: Vertical Slice 제외.
+- Main·Field·Dialogue·Schedule·Writing·Battle·Result·Grimoire·Settings를 같은 방향으로 통일.
+- 기존 16:9 자료는 Landscape 파생의 기준으로 보존하지만 Mobile 품질 통과 증거로 자동 승격하지 않음.
+- 지원 Aspect Ratio·Safe Area·Touch target·Canvas·Text scale은 `MOBILE-FOUNDATION-01`에서 시험값과 검증 계획으로 작성.
+
+책임 원본: `docs/planning/MOBILE_ORIENTATION_01_APPROVAL_2026-08-02.md`.
+
+## 5. 자동 적용할 권장 기본안
 
 다음은 프로젝트 방향을 바꾸지 않으므로 이후 기획 문서에 `RECOMMENDED_DEFAULT` 또는 `TEST_VALUE`로 작성한다.
 
-### 4.1 Mobile 세션·Resume Anchor
+### 5.1 Mobile 세션·Resume Anchor
 
 전체 46분 목표와 콘텐츠 순서는 유지한다.
 
@@ -70,12 +85,12 @@ human_playtest: NOT_RUN
 ```
 
 - 핵심 장면 경계에서 자동 저장.
-- 진행 중 작성 Draft는 별도 임시 상태로 저장하거나 안전하게 폐기하고 이유를 표시.
+- 진행 중 작성 Draft는 복구 가능한 임시 상태로 저장하거나 안전하게 폐기하고 이유를 표시.
 - Commit·Reward·Result·Record는 각각 한 번만 확정되는 idempotent 처리 계약.
 - 이어하기는 마지막 완료 Anchor 또는 복구 가능한 현재 단계에서 시작.
 - 전투 중단 시 적 공격과 입력 인식의 선후 관계를 복원 가능한 Event 순서로 기록.
 
-### 4.2 자유일정
+### 5.2 자유일정
 
 - `CALM`: 다음 Challenge에서 입력 복구·감속 보조 접근성을 강화.
 - `PREPARED`: 다음 Challenge의 조건·위험 미리보기 정보를 강화.
@@ -84,44 +99,44 @@ human_playtest: NOT_RUN
 - 유일 해법, 필수 정보, 영구 능력, 장기 최적 루트를 독점하지 않음.
 - 세 선택의 제작량과 효용 규모를 동등하게 유지.
 
-### 4.3 직접 작성·전투 시험값
+### 5.3 직접 작성·전투 시험값
 
-- 승인된 `판단·작성 중 진행 / 시스템 해결 중 정지`는 유지.
+- 승인된 `판단·작성 중 진행 / 시스템 해결 중 정지` 유지.
 - 일반 작성 `1.0×`, 선택형 감속 초기 후보 `0.5×`는 `TEST_VALUE`.
 - App background·OS interruption·blocking tutorial에서는 `0×`.
 - 감속 사용에 보상 불이익을 두지 않음.
 - 같은 문제에서 확인한 글자는 Token 재선택 허용.
 - 신규·미숙·중요 결정만 직접 작성 우선.
 
-## 5. 분야 간 충돌 판정
+## 6. 분야 간 충돌 판정
 
 | 대조 | 판정 | 이유 |
 |---|---|---|
 | 플레이어 약속 ↔ Core Loop | NO_CONFLICT | 직접 작성→의미 조합→세계 변화→기록이 일치 |
 | Core Loop ↔ 전투 | NO_CONFLICT_WITH_TEST_RISK | 상황 해결형 전투는 코어와 일치하나 Mobile 필기 피로 검증 필요 |
-| Mobile 우선 ↔ 승인 16:9 화면 | USER_DECISION_REQUIRED | 방향 미확정과 가로형 활성 소비자가 충돌 |
-| 46분 Slice ↔ Mobile 사용 맥락 | SHOULD_FIX | 콘텐츠 축소보다 Resume Anchor로 중단 가능 구조를 보완하는 것이 적합 |
-| 자유일정 ↔ Challenge | NEEDS_IMPROVEMENT | 태그 의도는 있으나 정확한 적용 계약이 없음 |
-| Grimoire/Main ↔ Mobile 방향 | BLOCKED_BY_DECISION | 방향 확정 전에 상세 레이아웃 잠금 시 재작업 |
-| Active Timer ↔ 접근성 | TEST_IN_VERTICAL_SLICE | 승인 방향은 유지하되 감속·중단·피로를 실기기로 검증 |
-| 기획 ↔ 구현 | NO_IMPLEMENTATION_YET | 제품 구현이 없으므로 불일치가 아니라 구현 전 계약 단계 |
+| Mobile 우선 ↔ 승인 16:9 화면 | RESOLVED_WITH_REVALIDATION | Landscape 고정 승인; 16:9 자료는 기준으로 보존하되 실기기 재검증 |
+| 46분 Slice ↔ Mobile 사용 맥락 | SHOULD_FIX | 콘텐츠 축소보다 Resume Anchor로 중단 가능 구조 보완 |
+| 자유일정 ↔ Challenge | NEEDS_IMPROVEMENT | 태그 의도는 있으나 정확한 적용 계약 필요 |
+| Grimoire/Main ↔ Mobile 방향 | UNBLOCKED | Landscape 기준 정보 구조·레이아웃 기획 가능 |
+| Active Timer ↔ 접근성 | TEST_IN_VERTICAL_SLICE | 감속·중단·피로를 실기기로 검증 |
+| 기획 ↔ 구현 | NO_IMPLEMENTATION_YET | 구현 전 계약 단계 |
 
-## 6. Grill Me 순서
+## 7. 다음 Grill Me 원칙
 
-한 번에 하나의 독립 결정만 묻는다.
+- 한 번에 하나의 독립적인 중요 결정만 묻는다.
+- OS·Store 우선순위는 관련 벤치마킹·기기 범위와 함께 별도 질문한다.
+- 핵심 경험을 바꾸지 않는 Touch target·Canvas·감속·저장 지점·성능 수치는 권장 시험값으로 작성하고 플레이테스트로 조정한다.
+- 새로운 질문은 실제 기획 충돌이나 제품 범위 분기가 확인될 때만 사용한다.
 
-1. `GM-MOBILE-ORIENTATION-01` — Mobile Demo 화면 방향.
-2. OS·Store 우선순위는 방향과 기획 화면 계약이 닫힌 뒤 별도 질문.
-3. 핵심 경험을 바꾸지 않는 수치·Touch target·Canvas·감속·저장 지점은 권장 시험값으로 작성하고 플레이테스트로 조정.
-
-## 7. 현재 판정
+## 8. 현재 판정
 
 ```text
+RESOLVED_USER_DECISION = GR-TPA-01 / GM-MOBILE-ORIENTATION-01
 AUTO_FIX_ELIGIBLE = GR-TPA-02 / 03 / 06 / 07 / 09
-USER_DECISION_REQUIRED = GR-TPA-01
 RESEARCH_OR_TEST_REQUIRED = GR-TPA-04 / 05 / 08
+NEXT_PLANNING_WORK = MOBILE RESUME·SAVE OWNERSHIP·LANDSCAPE INFORMATION ARCHITECTURE
 CODEX = BLOCKED
 PRODUCT_IMPLEMENTATION = NOT_STARTED
 ```
 
-첫 Grill Me 결정 전에는 Mobile 화면 상세 레이아웃을 확정하지 않는다. 승인 답변을 받으면 같은 Decision ID로 현재 결정·Mobile Foundation·UX·Sheet에 즉시 동기화한다.
+Landscape 기준 상세 기획은 진행할 수 있다. Runtime·Mobile device·Performance·Accessibility·Human 검증은 계속 `NOT_RUN`이다.


### PR DESCRIPTION
## Summary

- Continue the approved TOTAL_PLANNING adversarial audit from main `92c77e7`.
- Resolve the first verified P0 planning conflict with user-approved `GM-MOBILE-ORIENTATION-01`.
- Set the Mobile Vertical Slice to Landscape fixed across Main, Field, Dialogue, Schedule, Writing, Battle, Result, Grimoire, and Settings.
- Exclude Portrait gameplay, mixed per-screen orientation, and runtime auto-rotation from the Vertical Slice.
- Preserve approved 16:9 assets as Landscape derivation references without claiming Mobile device validation.
- Apply recommended planning defaults for Resume Anchors, save ownership, free-schedule effects, and handwriting/timer testing boundaries.

## Authority

- Decision: `docs/planning/MOBILE_ORIENTATION_01_APPROVAL_2026-08-02.md`
- Audit: `docs/planning/TOTAL_PLANNING_ADVERSARIAL_AUDIT_2026-08-02.md`
- Current decisions: `docs/planning/CURRENT_CONFIRMED_DECISIONS.md`
- Gates: `docs/DEVELOPMENT_GATES.md`
- UX contract: `docs/UX_UI_SYSTEM.md`
- Authority head: `ebc3f8f38d4346cc8b5751f5981e3c5997d0b41b`

## Sheet Sync

Decision ID `GM-MOBILE-ORIENTATION-01` was written and read back in:

- `00_프로젝트_허브!H2`
- `02_현재_확정결정!A27:J27`
- `04_누락_충돌_감사!A23:H23`
- `10_제품방향!A3:F6`
- `60_UX_UI_접근성!A2:J2`
- `60_UX_UI_접근성!A15:J15`
- `99_변경이력!A24:H24`

Sheet status: `SYNCED_TO_WORKING_BRANCH / READBACK_PASS`.

## Scope Boundary

No Godot product code, Scene, Resource, game data, balance finalization, asset production, or locked reference image was changed.

## Remaining Planning Work

- Resume Anchor and save-ownership specification.
- Landscape Aspect/Safe Area/Touch information hierarchy.
- Small-screen Writing/Battle layout candidates.
- Android/iOS, Store, minimum device, and performance decision packet.
- Further Grill Me only when a verified high-impact planning conflict remains.

## Remaining NOT_RUN

Runtime, Mobile device, Aspect ratio, performance, battery/thermal, accessibility, and human playtest remain `NOT_RUN`.