### PR TITLE
fix: make star circuit harness interactive

### DIFF
--- a/src/ui/star_circuit_harness.gd
+++ b/src/ui/star_circuit_harness.gd
@@ -1,6 +1,55 @@
 class_name StarCircuitHarness
 extends Control
 
+const ValidatorScript = preload("res://src/core/star/star_circuit_validator.gd")
+const CalculatorScript = preload("res://src/core/star/star_circuit_calculator.gd")
+const StateScript = preload("res://src/core/star/star_circuit_state.gd")
+const CoordinatorScript = preload("res://src/core/star/star_circuit_commit_coordinator.gd")
+const TypedStockScript = preload("res://src/core/resources/typed_glyph_stock_pool.gd")
+const VaultScript = preload("res://src/core/resources/vault_inventory.gd")
+const ReservationLedgerScript = preload("res://src/core/resources/resource_reservation_ledger.gd")
+const ManaScript = preload("res://src/core/resources/mana_pool.gd")
+const CommitRequestScript = preload("res://src/core/spells/spell_commit_request.gd")
+const CommitServiceScript = preload("res://src/core/spells/atomic_spell_commit_service.gd")
+const ResultLedgerScript = preload("res://src/core/atomic_result_ledger.gd")
+
+const GLYPH_IDS: Array[StringName] = [
+    &"HEAT", &"PROTECT", &"FLOW", &"FOCUS", &"DISPERSE", &"BURST",
+]
+const PHASE_EDIT := &"EDIT"
+const PHASE_TARGET := &"TARGET"
+const PHASE_FINAL := &"FINAL"
+const PHASE_CONFIRM := &"CONFIRM"
+const PHASE_COMMITTED := &"COMMITTED"
+
+var _signals_connected := false
+var _phase: StringName = PHASE_EDIT
+var _main_index := 0
+var _auxiliary_indices: Array[int] = [2, -1, -1, -1, -1]
+var _transaction_counter := 0
+var _selected_target: StringName = &""
+var _last_preview: Dictionary = {}
+var _last_status: StringName = &"READY"
+
+var _state
+var _validator
+var _calculator
+var _coordinator
+var _stock
+var _vault
+var _reservation_ledger
+var _mana
+var _commit_service
+
+
+func _ready() -> void:
+    initialize_demo()
+
+
+func initialize_demo() -> void:
+    _connect_signals_once()
+    _reset_demo()
+
 
 func test_contract_snapshot() -> Dictionary:
     return {
@@ -16,6 +65,30 @@ func test_contract_snapshot() -> Dictionary:
         "text_scale_130_percent": true,
         "color_not_sole_signal": true,
         "accessibility_input_alternative": true,
+        "interactive_demo": true,
+        "core_runtime_connected": true,
+    }
+
+
+func test_interaction_snapshot() -> Dictionary:
+    var auxiliary_glyphs: Array[StringName] = []
+    for glyph_index in _auxiliary_indices:
+        auxiliary_glyphs.append(&"EMPTY" if glyph_index < 0 else GLYPH_IDS[glyph_index])
+    var stock_counts: Dictionary = {}
+    if _stock != null:
+        stock_counts = Dictionary(_stock.to_dict().get("counts", {})).duplicate(true)
+    return {
+        "phase": _phase,
+        "main_glyph": GLYPH_IDS[_main_index],
+        "auxiliary_glyphs": auxiliary_glyphs,
+        "target_keyword": _selected_target,
+        "target_enabled": _target_buttons_enabled(),
+        "commit_enabled": not _button_disabled("SafeArea/CommitButton"),
+        "success_percent": int(_last_preview.get("success_percent", 0)),
+        "final_mana": int(_last_preview.get("final_mana", 0)),
+        "mana": 0 if _mana == null else int(_mana.current()),
+        "stock_counts": stock_counts,
+        "last_status": _last_status,
     }
 
 
@@ -24,13 +97,16 @@ func show_circuit_preview(text: String) -> void:
 
 
 func show_target_keywords(keywords: Array) -> void:
-    _set_label("SafeArea/TargetKeywordPanel/Label", " / ".join(PackedStringArray(keywords)))
+    _set_label(
+        "SafeArea/TargetKeywordPanel/Content/Label",
+        "Target Keywords · %s" % " / ".join(PackedStringArray(keywords))
+    )
 
 
 func show_final_preview(success_percent: int, final_mana: int) -> void:
     _set_label(
         "SafeArea/FinalPreviewPanel/Label",
-        "%s%% · Mana %s" % [success_percent, final_mana]
+        "Success %s%% · Mana %s" % [success_percent, final_mana]
     )
 
 
