### PR TITLE
docs: propagate landscape decision to cold-start context

### DIFF
--- a/START_HERE.md
+++ b/START_HERE.md
@@ -9,7 +9,9 @@
 | 프로젝트 | `GRIMOIRE: 세계를 다시 쓰는 법` |
 | 1차 플랫폼 | `Mobile` |
 | 후속 플랫폼 | `PC` |
-| 플랫폼 Decision | `GM-PLATFORM-02` (`GM-PLATFORM-01` 대체) |
+| 플랫폼 Decision | `GM-PLATFORM-02` |
+| Mobile 방향 | `GM-MOBILE-ORIENTATION-01 / LANDSCAPE_FIXED` |
+| Portrait·자동 회전 | `VERTICAL_SLICE 제외` |
 | 엔진 기준 후보 | `Godot 4.7.1 stable` |
 | 제품 단계 | `DEMO_FIRST_VERTICAL_SLICE` |
 | 기획 | `APPROVED` |
@@ -18,16 +20,14 @@
 | 전투 규칙 | `APPROVED_SITUATION_RESOLUTION_RULES` |
 | Asset Spec | `APPROVED_SPEC` |
 | 현재 제품 Gate | `MOBILE-FOUNDATION-01` |
-| 후속 설계 | `BOSS-PHASE-01 / GRIMOIRE-SCREEN-01 / AUDIO-DIRECTION-01` |
 | 구현 | `NOT_STARTED` |
 | Codex | `BLOCKED` |
 | Base | `v9.4.0` |
-| main 기준선 | `fe88236946a87362a43aafe598348b84c42a2243` |
-| 현재 Sync | `GR-SYNC-20260802-07 / SYNCED_TO_MAIN / SHEET_READBACK_PASS` |
-| Authority Commit | `fe88236946a87362a43aafe598348b84c42a2243` |
-| main Merge Commit | `fe88236946a87362a43aafe598348b84c42a2243` |
-| 병합 PR | `#27 / MERGED / CI·ADVERSARIAL PASS` |
-| Sync Receipt | `docs/planning/sync/GR-SYNC-20260802-07-MAIN.md` |
+| Orientation Authority | `ebc3f8f38d4346cc8b5751f5981e3c5997d0b41b` |
+| Orientation Main | `0bb1f4e2ee48f426579228e716abdba7edcbfc9c` |
+| PR | `#29 / MERGED / CI·ADVERSARIAL PASS` |
+| Sheet | `SYNCED_TO_MAIN / MAIN_SHEET_READBACK_PASS` |
+| Sync Receipt | `docs/planning/sync/GM-MOBILE-ORIENTATION-01-MAIN.md` |
 
 ## 먼저 읽을 문서
 
@@ -35,18 +35,29 @@
 2. `docs/ACTIVE_CONTEXT.md`
 3. `docs/planning/CURRENT_CONFIRMED_DECISIONS.md`
 4. `docs/planning/PLATFORM_MOBILE_FIRST_02_2026-08-02.md`
-5. `docs/planning/PROJECT_ADVERSARIAL_AUDIT_2026-08-02.md`
-6. `docs/planning/sync/GR-SYNC-20260802-07-MAIN.md`
-7. `docs/planning/GRIMOIRE_PLANNING_CANON_2026-07-31.md`
-8. `docs/planning/ART_BIBLE_01_APPROVAL_2026-08-01.md`
-9. `docs/planning/BATTLE_RULES_01_APPROVAL_2026-08-01.md`
-10. `docs/planning/ASSET_SPEC_01_APPROVAL_2026-08-01.md`
-11. `docs/DEVELOPMENT_GATES.md`
-12. `skills/PROJECT_BASE_ADAPTER.json`
+5. `docs/planning/MOBILE_ORIENTATION_01_APPROVAL_2026-08-02.md`
+6. `docs/planning/TOTAL_PLANNING_ADVERSARIAL_AUDIT_2026-08-02.md`
+7. `docs/planning/sync/GM-MOBILE-ORIENTATION-01-MAIN.md`
+8. `docs/planning/GRIMOIRE_PLANNING_CANON_2026-07-31.md`
+9. `docs/planning/ART_BIBLE_01_APPROVAL_2026-08-01.md`
+10. `docs/planning/BATTLE_RULES_01_APPROVAL_2026-08-01.md`
+11. `docs/planning/ASSET_SPEC_01_APPROVAL_2026-08-01.md`
+12. `docs/DEVELOPMENT_GATES.md`
+13. `docs/UX_UI_SYSTEM.md`
+14. `skills/PROJECT_BASE_ADAPTER.json`
 
 ## 현재 플레이어 약속
 
 > 마법학교 학생이 되어 글자의 의미를 배우고, 수업과 현장실습에서 주문을 직접 설계해 내가 생각한 해결법으로 세계를 바꾸는 마법 RPG.
