### PR TITLE
docs: finalize implementation entry Sheet readback

### DIFF
--- a/docs/planning/GRILL_ME_BATCH_MERGE_STATE.json
+++ b/docs/planning/GRILL_ME_BATCH_MERGE_STATE.json
@@ -46,10 +46,14 @@
     "main_finalization_sync_id": "GR-SYNC-20260802-20"
   },
   "last_complete_flush": {
-    "status": "DECISION_MERGED_FINALIZATION_IN_PROGRESS",
+    "status": "MERGED_AND_FINALIZED",
     "approved_at": "2026-08-02T20:59:00+09:00",
     "decision_merge_pull_request": 43,
     "decision_merge_commit": "9f7cc7ca803b518b7dbe6e7471797e34fec02350",
+    "finalization_pull_request": 45,
+    "finalization_merge_commit": "ef74bff304ba5d898b37c547e70218e347989eef",
+    "readback_finalization": "CURRENT_PR_CONTAINING_THIS_STATE",
+    "final_main_commit_resolution": "EXACT_READBACK_FINALIZATION_MERGE_SHA_RECORDED_IN_GOOGLE_SHEET",
     "pre_merge_gate": "PASS_P0_0_P1_0",
     "approved_decision_ids": [
       "GM-IMPLEMENTATION-ENTRY-01"
@@ -57,7 +61,7 @@
     "approved_decision_count": 1,
     "working_sync_id": "GR-SYNC-20260802-21",
     "main_finalization_sync_id": "GR-SYNC-20260802-22",
-    "sheet_state": "PENDING_EXACT_FINAL_MAIN_SHA",
+    "sheet_state": "SYNCED_TO_MAIN_AFTER_FINALIZATION_MERGE_AND_READBACK",
     "counter_reset": true
   },
   "current_work": {
@@ -66,7 +70,10 @@
     "approved_option": "A_FOUNDATION_POC_ONLY_TDD_WITH_HARD_CONTENT_LOCK",
     "decision_merge_pull_request": 43,
     "decision_merge_commit": "9f7cc7ca803b518b7dbe6e7471797e34fec02350",
+    "finalization_pull_request": 45,
+    "finalization_merge_commit": "ef74bff304ba5d898b37c547e70218e347989eef",
     "main_finalization_sync_id": "GR-SYNC-20260802-22",
+    "sheet_readback": "PASS",
     "implementation_entry": "APPROVED_CONDITIONAL_FOUNDATION_POC",
     "implementation": "NOT_STARTED",
     "codex_plan": "ALLOWED",
@@ -82,8 +89,7 @@
     "merge_blocking_p0": 0,
     "merge_blocking_p1": 0,
     "p1_open_for_execution": 3,
-    "sheet_readback": "PENDING_AFTER_FINALIZATION_MERGE",
-    "next_work": "Finalize main/Sheet sync, directly reconcile cold-start core docs, verify Godot toolchain, revalidate the plan on Base v9.4.3 main, then run GM-FOUNDATION-POC-EXECUTION-READINESS-01"
+    "next_work": "Directly reconcile cold-start core docs, verify Godot toolchain, revalidate the plan on Base v9.4.3 main, then run GM-FOUNDATION-POC-EXECUTION-READINESS-01"
   },
   "protected_boundaries": {
     "execution_profile": "PLANNING_ONLY_PROFILE_WITH_CONDITIONAL_FOUNDATION_POC_ENTRY",

--- a/docs/planning/sync/GR-SYNC-20260802-22-MAIN.md
+++ b/docs/planning/sync/GR-SYNC-20260802-22-MAIN.md
@@ -4,13 +4,17 @@
 
 ```yaml
 sync_id: GR-SYNC-20260802-22
-status: MAIN_FINALIZATION_IN_PROGRESS
+status: SYNCED_TO_MAIN_AFTER_FINALIZATION_AND_READBACK
 decision_id: GM-IMPLEMENTATION-ENTRY-01
 approved_option: A_FOUNDATION_POC_ONLY_TDD_WITH_HARD_CONTENT_LOCK
 approved_at: 2026-08-02T20:18+09:00
 merge_approved_at: 2026-08-02T20:59+09:00
 decision_pull_request: 43
 decision_merge_commit: 9f7cc7ca803b518b7dbe6e7471797e34fec02350
+finalization_pull_request: 45
+finalization_merge_commit: ef74bff304ba5d898b37c547e70218e347989eef
+readback_finalization: CURRENT_PR_CONTAINING_THIS_RECEIPT
+final_main_commit_resolution: EXACT_READBACK_FINALIZATION_MERGE_SHA_RECORDED_IN_GOOGLE_SHEET
 base_release_on_main: 9.4.3
 base_pr_38: MERGED
 base_pr_42: CLOSED_SUPERSEDED
@@ -20,7 +24,7 @@ pending_decisions_after_flush: 0
 implementation: NOT_STARTED
 codex_execution: BLOCKED
 execution_readiness: NOT_RUN
-sheet_state: PENDING_EXACT_FINAL_MAIN_SHA
+sheet_state: PASS
 ```
 
 ## 병합된 결정
@@ -45,9 +49,42 @@ TDD Foundation POC 설계·계획만 승인한다.
 - changed scope: documentation/planning-state files only
 - product code, Godot project, runtime data, asset, audio, ML changes: `0`
 
-## Base 동기화
+## PR #45 검증 근거
 
-PR #43 병합 직전 main은 PR #44를 통해 Base v9.4.3을 채택했다.
+- final head: `e687f03c940d8c1af0093f73e614997eead6aed2`
+- merge commit: `ef74bff304ba5d898b37c547e70218e347989eef`
+- CI run: `30747448737`
+- `ci-gate`: success
+- `adversarial-gate`: success
+- unresolved review threads: `0`
+- changed scope: `START_HERE`, Batch State, 이 Sync Receipt만
+
+## Google Sheet Readback
+
+반영·재조회 탭:
+
+```text
+00·01·02·04·05·10·20·30·60·80·90·99
+```
+
+확인:
+
+- finalization main `ef74bff...` 기록.
+- counter `0/10`.
+- pending `0`.
+- `GR-SYNC-20260802-22` 신규 변경이력 행 존재.
+- Base `v9.4.3`.
+- implementation `NOT_STARTED`.
+- Codex execution `BLOCKED`.
+- Runtime·Device·Performance·Accessibility·Human `NOT_RUN`.
+- 기존 `GR-SYNC-20260802-21` 행 보존.
+- 행 덮어쓰기 `0`, ID 충돌 `0`.
+
+```yaml
+sheet_readback: PASS
+```
+
+## Base 동기화
 
 - PR #38: v9.4.2 planning-first 도입 — merged
 - PR #42: 오래된 v9.4.3 Draft — closed/superseded
@@ -81,13 +118,6 @@ ACCESSIBILITY_VALIDATION = NOT_RUN
 HUMAN_VALIDATION = NOT_RUN
 ```
 
-## 완료 규칙
+## 자기참조 방지
 
-이 Finalization PR이 main에 병합된 후:
-
-1. 최종 main SHA를 Google Sheet `00·01·02·04·05·10·30·60·80·90·99`에 기록한다.
-2. Grill counter `0/10`, pending `0`, `GR-SYNC-20260802-22`를 Readback한다.
-3. 구현·Codex·검증 차단 상태가 유지되는지 확인한다.
-4. 정확한 최종 main SHA는 Sheet와 PR 기록을 권위 증거로 사용한다.
-
-이 규칙은 Finalization 문서가 자신의 미래 merge SHA를 요구하는 자기참조를 피한다.
+이 Readback Finalization PR이 병합되면 main SHA가 한 번 더 전진한다. 그 정확한 merge SHA는 Google Sheet와 PR 기록에 남기며, 이 문서는 자신의 미래 SHA를 고정값으로 요구하지 않는다.


### PR DESCRIPTION
## Purpose

Close the final GitHub/Google Sheet state after PR #43 and PR #45.

- Decision PR #43 merge: `9f7cc7ca803b518b7dbe6e7471797e34fec02350`
- Finalization PR #45 merge: `ef74bff304ba5d898b37c547e70218e347989eef`
- Sync: `GR-SYNC-20260802-22`
- Sheet readback: `PASS`
- Grill counter: `0/10`
- pending decisions: `0`

## Changes

- mark the one-decision boundary flush as merged and finalized;
- record finalization PR #45 and Sheet readback PASS;
- preserve self-reference-safe final-main resolution through this PR's merge SHA recorded in Google Sheet;
- preserve implementation NOT_STARTED and Codex execution BLOCKED.

## Remaining work

Cold-start core-document reconciliation, Godot toolchain preflight, Base v9.4.3 plan revalidation, and `GM-FOUNDATION-POC-EXECUTION-READINESS-01`.