@@ -55,7 +131,7 @@ func show_mastery_breakdown(
 
 
 func show_warning(message: String, cause_glyph_id: StringName = &"") -> void:
-    var prefix := "WARNING"
+    var prefix := "STATUS"
     if not cause_glyph_id.is_empty():
         prefix = "%s [%s]" % [prefix, String(cause_glyph_id)]
     _set_label("SafeArea/WarningPanel/Label", "%s: %s" % [prefix, message])
@@ -93,8 +169,382 @@ func clear_transient_states() -> void:
         _set_visible(path, false)
 
 
+func _connect_signals_once() -> void:
+    if _signals_connected:
+        return
+    _connect_button("SafeArea/CenterGlyph", Callable(self, "_on_main_pressed"))
+    for index in range(5):
+        _connect_button(
+            "SafeArea/StarVertices/Vertex%s" % index,
+            Callable(self, "_on_auxiliary_pressed").bind(index)
+        )
+    _connect_button("SafeArea/PreviewButton", Callable(self, "_on_preview_pressed"))
+    _connect_button(
+        "SafeArea/TargetKeywordPanel/Content/TargetButtons/FlowerButton",
+        Callable(self, "_on_target_pressed").bind(&"flower")
+    )
+    _connect_button(
+        "SafeArea/TargetKeywordPanel/Content/TargetButtons/WardButton",
+        Callable(self, "_on_target_pressed").bind(&"ward")
+    )
+    _connect_button("SafeArea/CommitButton", Callable(self, "_on_commit_pressed"))
+    _connect_button("SafeArea/CancelButton", Callable(self, "_on_cancel_pressed"))
+    _signals_connected = true
+
+
+func _connect_button(path: NodePath, callable: Callable) -> void:
+    var button := get_node_or_null(path) as Button
+    if button != null and not button.pressed.is_connected(callable):
+        button.pressed.connect(callable)
+
+
+func _reset_demo() -> void:
+    clear_transient_states()
+    _state = StateScript.new()
+    _validator = ValidatorScript.new()
+    _calculator = CalculatorScript.new()
+    _stock = TypedStockScript.create(18)
+    for glyph_id in GLYPH_IDS:
+        _stock.add_one(glyph_id)
+        _stock.add_one(glyph_id)
+    _vault = VaultScript.create(GLYPH_IDS.size())
+    for glyph_id in GLYPH_IDS:
+        var scribe: Dictionary = _vault.reserve_for_scribe(
+            glyph_id,
+            StringName("demo-scribe-%s" % String(glyph_id))
+        )
+        if StringName(scribe.get("status", &"")) == &"OK":
+            _vault.complete_scribe(StringName(scribe.get("reservation_id", &"")))
+    _reservation_ledger = ReservationLedgerScript.create(_stock, _vault)
+    _mana = ManaScript.create(100)
+    _commit_service = CommitServiceScript.create(ResultLedgerScript.new())
+    _state.configure_scenario({
+        "fixture_id": &"frostbloom-interactive-demo",
+        "objective": "Protect Frostbloom",
+        "threat": "Cold surge",
+        "situation": "The flower and ward are both valid explicit targets",
+        "target_keywords": [&"flower", &"ward"],
+    })
+    _state.transition_to(_state.State.CIRCUIT_EDIT)
+    _coordinator = CoordinatorScript.create(
+        _state,
+        _validator,
+        _calculator,
+        _reservation_ledger,
+        _mana,
+        _commit_service,
+        CommitRequestScript
+    )
+    _phase = PHASE_EDIT
+    _main_index = 0
+    _auxiliary_indices = [2, -1, -1, -1, -1]
+    _selected_target = &""
+    _last_preview.clear()
+    _last_status = &"READY"
+    _set_edit_enabled(true)
+    _set_target_buttons_enabled(false)
+    _set_button_disabled("SafeArea/PreviewButton", false)
+    _set_button_disabled("SafeArea/CommitButton", true)
+    _set_button_text("SafeArea/CommitButton", "COMMIT")
+    _set_button_text("SafeArea/CancelButton", "CANCEL")
+    _refresh_selection_ui()
+    show_circuit_preview("Circuit Preview\n1. Click Main/Aux glyphs\n2. Press PREVIEW CIRCUIT")
+    show_target_keywords(["locked until preview"])
+    _set_label("SafeArea/FinalPreviewPanel/Label", "Success --% · Mana --\nTarget --")
+    show_warning("Ready · default HEAT + FLOW example loaded")
+    _render_breakdown({})
+
+
+func _on_main_pressed() -> void:
+    if _phase != PHASE_EDIT:
+        return
+    _main_index = (_main_index + 1) % GLYPH_IDS.size()
+    _last_status = &"EDITED"
+    _refresh_selection_ui()
+    show_warning("Main glyph changed · preview again when ready")
+
+
+func _on_auxiliary_pressed(slot: int) -> void:
+    if _phase != PHASE_EDIT or slot < 0 or slot >= _auxiliary_indices.size():
+        return
+    var next_index := _auxiliary_indices[slot] + 1
+    _auxiliary_indices[slot] = -1 if next_index >= GLYPH_IDS.size() else next_index
+    _last_status = &"EDITED"
+    _refresh_selection_ui()
+    show_warning("Auxiliary slot A%s changed · empty slots are allowed" % slot)
+
+
+func _on_preview_pressed() -> void:
+    if _phase != PHASE_EDIT or _coordinator == null:
+        return
+    clear_transient_states()
+    _transaction_counter += 1
+    var main := _build_main_glyph()
+    var auxiliaries := _build_auxiliaries()
+    var result: Dictionary = _coordinator.prepare_circuit_preview(
+        StringName("interactive-star-%s" % _transaction_counter),
+        main,
+        auxiliaries
+    )
+    _last_status = StringName(result.get("status", &"UNKNOWN"))
+    if _last_status != &"CIRCUIT_PREVIEW_READY":
+        show_unstable_circuit(_validation_cause(main, auxiliaries), String(_last_status))
+        show_warning("Circuit rejected · change duplicate or invalid auxiliary glyphs")
+        return
+    _last_preview = Dictionary(result.get("preview", {})).duplicate(true)
+    _phase = PHASE_TARGET
+    _set_edit_enabled(false)
+    _set_button_disabled("SafeArea/PreviewButton", true)
+    _set_target_buttons_enabled(true)
+    _set_button_disabled("SafeArea/CommitButton", true)
+    var aux_names := _auxiliary_names(auxiliaries)
+    show_circuit_preview(
+        "Circuit Preview READY\nMain %s · Aux %s\nTarget not selected" % [
+            String(main.glyph_id),
+            "none" if aux_names.is_empty() else ", ".join(aux_names),
+        ]
+    )
+    show_target_keywords(["FLOWER", "WARD"])
+    show_warning("Circuit valid · select an explicit target keyword")
+    _render_breakdown(_last_preview)
+
+
+func _on_target_pressed(keyword: StringName) -> void:
+    if _phase != PHASE_TARGET or _coordinator == null:
+        return
+    var target := _target_data(keyword)
+    var result: Dictionary = _coordinator.select_target_and_prepare_final_preview(
+        keyword,
+        target,
+        {"effect": &"FROSTBLOOM_DEMO", "cause_glyph": GLYPH_IDS[_main_index]}
+    )
+    _last_status = StringName(result.get("status", &"UNKNOWN"))
+    if _last_status != &"FINAL_PREVIEW_READY":
+        show_warning("Target rejected · %s" % String(_last_status))
+        return
+    _selected_target = keyword
+    _last_preview = Dictionary(result.get("preview", {})).duplicate(true)
+    _phase = PHASE_FINAL
+    _set_target_buttons_enabled(false)
+    _set_button_disabled("SafeArea/CommitButton", false)
+    _set_label(
+        "SafeArea/FinalPreviewPanel/Label",
+        "Success %s%% · Mana %s\nTarget %s" % [
+            int(_last_preview.get("success_percent", 0)),
+            int(_last_preview.get("final_mana", 0)),
+            String(keyword).to_upper(),
+        ]
+    )
+    show_warning("Final preview ready · COMMIT requires a second confirmation press")
+    _render_breakdown(_last_preview)
+
+
+func _on_commit_pressed() -> void:
+    if _coordinator == null:
+        return
+    if _phase == PHASE_FINAL:
+        if not _coordinator.request_confirmation():
+            _last_status = &"CONFIRMATION_REJECTED"
+            show_warning("Commit confirmation could not be opened")
+            return
+        _phase = PHASE_CONFIRM
+        _last_status = &"CONFIRMATION_REQUIRED"
+        _set_button_text("SafeArea/CommitButton", "CONFIRM COMMIT")
+        show_warning("Press CONFIRM COMMIT again · resources are still unchanged")
+        return
+    if _phase != PHASE_CONFIRM:
+        return
+    var result: Dictionary = _coordinator.confirm_commit()
+    _last_status = StringName(result.get("status", &"UNKNOWN"))
+    if _last_status != &"COMMITTED":
+        if _last_status == &"INSUFFICIENT_MANA":
+            show_insufficient_mana(
+                int(_last_preview.get("final_mana", 0)),
+                int(_mana.current())
+            )
+        show_warning("Commit failed safely · %s" % String(_last_status))
+        return
+    _phase = PHASE_COMMITTED
+    _set_button_disabled("SafeArea/CommitButton", true)
+    _set_button_text("SafeArea/CommitButton", "COMMITTED")
+    _set_button_text("SafeArea/CancelButton", "RESET")
+    show_warning(
+        "COMMITTED · %s target · Mana remaining %s · press RESET to try again" % [
+            String(_selected_target).to_upper(),
+            int(_mana.current()),
+        ]
+    )
+    _render_breakdown(_last_preview)
+
+
+func _on_cancel_pressed() -> void:
+    if _phase == PHASE_CONFIRM and _coordinator != null:
+        _coordinator.cancel_confirmation()
+    _reset_demo()
+
+
+func _build_main_glyph() -> Dictionary:
+    var glyph_id := GLYPH_IDS[_main_index]
+    return {
+        "glyph_id": glyph_id,
+        "source": &"VAULT",
+        "mastery": 70,
+        "base_mana": _main_base_mana(glyph_id),
+        "base_success": 75,
+    }
+
+
+func _build_auxiliaries() -> Array:
+    var auxiliaries: Array = []
+    for slot in range(_auxiliary_indices.size()):
+        var glyph_index := _auxiliary_indices[slot]
+        if glyph_index < 0:
+            continue
+        var glyph_id := GLYPH_IDS[glyph_index]
+        auxiliaries.append({
+            "slot": slot,
+            "glyph_id": glyph_id,
+            "source": &"STOCK",
+            "mastery": 70,
+            "base_mana": 4,
+            "special": _auxiliary_special(glyph_id),
+        })
+    return auxiliaries
+
+
+func _target_data(keyword: StringName) -> Dictionary:
+    if keyword == &"ward":
+        return {"difficulty": 10, "mana_cost": 2, "output_cost": 0, "duration_cost": 0}
+    return {"difficulty": 5, "mana_cost": 0, "output_cost": 0, "duration_cost": 0}
+
+
+func _main_base_mana(glyph_id: StringName) -> int:
+    match glyph_id:
+        &"BURST":
+            return 14
+        &"PROTECT":
+            return 12
+        &"FOCUS":
+            return 11
+        _:
+            return 10
+
+
+func _auxiliary_special(glyph_id: StringName) -> StringName:
+    if glyph_id == &"FOCUS":
+        return &"PRECISION"
+    if glyph_id == &"DISPERSE":
+        return &"REDUCTION"
+    return &"NORMAL"
+
+
+func _refresh_selection_ui() -> void:
+    _set_button_text("SafeArea/CenterGlyph", "MAIN\n%s" % String(GLYPH_IDS[_main_index]))
+    var masteries: Dictionary = {GLYPH_IDS[_main_index]: 70}
+    for slot in range(_auxiliary_indices.size()):
+        var glyph_index := _auxiliary_indices[slot]
+        var text := "A%s\nEMPTY" % slot
+        if glyph_index >= 0:
+            var glyph_id := GLYPH_IDS[glyph_index]
+            text = "A%s\n%s" % [slot, String(glyph_id)]
+            masteries[glyph_id] = 70
+        _set_button_text("SafeArea/StarVertices/Vertex%s" % slot, text)
+    var lines: Array[String] = ["Mastery"]
+    for glyph_id in masteries.keys():
+        lines.append("%s · %s" % [String(glyph_id), int(masteries[glyph_id])])
+    _set_label("SafeArea/MasteryPanel/Label", "\n".join(lines))
+
+
+func _render_breakdown(preview: Dictionary) -> void:
+    var success_text := "preview required"
+    var mana_text := "preview required"
+    if not preview.is_empty():
+        success_text = "%s%% · %s" % [
+            int(preview.get("success_percent", 0)),
+            String(preview.get("success_label", &"")),
+        ]
+        mana_text = "%s · pool %s" % [
+            int(preview.get("final_mana", 0)),
+            int(_mana.current()),
+        ]
+    _set_label(
+        "SafeArea/BreakdownPanel/Label",
+        "Success: %s\nMana: %s\nTyped Stock: %s" % [
+            success_text,
+            mana_text,
+            _stock_summary(),
+        ]
+    )
+
+
+func _stock_summary() -> String:
+    if _stock == null:
+        return "--"
+    var parts: Array[String] = []
+    for glyph_id in GLYPH_IDS:
+        parts.append("%s:%s" % [String(glyph_id), int(_stock.matching_count(glyph_id))])
+    return " ".join(parts)
+
+
+func _auxiliary_names(auxiliaries: Array) -> Array[String]:
+    var names: Array[String] = []
+    for item in auxiliaries:
+        names.append(String(Dictionary(item).get("glyph_id", &"")))
+    return names
+
+
+func _validation_cause(main: Dictionary, auxiliaries: Array) -> StringName:
+    var seen: Dictionary = {}
+    for item in auxiliaries:
+        var glyph_id := StringName(Dictionary(item).get("glyph_id", &""))
+        if seen.has(glyph_id):
+            return glyph_id
+        seen[glyph_id] = true
+    return StringName(main.get("glyph_id", &""))
+
+
+func _set_edit_enabled(value: bool) -> void:
+    _set_button_disabled("SafeArea/CenterGlyph", not value)
+    for index in range(5):
+        _set_button_disabled("SafeArea/StarVertices/Vertex%s" % index, not value)
+
+
+func _set_target_buttons_enabled(value: bool) -> void:
+    _set_button_disabled(
+        "SafeArea/TargetKeywordPanel/Content/TargetButtons/FlowerButton",
+        not value
+    )
+    _set_button_disabled(
+        "SafeArea/TargetKeywordPanel/Content/TargetButtons/WardButton",
+        not value
+    )
+
+
+func _target_buttons_enabled() -> bool:
+    return not _button_disabled(
+        "SafeArea/TargetKeywordPanel/Content/TargetButtons/FlowerButton"
+    )
+
+
+func _button_disabled(path: NodePath) -> bool:
+    var button := get_node_or_null(path) as Button
+    return true if button == null else button.disabled
+
+
+func _set_button_disabled(path: NodePath, value: bool) -> void:
+    var button := get_node_or_null(path) as Button
+    if button != null:
+        button.disabled = value
+
+
+func _set_button_text(path: NodePath, value: String) -> void:
+    var button := get_node_or_null(path) as Button
+    if button != null:
+        button.text = value
+
+
 func _set_label(path: NodePath, text: String) -> void:
-    var label := get_node_or_null(path)
+    var label := get_node_or_null(path) as Label
     if label != null:
         label.text = text
 

--- a/src/ui/star_circuit_harness.tscn
+++ b/src/ui/star_circuit_harness.tscn
@@ -30,8 +30,8 @@ offset_top = 284.0
 offset_right = 704.0
 offset_bottom = 412.0
 custom_minimum_size = Vector2(48, 48)
-text = "MAIN"
-tooltip_text = "Main glyph: exactly one"
+text = "MAIN\nHEAT"
+tooltip_text = "Click to cycle the main glyph"
 
 [node name="StarVertices" type="Control" parent="SafeArea"]
 layout_mode = 1
@@ -48,8 +48,8 @@ offset_top = 80.0
 offset_right = 680.0
 offset_bottom = 160.0
 custom_minimum_size = Vector2(48, 48)
-text = "A0"
-tooltip_text = "Optional auxiliary glyph 1 of 5"
+text = "A0\nFLOW"
+tooltip_text = "Click to cycle optional auxiliary glyph 1 of 5"
 
 [node name="Vertex1" type="Button" parent="SafeArea/StarVertices"]
 offset_left = 820.0
@@ -57,8 +57,8 @@ offset_top = 240.0
 offset_right = 900.0
 offset_bottom = 320.0
 custom_minimum_size = Vector2(48, 48)
-text = "A1"
-tooltip_text = "Optional auxiliary glyph 2 of 5"
+text = "A1\nEMPTY"
+tooltip_text = "Click to cycle optional auxiliary glyph 2 of 5"
 
 [node name="Vertex2" type="Button" parent="SafeArea/StarVertices"]
 offset_left = 740.0
@@ -66,8 +66,8 @@ offset_top = 500.0
 offset_right = 820.0
 offset_bottom = 580.0
 custom_minimum_size = Vector2(48, 48)
-text = "A2"
-tooltip_text = "Optional auxiliary glyph 3 of 5"
+text = "A2\nEMPTY"
+tooltip_text = "Click to cycle optional auxiliary glyph 3 of 5"
 
 [node name="Vertex3" type="Button" parent="SafeArea/StarVertices"]
 offset_left = 460.0
@@ -75,8 +75,8 @@ offset_top = 500.0
 offset_right = 540.0
 offset_bottom = 580.0
 custom_minimum_size = Vector2(48, 48)
-text = "A3"
-tooltip_text = "Optional auxiliary glyph 4 of 5"
+text = "A3\nEMPTY"
+tooltip_text = "Click to cycle optional auxiliary glyph 4 of 5"
 
 [node name="Vertex4" type="Button" parent="SafeArea/StarVertices"]
 offset_left = 380.0
@@ -84,8 +84,8 @@ offset_top = 240.0
 offset_right = 460.0
 offset_bottom = 320.0
 custom_minimum_size = Vector2(48, 48)
-text = "A4"
-tooltip_text = "Optional auxiliary glyph 5 of 5"
+text = "A4\nEMPTY"
+tooltip_text = "Click to cycle optional auxiliary glyph 5 of 5"
 
 [node name="CircuitPreviewPanel" type="PanelContainer" parent="SafeArea"]
 offset_left = 16.0
@@ -94,24 +94,47 @@ offset_right = 336.0
 offset_bottom = 112.0
 
 [node name="Label" type="Label" parent="SafeArea/CircuitPreviewPanel"]
-text = "Circuit Preview"
+text = "Circuit Preview\nEdit glyphs, then press PREVIEW CIRCUIT"
 autowrap_mode = 2
 
 [node name="TargetKeywordPanel" type="PanelContainer" parent="SafeArea"]
 offset_left = 16.0
 offset_top = 128.0
 offset_right = 336.0
-offset_bottom = 224.0
+offset_bottom = 248.0
 
-[node name="Label" type="Label" parent="SafeArea/TargetKeywordPanel"]
-text = "Target Keywords · available after circuit preview"
+[node name="Content" type="VBoxContainer" parent="SafeArea/TargetKeywordPanel"]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="Label" type="Label" parent="SafeArea/TargetKeywordPanel/Content"]
+layout_mode = 2
+text = "Target Keywords · locked until circuit preview"
 autowrap_mode = 2