+
+비타협 코어:
+
+- 의미를 가진 글자와 직접 작성.
+- `메인 글자 1개 + 보조 글자 0개 이상`.
+- 상황·목표·위험에 따른 주문 설계 판단.
+- 입력 실패·문법 실패·상황 설계 실패·비용 부족 분리.
+- 즉각적이고 설명 가능한 세계 변화.
+- 학습→증명→표현→응용→발견·기록 순환.
 
 ## Vertical Slice
 
@@ -64,6 +75,7 @@
 - 글자: `흐름 / 집중 / 분산`.
 - 목표 `45~50분`, 콘텐츠 상한 `53분`, 하드 상한 `60분`.
 - 직접 작성 성공 7회, 안내형 복구 포함 목표 상한 10회.
+- 같은 문제에서 확인한 글자는 Token 재선택 허용.
 - 메인 동반 정령 초기 형상 1개, 수호형 보조 소환수 1체.
 - 마도서는 해결 과정·결과·부작용·발견을 기록하며 자동 주문 Stock이 아니다.
 
@@ -81,61 +93,96 @@
 
 - 일반 적은 단일 페이즈.
 - 판단·작성 중 타이머 진행, 시스템 해결 중 정지.
+- 선택형 작성 감속 초기 후보 `0.5×`는 `TEST_VALUE`.
 - 기본 적의 승리는 HP 0 처치가 아니라 `불안정도 0 → 진정·해결`.
 - 플레이어 HP 0 또는 선언된 치명적 환경 붕괴가 패배.
 - 환경 보존도·부작용·남은 HP가 결과 품질을 만든다.
 
+## Mobile Landscape 계약
+
+`GM-MOBILE-ORIENTATION-01`에 따라 Mobile Vertical Slice의 핵심 화면은 Landscape 고정이다.
+
+```text
+Landscape Main
+→ Landscape Field / Dialogue / Schedule
+→ Landscape Writing Overlay
+→ Landscape Battle
+→ Landscape Result
+→ Landscape Field Return
+→ Landscape Grimoire
+```
+
+적용:
+
+- Main·Field·Dialogue·Schedule·Writing·Battle·Result·Grimoire·Settings 전부 Landscape.
+- Portrait Gameplay·화면별 혼합 방향·Runtime 자동 회전은 Vertical Slice 제외.
+- 기존 16:9 자료는 Landscape 파생 기준으로 보존하지만 Mobile 실기기 통과 증거가 아니다.
+- 직접 작성 Canvas와 적 위험·상태·작성 정보의 동시 판독을 우선한다.
+- Landscape 고정의 세션 마찰은 Resume Anchor·자동 저장·이어하기로 보완한다.
+
 ## 현재 화면·아트
 
-- 승인 기준은 16:9 고정 3/4 Field, 같은 장소 Half-body Dialogue, 별도 Battle, Result 후 Field 복귀다.
+- 고정 3/4 Field, 같은 장소 Half-body Dialogue, 별도 Battle, Result 후 Field 복귀.
 - Soft Storybook 배경 + Anime Cel 캐릭터, Navy/Gold UI + Blue Glyph.
+- 우측 Writing Panel은 축소 Rail에서 작성 시 확장한다.
 - Grimoire 파생 화면을 Main보다 먼저 설계한다.
 - 잠긴 기준 이미지 SHA-256: `b55ce1dec6c2521668602d1ce6547526e7f40b8c7c9b6f5276d9289a67f14f7a`.
-- 기존 16:9·PC 해상도 규격은 보존되지만 Mobile 실기기 적합성은 `NOT_RUN`이다.
+- 잠긴 원본 수정·재생성·리터치·재배치 금지.
 
-## Mobile 우선 전환
+## MOBILE-FOUNDATION-01
 
-`GM-PLATFORM-02`에 따라 1차 플랫폼을 Mobile로 전환했다. 기존 PC 중심 입력은 후속 적응 자료로 보존한다.
+현재 작성 순서:
 
