### PR TITLE
docs: finalize Grill Me policy state without self-referential SHA

### DIFF
--- a/docs/planning/GRILL_ME_BATCH_MERGE_STATE.json
+++ b/docs/planning/GRILL_ME_BATCH_MERGE_STATE.json
@@ -29,21 +29,23 @@
   "required_pre_merge_gate": "GM-PREMERGE-ADVERSARIAL-GATE-01",
   "last_complete_flush": {
     "decision_main": "b905413e34263c8a004239efd018497dcc7e77ae",
-    "cold_start_main": "fe983e3d4ec327d8ceacc41b9976002cad88a524",
-    "merged_prs": [31, 32, 33],
-    "sheet_state": "SYNCED_TO_MAIN_DECISION_COLD_START_PENDING",
-    "sheet_readback": "PASS",
-    "open_prs_after_decision_merge": 0
+    "cold_start_main_resolution": "CURRENT_MAIN_CONTAINING_THIS_FILE; exact SHA recorded in Google Sheet 00/02/04/99",
+    "merged_prs": [31, 32, 33, 34, 35],
+    "sheet_state": "SYNCED_TO_MAIN_AFTER_FINALIZATION_MERGE_AND_READBACK",
+    "counter_reset": true,
+    "open_prs_expected_after_flush": 0
   },
   "current_policy_adoption": {
     "sync_id": "GR-SYNC-20260802-09",
-    "policy_branch": "chatgpt/grimoire-grill-batch-merge-policy-20260802",
-    "main_sync_branch": "chatgpt/grimoire-grill-policy-main-sync-20260802",
-    "status": "MAIN_SYNC_PR_OPEN_DRAFT",
+    "status": "SYNCED_TO_MAIN_WHEN_THIS_FILE_IS_PRESENT_ON_MAIN",
     "authority_commit": "276f09e832e7651cc5fa1918388759a275f4bf65",
     "final_policy_head": "cbaf5b9af8925d9b84ff59857e8584b2556b4586",
     "decision_pull_request": 33,
     "decision_main_commit": "b905413e34263c8a004239efd018497dcc7e77ae",
+    "main_sync_pull_request": 34,
+    "main_sync_main_commit": "e2fcbf3e7a28c57dc24f1ae469d4d7bd17567945",
+    "finalization_pull_request": 35,
+    "finalization_main_commit_resolution": "CURRENT_MAIN_CONTAINING_THIS_FILE; exact SHA recorded in Google Sheet",
     "pre_merge_audit": "PASS_P0_0_P1_0",
     "ci": "PASS",
     "sheet_ranges": [
@@ -53,11 +55,8 @@
       "04_누락_충돌_감사!A25:H25",
       "99_변경이력!A26:H26"
     ],
-    "sheet_readback": "PASS",
-    "main_sync_pull_request": 34,
-    "main_sync_ci": "PENDING_FINAL_HEAD",
-    "main_sync_pre_merge_audit": "PENDING_FINAL_HEAD",
-    "cold_start_main_commit": null
+    "sheet_readback_rule": "Final exact main SHA is authoritative only after post-merge Sheet readback",
+    "next_planning_work": "Smartphone Landscape Writing/Battle Wireframe contract"
   },
   "protected_boundaries": {
     "execution_profile": "PLANNING_ONLY_PROFILE",

--- a/docs/planning/sync/GR-SYNC-20260802-09-MAIN.md
+++ b/docs/planning/sync/GR-SYNC-20260802-09-MAIN.md
@@ -4,17 +4,21 @@
 
 ```yaml
 sync_id: GR-SYNC-20260802-09
-status: MAIN_SYNC_IN_PROGRESS
+status: SYNCED_TO_MAIN_WHEN_THIS_FILE_IS_PRESENT_ON_MAIN
 decision_id: GM-GRILL-MERGE-CADENCE-01
 pre_merge_gate: GM-PREMERGE-ADVERSARIAL-GATE-01
 decision_pr: 33
 decision_main: b905413e34263c8a004239efd018497dcc7e77ae
+main_sync_pr: 34
+main_sync_main: e2fcbf3e7a28c57dc24f1ae469d4d7bd17567945
+finalization_pr: 35
+finalization_main_resolution: CURRENT_MAIN_CONTAINING_THIS_FILE / exact SHA in Google Sheet
 policy_final_head: cbaf5b9af8925d9b84ff59857e8584b2556b4586
 policy_premerge_verdict: PASS_P0_0_P1_0
 policy_ci: PASS
-main_sync_branch: chatgpt/grimoire-grill-policy-main-sync-20260802
 sheet_id: 19FftrZ4WzB-CXa9Q-y25iKMhmEs1Ip4Ea3ramf2xKqM
 counter: 0_of_10
+pending_decisions: []
 product_implementation: NOT_STARTED
 codex: BLOCKED
 runtime_validation: NOT_RUN
@@ -22,6 +26,8 @@ mobile_device_validation: NOT_RUN
 accessibility_validation: NOT_RUN
 human_validation: NOT_RUN
 ```
+
+`finalization_main_resolution`은 자기 자신의 아직 알 수 없는 squash SHA를 문서에 하드코딩하지 않기 위한 규칙이다. 이 파일이 main에 존재하고 Google Sheet `00·02·04·99`에 그 main SHA가 기록·재조회되면 동기화가 완료된 것으로 판정한다.
 
 ## 2. 확정된 운영 규칙
 
@@ -33,37 +39,48 @@ human_validation: NOT_RUN
 - P0/P1, Sync 불일치, CI 실패, merge conflict, 미해결 Review가 있으면 병합하지 않는다.
 - main·Sheet·cold-start 재검증을 마친 뒤에만 Counter를 0으로 Reset하고 `SYNCED_TO_MAIN`을 선언한다.
 
-## 3. PR #33 병합 전 검증
+## 3. 정책 PR #33 검증·병합
 
 - Baseline main `fe983e3...`.
 - Final policy head `cbaf5b9...`.
 - Branch behind 0.
-- Changed files는 운영 문서 9개뿐.
-- 제품 코드·Scene·Script·Resource·데이터·잠긴 Asset 변경 0.
-- Open PR inventory는 PR #33만 존재.
-- PR #31·#32는 이미 merged.
+- 변경은 운영 문서뿐이며 제품 파일 침범 0.
 - Sheet `00·01·02·04·99` Readback PASS.
 - Review thread 0, requested changes 0.
 - Mergeable true.
-- CI run `30736039615`:
-  - Generator PASS.
-  - Unit PASS.
-  - JSON/Registry PASS.
-  - Adversarial Gate PASS.
+- CI run `30736039615`: Generator·Unit·JSON/Registry·Adversarial PASS.
 - 전용 감사 보고서:
   `docs/planning/PRE_MERGE_ADVERSARIAL_REVIEW_PR33_2026-08-02.md`.
 - Verdict: `PASS / P0=0 / P1=0`.
+- PR #33 main: `b905413e34263c8a004239efd018497dcc7e77ae`.
 
-## 4. 병합 결과
+## 4. Main-sync PR #34 검증·병합
 
-```text
-PR #33 = MERGED
-Decision main = b905413e34263c8a004239efd018497dcc7e77ae
-```
+- Base main `b905413...`.
+- Final head `8c142f8...`.
+- Branch behind 0.
+- 변경 파일:
+  - `AGENTS.md` — 고정된 과거 작업 브랜치를 동적 상태 참조로 교정.
+  - `GRILL_ME_BATCH_MERGE_STATE.json`.
+  - 이 Main Sync Receipt.
+- Sheet 교차 대조에서 `01_작업순서`가 PR #33의 stale working HEAD를 가리키는 P1을 발견하고 PR #34 상태로 교정.
+- 교정 후 P0=0, P1=0.
+- CI run `30736214786`: Generator·Unit·JSON/Registry·Adversarial PASS.
+- Review thread 0, mergeable true.
+- PR #34 main: `e2fcbf3e7a28c57dc24f1ae469d4d7bd17567945`.
 
-정책 결정은 main에 존재한다. 이 영수증과 상태 JSON을 병합하는 main-sync PR의 최종 main SHA는 병합 후 기록한다.
+## 5. 최종화 PR #35
 
-## 5. Google Sheet 범위
+PR #34 병합 후 상태 JSON과 이 영수증에 병합 전 상태 문구가 남아 있는 것을 최종 재검증에서 발견했다.
+
+해결:
+
+- 상태를 `SYNCED_TO_MAIN_WHEN_THIS_FILE_IS_PRESENT_ON_MAIN`으로 변경.
+- 자기 자신의 미래 squash SHA를 하드코딩하지 않고, 현재 main과 Sheet Readback으로 해결.
+- PR #35 병합 직전에도 동일 체크리스트·CI·Sheet 교차 대조를 실행.
+- PR #35의 실제 main SHA는 병합 후 Google Sheet에 기록하고 재조회한다.
+
+## 6. Google Sheet 범위
 
 - `00_프로젝트_허브!H2`
 - `01_작업순서!A19:J19`
@@ -71,11 +88,17 @@ Decision main = b905413e34263c8a004239efd018497dcc7e77ae
 - `04_누락_충돌_감사!A25:H25`
 - `99_변경이력!A26:H26`
 
-현재 Sheet는 decision main `b905413...`을 기록했고, main-sync PR 병합과 최종 Main Readback을 기다린다.
+완료 판정:
 
-## 6. Cold-start 복원
+```text
+이 파일이 main에 존재
++ PR #35 merged
++ final main SHA가 Sheet에 기록
++ 해당 Sheet 범위 재조회 PASS
+= GR-SYNC-20260802-09 SYNCED_TO_MAIN
+```
 
-다음 읽기 순서로 새 정책을 복원한다.
+## 7. Cold-start 복원
 
 ```text
 AGENTS.md
@@ -86,9 +109,9 @@ AGENTS.md
 → 이 Main Sync Receipt
 ```
 
-현재 정책 상태의 기계 권위는 `GRILL_ME_BATCH_MERGE_STATE.json`이다. 작업 브랜치는 각 작업마다 새로 생성하며, 상태 JSON의 pending Decision과 counter를 기준으로 한다.
+작업 브랜치는 각 작업마다 새로 생성하며 상태 JSON의 pending Decision과 counter를 기준으로 한다.
 
-## 7. 다음 기획 작업
+## 8. 다음 기획 작업
 
 ```text
 Smartphone Landscape Writing/Battle Wireframe 계약
@@ -98,15 +121,13 @@ Smartphone Landscape Writing/Battle Wireframe 계약
 
 다음 Grill Me 승인 Decision부터 카운터를 `1/10`으로 올린다. 일반 기획 작업·벤치마크·비승인 후보·단순 수정은 카운트하지 않는다.
 
-## 8. 완료 조건
+## 9. 남은 미검증
 
-main-sync PR에서 다음을 다시 확인한다.
+- Godot Runtime.
+- Smartphone 실기기·Aspect·Cutout.
+- Tablet Smoke.
+- Performance·Battery·Thermal.
+- Accessibility.
+- Human playtest.
 
-- latest main과 merge-base.
-- changed files 범위.
-- State JSON parse.
-- Generator·Unit·JSON/Registry·Adversarial CI.
-- PR mergeability·review thread.
-- Sheet와 GitHub의 decision main·counter·다음 작업 일치.
-
-main-sync PR 병합 후 Sheet에 final cold-start main SHA를 기록하고 Readback PASS를 확인하면 이 영수증 상태를 `SYNCED_TO_MAIN`으로 해석한다.
+제품 구현 권한은 부여되지 않았으며 `PLANNING_ONLY_PROFILE`, `implementation: NOT_STARTED`, `codex: BLOCKED`를 유지한다.


### PR DESCRIPTION
## Decision / Sync Scope

- Decision ID: `GM-GRILL-MERGE-CADENCE-01`
- Sync ID: `GR-SYNC-20260802-09`
- Base main: `e2fcbf3e7a28c57dc24f1ae469d4d7bd17567945`
- Counter: `0/10`
- Merge trigger: `POST_MERGE_STATE_CORRECTION / WORK_HANDOFF_FLUSH`

## Summary

- Correct the machine state and Main Sync Receipt that still contained PR #34 pre-merge status after PR #34 merged.
- Use a non-self-referential completion rule: when these final files are present on main and the exact main SHA is recorded/read back in Google Sheet, the sync is complete.
- Preserve all policy decisions, counter values, protected product boundaries, and next planning work.

## Changed Files

- `docs/planning/GRILL_ME_BATCH_MERGE_STATE.json`
- `docs/planning/sync/GR-SYNC-20260802-09-MAIN.md`

## Mandatory Checks

- Branch behind 0.
- Only these two operating state files changed.
- State JSON parses.
- Generator, Unit, JSON/Registry, Adversarial CI pass.
- Sheet 00·01·02·04·99 matches Decision main, PR #33/#34 status, counter 0/10, and finalization PR state.
- Mergeability and review threads pass.
- P0=0 and P1=0 before merge.

## Remaining NOT_RUN

Runtime, device/aspect, performance, battery/thermal, accessibility, and human playtest remain `NOT_RUN`.