+
+[node name="TargetButtons" type="HBoxContainer" parent="SafeArea/TargetKeywordPanel/Content"]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="FlowerButton" type="Button" parent="SafeArea/TargetKeywordPanel/Content/TargetButtons"]
+custom_minimum_size = Vector2(96, 48)
+layout_mode = 2
+disabled = true
+text = "FLOWER"
+tooltip_text = "Select the flower as the explicit target"
+
+[node name="WardButton" type="Button" parent="SafeArea/TargetKeywordPanel/Content/TargetButtons"]
+custom_minimum_size = Vector2(96, 48)
+layout_mode = 2
+disabled = true
+text = "WARD"
+tooltip_text = "Select the ward as the explicit target"
 
 [node name="MasteryPanel" type="PanelContainer" parent="SafeArea"]
 offset_left = 16.0
-offset_top = 240.0
+offset_top = 264.0
 offset_right = 336.0
-offset_bottom = 400.0
+offset_bottom = 424.0
 
 [node name="Label" type="Label" parent="SafeArea/MasteryPanel"]
 text = "Mastery\n--"
@@ -124,17 +147,17 @@ offset_right = 1232.0
 offset_bottom = 344.0
 
 [node name="Label" type="Label" parent="SafeArea/BreakdownPanel"]
-text = "Success: --\nMana: --"
+text = "Success: --\nMana: --\nResources: --"
 autowrap_mode = 2
 
 [node name="WarningPanel" type="PanelContainer" parent="SafeArea"]
 offset_left = 920.0
 offset_top = 360.0
 offset_right = 1232.0