-`MOBILE-FOUNDATION-01`에서 확정·검증할 항목:
+1. Resume Anchor·Save Ownership.
+2. Landscape 지원 Aspect·Safe Area·Notch·System gesture.
+3. Touch·Stylus stroke, 후보, Undo·부분 삭제·초기화·취소·확정·구현.
+4. 작은 화면에서 적 위험·목표·주인공 상태·Writing Panel 정보 위계.
+5. App pause/resume·background/foreground·interrupted stroke·stale request.
+6. Device·Memory·Texture·load·frame pacing·battery·thermal 검증 계획.
+7. 후속 PC Mouse·Pen·Keyboard 적응 원칙.
 
-- Touch·Stylus 작성, 후보 선택, Undo·부분 삭제·초기화·취소·확정·구현.
-- 방향·화면 비율·Safe Area·Notch·System gesture.
-- 작은 화면에서 적 위험·상태·작성 Panel의 가림 방지.
-- App pause/resume, background/foreground, interrupted stroke, stale request.
-- Device·Memory·Texture·load·frame pacing·battery·thermal 검증 계획.
-- 후속 PC의 Mouse/Pen/Keyboard 적응 원칙.
+아직 확정하지 않는 것:
 
-Android/iOS, Store, 가로/세로, 최소 기기, 성능 수치, 인식 처리 방식은 아직 확정하지 않는다.
+- Android/iOS·Store 우선순위.
+- 지원 Aspect Ratio와 최소 기기.
+- Touch target·Canvas·Text scale 최종값.
+- Frame rate·Memory·Battery·Thermal 수치.
+- 인식 알고리즘·Latency·허용치.
 
-## Base v9.4
+## 적대적 총기획 감사
 
-- Release: `a728712cb776ec98f4875914a580fcf7d0156593`.
-- Evidence: `ef1fba11167e4da0b298123b0c85ebd268191a42`.
-- Finalization: `87a0b54c2847ce4b685879209205957c170cc1cd`.
-- Registry: `693a0dff3f054ecdd653079909e044211473838e73dd9aff07734d1ce5694c59`.
-- Adapter: `skills/PROJECT_BASE_ADAPTER.json`.
-- Adapter SHA-256: `980e2f4e21bd09ac49946f90d095680220013cbab6cdf62421fc01ca1b7be8c5`.
+확인된 첫 P0 충돌인 “방향 미확정 ↔ 가로형·16:9 활성 소비자”는 `GM-MOBILE-ORIENTATION-01`로 해결했다.
+
+남은 분류:
+
+- 자동 보완: Resume Anchor, Save Ownership, 자유일정 효과, PC 입력의 후속 부록화.
+- 테스트 필요: Active Timer 접근성, 7~10회 필기 피로, 기기·성능.
+- 사용자 중요 결정: 실제 범위 분기나 기획 충돌이 확인될 때만 Grill Me.
 
 ## 검증된 운영 상태
 
-PR #27 final workflow run `30728196595`에서 다음을 통과했다.
+PR #29 branch head `ebc3f8f...`, Actions run `30729161745`:
 
-- Generator check.
-- Base v9.4·Mobile-first 회귀 단위 테스트.
-- JSON·Registry·권위 경로 검사.
-- Adversarial gate.
+- Generator check: PASS.
+- Base v9.4 adoption unit tests: PASS.
+- JSON·Registry·authority path checks: PASS.
+- Adversarial gate: PASS.
 
-Generator의 구형 `PC/ASSET_SPEC_01` 하드코딩도 Adapter 파생형으로 교정했고, Snapshot·Compatibility View를 재생성했다.
+Sheet:
+
+- `00·02·04·10·60·99` 관련 범위 반영.
+- Main commit `0bb1f4e...` 재조회.
+- `04!H23`, `99!H24`: `MAIN_SHEET_READBACK_PASS`.
 
 ## 다음 작업
 
 ```text
-적대적 총기획 감사
-→ 핵심 기획 충돌만 Grill Me
-→ 승인된 기획 정본·Sheet 즉시 동기화
-→ MOBILE-FOUNDATION-01
-→ BOSS-PHASE-01·Grimoire/Main 영향 재검토
+Resume Anchor·Save Ownership 명세
+→ Landscape Aspect·Safe Area·Touch 정보 위계
+→ 작은 화면 Writing/Battle 레이아웃 후보
+→ MOBILE-FOUNDATION-01 통합 계약
+→ 중요 충돌만 Grill Me
+→ BOSS-PHASE-01·GRIMOIRE-SCREEN-01
 → AUDIO-DIRECTION-01
 → Mobile 기준 통합 검수
 → Codex Plan 승인·기술 검수
@@ -144,11 +191,10 @@ Generator의 구형 `PC/ASSET_SPEC_01` 하드코딩도 Adapter 파생형으로 �
 
 ## 현재 검증 경계
 
-- Sheet 14개 탭 Readback: `PASS`.
-- Generator·Generated Views: `PASS / CURRENT`.
-- Unit·JSON·Registry·Adversarial CI: `PASS`.
-- PR #27: `MERGED`; GitHub·Sheet `SYNCED_TO_MAIN`.
-- Godot Runtime·Mobile device·PC adaptation·성능·접근성·사람 플레이: `NOT_RUN`.
+- Planning·Orientation 문서 정합성: `PASS`.
+- GitHub PR #29: `MERGED`.
+- Sheet Main Readback: `PASS`.
+- Godot Runtime·Mobile device·Aspect·Performance·Accessibility·Human: `NOT_RUN`.
 
 ## 현재 금지
 
@@ -156,5 +202,5 @@ Generator의 구형 `PC/ASSET_SPEC_01` 하드코딩도 Adapter 파생형으로 �
 - Godot 제품 코드·Scene·Resource·게임 데이터 생성.
 - Codex Build.
 - 잠긴 기준 이미지 편집·재생성.
-- OS·방향·성능·인식 수치를 증거 없이 확정.
-- 런타임·Mobile device·성능·접근성·사람 검증을 실행 없이 완료 처리.
+- Portrait·자동 회전을 승인 없이 Vertical Slice 범위로 확장.
+- 미검증 수치를 최종값 또는 검증 완료로 표시.

--- a/docs/ACTIVE_CONTEXT.md
+++ b/docs/ACTIVE_CONTEXT.md
@@ -6,11 +6,13 @@
 project: "GRIMOIRE: 세계를 다시 쓰는 법"
 repository: alsdmlals4-eng/GRIMOIRE-
 default_branch: main
-working_branch: main
-pull_request: 27
 primary_platform: Mobile
 follow_up_platform: PC
 platform_decision: GM-PLATFORM-02
+mobile_orientation_decision: GM-MOBILE-ORIENTATION-01
+mobile_orientation: LANDSCAPE_FIXED
+portrait_gameplay: NOT_SUPPORTED_IN_VERTICAL_SLICE
+runtime_rotation: DISABLED_IN_VERTICAL_SLICE
 engine_baseline_candidate: Godot 4.7.1 stable
 product_stage: DEMO_FIRST_VERTICAL_SLICE
 execution_profile: PLANNING_ONLY_PROFILE
@@ -26,17 +28,14 @@ implementation: NOT_STARTED
 codex: BLOCKED
 runtime_validation: NOT_RUN
 mobile_device_validation: NOT_RUN
+performance_validation: NOT_RUN
+accessibility_validation: NOT_RUN
 human_validation: NOT_RUN
-canon_sync_state: SYNCED_TO_MAIN
-sync_bundle: GR-SYNC-20260802-07
-authority_commit: fe88236946a87362a43aafe598348b84c42a2243
-verified_code_head: fe88236946a87362a43aafe598348b84c42a2243
-sheet_readback: PASS
-generator_check: PASS
-unit_json_registry_checks: PASS
-adversarial_gate: PASS
-main_baseline_commit: fe88236946a87362a43aafe598348b84c42a2243
-main_sync: SYNCED_TO_MAIN
+orientation_authority_head: ebc3f8f38d4346cc8b5751f5981e3c5997d0b41b
+orientation_main_commit: 0bb1f4e2ee48f426579228e716abdba7edcbfc9c
+orientation_pr: 29
+orientation_sheet_sync: SYNCED_TO_MAIN
+orientation_sheet_readback: PASS
 ```
 
 제품용 `project.godot`, Scene, Script, Resource, 게임 데이터, 런타임 Asset은 없다.
@@ -49,9 +48,12 @@ AGENTS.md
 → 이 문서
 → docs/planning/CURRENT_CONFIRMED_DECISIONS.md
 → docs/planning/PLATFORM_MOBILE_FIRST_02_2026-08-02.md