-offset_bottom = 448.0
+offset_bottom = 464.0
 
 [node name="Label" type="Label" parent="SafeArea/WarningPanel"]
-text = "WARNING: none"
+text = "READY: edit Main/Aux glyphs"
 autowrap_mode = 2
 
 [node name="FinalPreviewPanel" type="PanelContainer" parent="SafeArea"]
@@ -144,7 +167,7 @@ offset_right = 1232.0
 offset_bottom = 144.0
 
 [node name="Label" type="Label" parent="SafeArea/FinalPreviewPanel"]
-text = "Success --% · Mana --"
+text = "Success --% · Mana --\nTarget --"
 autowrap_mode = 2
 
 [node name="InsufficientManaState" type="PanelContainer" parent="SafeArea"]
@@ -171,13 +194,22 @@ horizontal_alignment = 1
 
 [node name="AccessibilityInputPanel" type="PanelContainer" parent="SafeArea"]
 offset_left = 16.0
-offset_top = 416.0
+offset_top = 440.0
 offset_right = 336.0
-offset_bottom = 520.0
+offset_bottom = 544.0
 
 [node name="Label" type="Label" parent="SafeArea/AccessibilityInputPanel"]
 text = "ACCESSIBLE INPUT · Tap / Guided trace / Stylus"
 autowrap_mode = 2