-→ docs/planning/sync/GR-SYNC-20260802-07-MAIN.md
+→ docs/planning/MOBILE_ORIENTATION_01_APPROVAL_2026-08-02.md
+→ docs/planning/TOTAL_PLANNING_ADVERSARIAL_AUDIT_2026-08-02.md
+→ docs/planning/sync/GM-MOBILE-ORIENTATION-01-MAIN.md
 → 질문 주제의 승인 책임 원본
 → docs/DEVELOPMENT_GATES.md
+→ docs/UX_UI_SYSTEM.md
 → docs/DESIGN_DOCUMENT_REGISTRY.json
 → skills/PROJECT_BASE_ADAPTER.json
 ```
@@ -65,7 +67,7 @@ AGENTS.md
 - 의미를 가진 글자와 직접 작성.
 - `메인 글자 1개 + 보조 글자 0개 이상`.
 - 상황·목표·위험에 따른 주문 설계 판단.
-- 입력 실패·문법 실패·상황 설계 실패 분리.
+- 입력 실패·문법 실패·상황 설계 실패·비용 부족 분리.
 - 즉각적이고 설명 가능한 세계 변화.
 - 학습→증명→표현→응용→발견·기록 순환.
 
@@ -86,6 +88,7 @@ AGENTS.md
 - 글자 `흐름 / 집중 / 분산`.
 - 자유일정 `휴식 / 준비 / 교류`.
 - 필수 성공 작성 7회, 안내형 복구 포함 목표 상한 10회.
+- 같은 문제에서 확인한 글자는 Token으로 재선택 가능.
 - 메인 동반 정령 초기 형상 1개, 수호형 보조 소환수 1체.
 - 마도서는 과정·결과·부작용·발견을 기록하며 자동 주문 Stock이 아니다.
 
@@ -100,13 +103,13 @@ AGENTS.md
 화면 계약:
 
 ```text
-고정 3/4 Field
+Landscape 고정 3/4 Field
 → 같은 장소 Half-body Dialogue
-→ Writing Overlay
+→ Landscape Writing Overlay
 → 별도 3/4 Battle
 → Result
 → 원래 Field 변화 복귀
-→ Grimoire 기록
+→ Landscape Grimoire 기록
 ```
 
 - Soft Storybook 배경 + Anime Cel 캐릭터.
@@ -115,7 +118,7 @@ AGENTS.md
 - 동반 정령·수호 소환수 상태 배지.
 - 우측 Writing Panel 축소→확장.
 - Grimoire 파생 화면을 Main보다 먼저 설계.
-- 기존 16:9·PC 해상도 기준은 승인 Asset 기준이지만 Mobile 적합성은 미검증이다.
+- 기존 16:9 자료는 Landscape 파생 기준이지만 Mobile 적합성은 미검증이다.
 
 ## 전투 계약
 
@@ -123,13 +126,14 @@ AGENTS.md
 상단·중앙 = 강한 적 1개체·환경 목표·공격 예고
 좌측 하단 = 주인공 초상·HP·마나·상태
 좌측 보조 = 동반 정령·수호 상태 배지
-작성 영역 = 직접 글자·마법진 작성
+우측 = 직접 글자·마법진 작성
 ```
 
 - 일반 적은 단일 페이즈.
 - 적은 일정 시간마다 공격.
 - 작성 후 `[구현]`과 마나 검증을 거쳐 즉시 시전.
 - 판단·작성 중 타이머 진행, 시스템 해결 중 정지.
+- 선택형 작성 감속 초기 후보 `0.5×`는 `TEST_VALUE`.
 - 기본 적은 HP 대신 `불안정도`를 사용하며 0이면 진정·해결.
 - 플레이어 HP 0 또는 치명적 환경 붕괴가 패배.
 - 환경 보존도·부작용·남은 HP·해결 방식은 결과 품질을 만든다.
@@ -140,65 +144,85 @@ AGENTS.md
 - 1차 플랫폼: `Mobile`.
 - 후속 플랫폼: `PC`.
 - 기존 `GM-PLATFORM-01 / PC 우선·Mobile 후속`은 `SUPERSEDED`.
-- Touch·Stylus 직접 작성과 화면 내 명시적 Undo·부분 삭제·초기화·취소·확정·구현을 재설계한다.
+- Touch·Stylus 직접 작성과 화면 내 Undo·부분 삭제·초기화·취소·확정·구현을 우선한다.
 - Mouse/Pen/Keyboard는 후속 PC 적응 자료다.
-- Android/iOS, Store, Landscape/Portrait, 최소 기기, 성능 수치, 인식 처리 방식은 미확정이다.
 
-## Base v9.4 운영체계
+## GM-MOBILE-ORIENTATION-01
 
-```yaml
-release_commit: a728712cb776ec98f4875914a580fcf7d0156593
-evidence_commit: ef1fba11167e4da0b298123b0c85ebd268191a42
-finalization_commit: 87a0b54c2847ce4b685879209205957c170cc1cd
-registry_sha256: 693a0dff3f054ecdd653079909e044211473838e73dd9aff07734d1ce5694c59
-canonical_adapter: skills/PROJECT_BASE_ADAPTER.json
-canonical_adapter_sha256: 980e2f4e21bd09ac49946f90d095680220013cbab6cdf62421fc01ca1b7be8c5
-generator: tools/generate_project_operating_views.py
-generated_views: CURRENT
+- Mobile Vertical Slice 전체 `Landscape 고정`.
+- Main·Field·Dialogue·Schedule·Writing·Battle·Result·Grimoire·Settings에 적용.
+- Portrait Gameplay·혼합 방향·Runtime 자동 회전 제외.
+- 직접 작성 Canvas와 적 위험·상태·작성 정보 동시 판독을 우선.
+- 기존 16:9 자료는 파생 기준으로 보존하되 실기기 검증을 대체하지 않음.
+- 지원 Aspect·Safe Area·Touch target·Canvas·Text scale은 Mobile Foundation에서 시험값으로 작성.
+- Portrait 지원은 별도 Decision 없이는 추가하지 않음.
+
+## Resume·Save 권장 기본안
+
+전체 콘텐츠와 46분 목표는 유지하면서 핵심 경계에 Resume Anchor를 둔다.
+
+```text
+첫 수업·교내 연습
+→ Anchor A
+→ 자유일정 A·실기시험
+→ Anchor B
+→ 자유일정 B·학교축제
+→ Anchor C
+→ 자유일정 C·현장 전투
+→ Anchor D
+→ 현장 환경·귀환·마도서 기록
 ```
 
-Snapshot과 Compatibility View는 Generator 생성물이며 직접 편집하지 않는다.
+상태 소유권 후보:
+
+```text
+Draft → Recognizing → Candidate → Committed → Resolved → Recorded
+```
+
+- Commit·Reward·Result·Record는 각각 한 번만 확정.
+- interrupted stroke·stale recognition은 안전하게 폐기하거나 복구 이유 표시.
+- 이어하기는 마지막 완료 Anchor 또는 복구 가능한 현재 단계에서 시작.
 
 ## 완료된 작업
 
-- Base v9.4 운영 계약 채택(PR #26, main `3ecf67c...`).
-- 프로젝트 GitHub·27개 Sheet 탭 감사.
-- Art Style, Art Bible, 전투 화면·시간·승패 규칙 승인.
-- Asset Spec 승인 및 main·Sheet 동기화(PR #24·#25).
-- 프로젝트 코어·Vertical Slice·잠긴 시각 기준 보존.
-- `GM-PLATFORM-02` GitHub authority와 Sheet 14개 탭 동기화·Readback PASS.
-- `60_UX_UI_접근성`의 `GR-UX-13/14` 위치 오류 적대적 교정.
-- Generator의 PC·Asset Spec Gate 하드코딩 제거.
-- 생성 Snapshot·Compatibility View 재생성.
-- PR #27 Generator·Unit·JSON·Registry·Adversarial CI PASS.
-- Issue #9 Mobile-first 검증 범위 갱신, Issue #16 완료 처리.
+- Base v9.4 운영 계약 채택.
+- GitHub·27개 Sheet 탭 감사.
+- 프로젝트 코어·Vertical Slice·Art Style·Art Bible·Battle Rules·Asset Spec 승인.
+- `GM-PLATFORM-02 / Mobile 우선·PC 후속` main·Sheet 동기화.
+- `GM-MOBILE-ORIENTATION-01 / Landscape 고정` 승인.
+- 방향 미확정과 가로형·16:9 활성 소비자의 P0 충돌 해결.
+- PR #29 main `0bb1f4e...` 병합.
+- Sheet `00·02·04·10·60·99` 관련 범위 main SHA Readback PASS.
+- PR #29 Generator·Unit·JSON·Registry·Adversarial PASS.
 
 ## 현재 작업
 
-Sync Bundle `GR-SYNC-20260802-07`은 `SYNCED_TO_MAIN`이다.
+```text
+Resume Anchor·Save Ownership 명세
+→ Landscape Aspect·Safe Area·Touch 정보 위계
+→ 작은 화면 Writing/Battle 레이아웃 후보
+→ MOBILE-FOUNDATION-01 통합 계약
+```
 
-- PR #27은 main `fe88236...`로 병합됐다.
-- GitHub 정본·Adapter·Generated Views·Sheet 변경이력의 main SHA Readback를 유지한다.
-- 현재 작업은 적대적 총기획 감사와 중요 기획 Decision의 Grill Me다.
+세부 수치와 데이터는 `RECOMMENDED_DEFAULT / TEST_VALUE`로 작성한다. 핵심 방향·범위 충돌만 Grill Me로 사용자에게 질문한다.
 
-## 다음 제품 작업
+## 후속 제품 작업
 
 ```text