+
+[node name="PreviewButton" type="Button" parent="SafeArea"]
+offset_left = 560.0
+offset_top = 600.0
+offset_right = 720.0
+offset_bottom = 656.0
+custom_minimum_size = Vector2(48, 48)
+text = "PREVIEW CIRCUIT"
+tooltip_text = "Validate the selected star circuit before target selection"
 
 [node name="CancelButton" type="Button" parent="SafeArea"]
 offset_left = 920.0
@@ -186,7 +218,7 @@ offset_right = 1008.0
 offset_bottom = 624.0
 custom_minimum_size = Vector2(48, 48)
 text = "CANCEL"
-tooltip_text = "Cancel without resource mutation"
+tooltip_text = "Cancel without resource mutation and reset the demo"
 
 [node name="CommitButton" type="Button" parent="SafeArea"]
 offset_left = 1024.0
@@ -194,5 +226,6 @@ offset_top = 560.0
 offset_right = 1216.0
 offset_bottom = 624.0
 custom_minimum_size = Vector2(48, 48)
+disabled = true
 text = "COMMIT"
-tooltip_text = "Explicit commit after final preview"
+tooltip_text = "Explicit two-step commit after final preview"

--- a/tests/integration/test_star_circuit_harness_scene.gd
+++ b/tests/integration/test_star_circuit_harness_scene.gd
@@ -2,6 +2,7 @@ extends RefCounted
 
 const SCENE_PATH := "res://src/ui/star_circuit_harness.tscn"
 
+
 func run(case) -> void:
     case.assert_true(FileAccess.file_exists(SCENE_PATH), "Star circuit harness scene must exist")
     if not FileAccess.file_exists(SCENE_PATH):
@@ -10,6 +11,7 @@ func run(case) -> void:
     case.assert_true(packed != null and packed.can_instantiate(), "Star harness scene must load")
     if packed == null or not packed.can_instantiate():
         return
+
     var scene = packed.instantiate()
     case.assert_true(scene.get_node_or_null("SafeArea/CenterGlyph") != null, "Center glyph control exists")
     for index in range(5):
@@ -17,6 +19,9 @@ func run(case) -> void:
     case.assert_true(scene.get_node_or_null("SafeArea/CircuitPreviewPanel") != null, "Circuit preview exists")
     case.assert_true(scene.get_node_or_null("SafeArea/TargetKeywordPanel") != null, "Target keyword panel exists")
     case.assert_true(scene.get_node_or_null("SafeArea/FinalPreviewPanel") != null, "Final preview exists")
+    case.assert_true(scene.get_node_or_null("SafeArea/PreviewButton") != null, "Explicit circuit preview button exists")
+    case.assert_true(scene.get_node_or_null("SafeArea/TargetKeywordPanel/Content/TargetButtons/FlowerButton") != null, "Flower target button exists")
+    case.assert_true(scene.get_node_or_null("SafeArea/TargetKeywordPanel/Content/TargetButtons/WardButton") != null, "Ward target button exists")
     case.assert_true(scene.get_node_or_null("SafeArea/CommitButton") != null, "Explicit commit button exists")
     case.assert_true(scene.has_method("test_contract_snapshot"), "Harness exposes read-only test contract snapshot")
     if scene.has_method("test_contract_snapshot"):