-적대적 총기획 감사
-→ 중요 기획 충돌 Grill Me
-→ 승인 정본·Sheet 즉시 동기화
-→ MOBILE-FOUNDATION-01
-→ BOSS-PHASE-01·Grimoire/Main 파생 화면 영향 재검토
+MOBILE-FOUNDATION-01 승인
+→ BOSS-PHASE-01·GRIMOIRE-SCREEN-01
 → AUDIO-DIRECTION-01
 → Mobile 기준 기획·아트·UX 통합 검수
-→ Codex Plan 승인·기술 검수
+→ 사용자 Codex Plan 승인
+→ Codex read-only Plan·기술 검수
 → Validation-First 구현
 ```
 
 ## MOBILE-FOUNDATION-01 범위
 
+- Resume Anchor·Save Ownership.
+- Landscape 지원 Aspect·Safe Area·Notch·System gesture.
 - Touch·Stylus 입력·복구·확정 상태 계약.
-- 방향·비율·Safe Area·Notch·System gesture 결정 패킷.
 - 작은 화면 Battle/Writing 정보 위계와 가림 방지.
 - App pause/resume·background/foreground·interrupted stroke·stale request 방어.
 - Device·Memory·Texture·load·frame pacing·battery·thermal 측정 계획.
@@ -206,10 +230,10 @@ Sync Bundle `GR-SYNC-20260802-07`은 `SYNCED_TO_MAIN`이다.
 
 ## 미검증
 
-- Mobile OS·Store·방향·최소 기기.
-- Touch target·Canvas 크기·인식 알고리즘·허용치·지연.
+- Android/iOS·Store·지원 Aspect·최소 기기.
+- Touch target·Canvas·Text scale·인식 알고리즘·허용치·지연.
 - 적 공격 간격·피해량·HP·마나·불안정도 변화량·수호 완화율.
 - 환경 결과 임계값.
-- Godot Runtime·Mobile device·PC 적응·성능·접근성·사람 플레이.
+- Godot Runtime·Mobile device·PC 적응·Performance·Accessibility·Human.
 
-PR #27은 사용자 승인 후 main에 병합됐으며, 제품 구현은 별도 기획 완료 Gate 전까지 시작하지 않는다.
+제품 구현은 기획 완료 Gate와 사용자 승인 전까지 시작하지 않는다.

--- a/docs/planning/sync/GM-MOBILE-ORIENTATION-01-MAIN.md
+++ b/docs/planning/sync/GM-MOBILE-ORIENTATION-01-MAIN.md
@@ -1,0 +1,78 @@
+# GM-MOBILE-ORIENTATION-01 Main Sync Receipt
+
+```yaml
+decision_id: GM-MOBILE-ORIENTATION-01
+status: SYNCED_TO_MAIN
+approved_at: 2026-08-02 KST
+primary_platform: Mobile
+orientation: LANDSCAPE_FIXED
+portrait_gameplay: NOT_SUPPORTED_IN_VERTICAL_SLICE
+runtime_rotation: DISABLED_IN_VERTICAL_SLICE
+authority_branch_head: ebc3f8f38d4346cc8b5751f5981e3c5997d0b41b
+merged_pr: 29
+authority_main_commit: 0bb1f4e2ee48f426579228e716abdba7edcbfc9c
+sheet_id: 19FftrZ4WzB-CXa9Q-y25iKMhmEs1Ip4Ea3ramf2xKqM
+sheet_status: SYNCED_TO_MAIN
+sheet_readback: PASS
+runtime_validation: NOT_RUN
+mobile_device_validation: NOT_RUN
+performance_validation: NOT_RUN
+accessibility_validation: NOT_RUN
+human_playtest: NOT_RUN
+```
+
+## 승인 내용
+
+Mobile Vertical Slice의 Main·Field·Dialogue·Schedule·Writing·Battle·Result·Grimoire·Settings를 Landscape 고정으로 사용한다.
+
+Vertical Slice 범위에서 다음은 제외한다.
+
+- Portrait Gameplay.
+- 화면별 혼합 방향.
+- Runtime 자동 회전.
+- Landscape·Portrait 양쪽 완전 대응.
+
+기존 16:9 자료는 Landscape 파생 기준으로 보존하지만 Mobile 실기기 적합성 증거로 자동 승격하지 않는다.
+
+## GitHub 반영
+
+- `docs/planning/MOBILE_ORIENTATION_01_APPROVAL_2026-08-02.md`
+- `docs/planning/TOTAL_PLANNING_ADVERSARIAL_AUDIT_2026-08-02.md`
+- `docs/planning/CURRENT_CONFIRMED_DECISIONS.md`
+- `docs/DEVELOPMENT_GATES.md`
+- `docs/UX_UI_SYSTEM.md`
+- PR `#29`
+- Main commit `0bb1f4e2ee48f426579228e716abdba7edcbfc9c`
+
+## Google Sheet 반영·재조회
+
+- `00_프로젝트_허브!H2`
+- `02_현재_확정결정!A27:J27`
+- `04_누락_충돌_감사!A23:H23`
+- `10_제품방향!A3:F6`
+- `60_UX_UI_접근성!A2:J2`
+- `60_UX_UI_접근성!A15:J15`
+- `99_변경이력!A24:H24`
+
+최종 Readback:
+
+- Decision ID·Landscape 값·Authority SHA·PR 번호 일치.
+- `04!H23 = SYNCED_TO_MAIN / MAIN_SHEET_READBACK_PASS`.
+- `99!H24 = MAIN_SHEET_READBACK_PASS`.
+
+## 검증
+
+PR #29 branch head `ebc3f8f...`의 GitHub Actions run `30729161745`:
+
+- Generator check: PASS.
+- Base v9.4 adoption unit tests: PASS.
+- JSON·Registry·authority path checks: PASS.
+- Adversarial changed-path gate: PASS.
+
+## 남은 기획·검증
+
+- Resume Anchor·Save Ownership 명세.
+- Landscape 지원 Aspect·Safe Area·Touch 정보 위계.
+- 작은 화면 Writing·Battle 레이아웃 후보.
+- Android/iOS·Store·최소 기기·성능 결정 패킷.
+- Runtime·Mobile device·Performance·Accessibility·Human: `NOT_RUN`.