@@ -26,4 +31,58 @@ func run(case) -> void:
         case.assert_false(bool(snapshot.slot_order_effect), "Vertex order has no hidden effect")
         case.assert_true(bool(snapshot.target_after_circuit_preview), "Target follows circuit preview")
         case.assert_true(bool(snapshot.numeric_success_preview), "Numeric success preview is exposed")
+        case.assert_true(bool(snapshot.interactive_demo), "Harness declares an interactive demo")
+
+    case.assert_true(scene.has_method("initialize_demo"), "Harness exposes deterministic demo initialization")
+    case.assert_true(scene.has_method("test_interaction_snapshot"), "Harness exposes interaction state for tests")
+    if not scene.has_method("initialize_demo") or not scene.has_method("test_interaction_snapshot"):
+        scene.free()
+        return
+
+    scene.initialize_demo()
+    var initial: Dictionary = scene.test_interaction_snapshot()
+    case.assert_equal(&"EDIT", initial.phase, "Demo starts in edit phase")
+    case.assert_equal(&"HEAT", initial.main_glyph, "Demo starts with HEAT as main glyph")
+    case.assert_equal(&"FLOW", initial.auxiliary_glyphs[0], "Demo starts with FLOW auxiliary for a visible typed-stock example")
+    case.assert_false(bool(initial.target_enabled), "Targets remain locked before circuit preview")
+    case.assert_false(bool(initial.commit_enabled), "Commit remains locked before final preview")
+
+    scene.get_node("SafeArea/PreviewButton").pressed.emit()
+    var circuit_ready: Dictionary = scene.test_interaction_snapshot()
+    case.assert_equal(&"TARGET", circuit_ready.phase, "Preview advances to target selection")
+    case.assert_true(bool(circuit_ready.target_enabled), "Targets unlock after circuit preview")
+    case.assert_false(bool(circuit_ready.commit_enabled), "Commit remains locked until target selection")
+
+    scene.get_node("SafeArea/TargetKeywordPanel/Content/TargetButtons/FlowerButton").pressed.emit()
+    var final_ready: Dictionary = scene.test_interaction_snapshot()
+    case.assert_equal(&"FINAL", final_ready.phase, "Target selection creates final preview")
+    case.assert_equal(70, final_ready.success_percent, "Interactive example exposes the approved 70 percent final preview")
+    case.assert_equal(16, final_ready.final_mana, "Interactive example exposes the approved 16 mana final preview")
+    case.assert_true(bool(final_ready.commit_enabled), "Commit unlocks only after final preview")
+
+    scene.get_node("SafeArea/CommitButton").pressed.emit()
+    var confirmation: Dictionary = scene.test_interaction_snapshot()
+    case.assert_equal(&"CONFIRM", confirmation.phase, "First commit press requests explicit confirmation")
+    case.assert_equal("CONFIRM COMMIT", scene.get_node("SafeArea/CommitButton").text, "Commit button clearly changes to confirmation")
+
+    scene.get_node("SafeArea/CommitButton").pressed.emit()
+    var committed: Dictionary = scene.test_interaction_snapshot()
+    case.assert_equal(&"COMMITTED", committed.phase, "Second commit press commits the spell")
+    case.assert_true(int(committed.mana) < int(initial.mana), "Committed demo consumes the previewed mana")
+    case.assert_equal(
+        int(initial.stock_counts.get(&"FLOW", 0)) - 1,
+        int(committed.stock_counts.get(&"FLOW", 0)),
+        "Committed demo consumes only the matching FLOW typed stock"
+    )
+    case.assert_true(String(committed.last_status).contains("COMMITTED"), "Committed result is visible")
     scene.free()