### PR DESCRIPTION
## Summary

- Propagate merged `GM-MOBILE-ORIENTATION-01` into cold-start and active handoff documents.
- Add a main-sync receipt for PR #29 and main commit `0bb1f4e2ee48f426579228e716abdba7edcbfc9c`.
- Make the next planning work explicit: Resume/Save ownership, Landscape Aspect/Safe Area/Touch hierarchy, then small-screen Writing/Battle layouts.
- Preserve Adapter scope: the Adapter continues to own platform/Gate routing, while the orientation domain decision remains in Current Decisions and its authority document.

## Changed Files

- `START_HERE.md`
- `docs/ACTIVE_CONTEXT.md`
- `docs/planning/sync/GM-MOBILE-ORIENTATION-01-MAIN.md`

## Verified Source State

- Decision authority head: `ebc3f8f38d4346cc8b5751f5981e3c5997d0b41b`
- Decision main commit: `0bb1f4e2ee48f426579228e716abdba7edcbfc9c`
- PR #29: merged
- Sheet: `SYNCED_TO_MAIN / MAIN_SHEET_READBACK_PASS`

## Scope Boundary

No product code, Scene, Resource, data, asset, balance, registry, Adapter schema, or generated view changed.

## Remaining NOT_RUN

Runtime, Mobile device, supported Aspect, performance, accessibility, and human playtest remain `NOT_RUN`.