+
+    var cancel_scene = packed.instantiate()
+    cancel_scene.initialize_demo()
+    var before_cancel: Dictionary = cancel_scene.test_interaction_snapshot()
+    cancel_scene.get_node("SafeArea/CancelButton").pressed.emit()
+    var after_cancel: Dictionary = cancel_scene.test_interaction_snapshot()
+    case.assert_equal(before_cancel.mana, after_cancel.mana, "Cancel/reset spends no mana")
+    case.assert_equal(before_cancel.stock_counts, after_cancel.stock_counts, "Cancel/reset consumes no typed stock")
+    case.assert_equal(&"EDIT", after_cancel.phase, "Cancel returns to a fresh edit phase")
+    cancel_scene.free()


### PR DESCRIPTION
## 문제와 근본 원인

Godot에서 `project.godot`을 실행하면 별형 회로의 정적 레이아웃만 표시되고 Button이 반응하지 않았다.

확인 결과 `star_circuit_harness.gd`에는 `_ready()` 초기화와 `pressed` signal 연결이 없었고, Scene에는 명시적 Preview/Target 선택 컨트롤도 없었다. 기존 테스트도 노드 존재만 확인해 정적 Harness를 통과시켰다.

## 수정

- Main 버튼: 6개 glyph 순환 선택
- A0~A4: EMPTY와 6개 glyph 순환 선택
- `PREVIEW CIRCUIT`: 실제 `StarCircuitValidator`와 Coordinator 호출
- Preview 성공 뒤 FLOWER/WARD Target 활성화
- Target 선택 뒤 실제 `StarCircuitCalculator` 기반 숫자 성공률·Mana 표시
- `COMMIT` → `CONFIRM COMMIT`의 명시적 2단계 확인
- 두 번째 확인에서 실제 Atomic Coordinator가 Mana·동일 glyph Typed Stock·Vault를 exactly-once 소비
- `CANCEL/RESET`: 확인 취소 후 자원 무변이 초기화
- 중복 Auxiliary glyph는 실제 Validator가 거부하고 원인 상태를 표시

변경 범위는 Scene·Harness·상호작용 회귀 테스트 3개 파일뿐이며 핵심 계산식과 기획 정본은 변경하지 않았다.

## TDD와 최종 검증

```yaml
red_head: 8a7e52ff23d69c3aaa93bf8d78a586834f823717
red_run: 31067904559
red_result: PREVIEW_TARGET_INTERACTION_MISSING_EXPECTED_FAILURE
exact_head: 7ab928d8d7b0593e0a5f637ad1355d4a9062462a
star_runtime_run: 31068101707
planning_base_run: 31068101732
physical_pack_run: 31068101703
godot_toolchain_run: 31068101708
runtime_suites: 31
assertions: 1164
failures: 0
result: PASS
```

Toolchain 첫 시도는 계약 PASS 뒤 외부 Export Template 다운로드가 15분 제한에 걸려 cancelled됐지만, 동일 exact HEAD의 Job 재실행에서 Engine·Export Template 검증과 Report 업로드가 PASS했다.

```yaml
changed_files: 3
comments: 0
unresolved_review_threads: 0
mergeable: true
```

## 경계

- Low-fi 상호작용 Harness이며 완성 게임 Scene·최종 아트가 아니다.
- 실제 모바일 기기·Screen Reader·사람 검증은 계속 `NOT_RUN`이다.
- 자동 Target·자동 Commit·다른 glyph Stock 대체는 허용하지 않는다.