### PR TITLE
fix: make star harness layout responsive and non-overlapping

### DIFF
--- a/src/ui/star_circuit_harness.tscn
+++ b/src/ui/star_circuit_harness.tscn
@@ -24,11 +24,15 @@ grow_horizontal = 2
 grow_vertical = 2
 
 [node name="CenterGlyph" type="Button" parent="SafeArea"]
-layout_mode = 0
-offset_left = 576.0
-offset_top = 284.0
-offset_right = 704.0
-offset_bottom = 412.0
+layout_mode = 1
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -64.0
+offset_top = -64.0
+offset_right = 64.0
+offset_bottom = 64.0
 custom_minimum_size = Vector2(48, 48)
 text = "MAIN\nHEAT"
 tooltip_text = "Click to cycle the main glyph"
@@ -43,54 +47,80 @@ grow_vertical = 2
 mouse_filter = 2
 
 [node name="Vertex0" type="Button" parent="SafeArea/StarVertices"]
-offset_left = 600.0
-offset_top = 80.0
-offset_right = 680.0
-offset_bottom = 160.0
+layout_mode = 1
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -40.0
+offset_top = -272.0
+offset_right = 40.0
+offset_bottom = -192.0
 custom_minimum_size = Vector2(48, 48)
 text = "A0\nFLOW"
 tooltip_text = "Click to cycle optional auxiliary glyph 1 of 5"
 
 [node name="Vertex1" type="Button" parent="SafeArea/StarVertices"]
-offset_left = 820.0
-offset_top = 240.0
-offset_right = 900.0
-offset_bottom = 320.0
+layout_mode = 1
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = 150.0
+offset_top = -96.0
+offset_right = 230.0
+offset_bottom = -16.0
 custom_minimum_size = Vector2(48, 48)
 text = "A1\nEMPTY"
 tooltip_text = "Click to cycle optional auxiliary glyph 2 of 5"
 
 [node name="Vertex2" type="Button" parent="SafeArea/StarVertices"]
-offset_left = 740.0
-offset_top = 500.0
-offset_right = 820.0
-offset_bottom = 580.0
+layout_mode = 1
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = 90.0
+offset_top = 168.0
+offset_right = 170.0
+offset_bottom = 248.0
 custom_minimum_size = Vector2(48, 48)
 text = "A2\nEMPTY"
 tooltip_text = "Click to cycle optional auxiliary glyph 3 of 5"
 
 [node name="Vertex3" type="Button" parent="SafeArea/StarVertices"]
-offset_left = 460.0
-offset_top = 500.0
-offset_right = 540.0
-offset_bottom = 580.0
+layout_mode = 1
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -170.0
+offset_top = 168.0
+offset_right = -90.0
+offset_bottom = 248.0
 custom_minimum_size = Vector2(48, 48)
 text = "A3\nEMPTY"
 tooltip_text = "Click to cycle optional auxiliary glyph 4 of 5"
 
 [node name="Vertex4" type="Button" parent="SafeArea/StarVertices"]
-offset_left = 380.0
-offset_top = 240.0
-offset_right = 460.0
-offset_bottom = 320.0
+layout_mode = 1
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -230.0
+offset_top = -96.0
+offset_right = -150.0
+offset_bottom = -16.0
 custom_minimum_size = Vector2(48, 48)
 text = "A4\nEMPTY"
 tooltip_text = "Click to cycle optional auxiliary glyph 5 of 5"
 
 [node name="CircuitPreviewPanel" type="PanelContainer" parent="SafeArea"]
-offset_left = 16.0
+layout_mode = 1
+offset_left = 64.0
 offset_top = 16.0
-offset_right = 336.0
+offset_right = 352.0
 offset_bottom = 112.0
 
 [node name="Label" type="Label" parent="SafeArea/CircuitPreviewPanel"]
@@ -98,9 +128,10 @@ text = "Circuit Preview\nEdit glyphs, then press PREVIEW CIRCUIT"
 autowrap_mode = 2
 
 [node name="TargetKeywordPanel" type="PanelContainer" parent="SafeArea"]
-offset_left = 16.0
+layout_mode = 1
+offset_left = 64.0
 offset_top = 128.0
-offset_right = 336.0
+offset_right = 352.0
 offset_bottom = 248.0
 
 [node name="Content" type="VBoxContainer" parent="SafeArea/TargetKeywordPanel"]
@@ -131,9 +162,10 @@ text = "WARD"
 tooltip_text = "Select the ward as the explicit target"
 
 [node name="MasteryPanel" type="PanelContainer" parent="SafeArea"]
-offset_left = 16.0
+layout_mode = 1
+offset_left = 64.0
 offset_top = 264.0
-offset_right = 336.0
+offset_right = 352.0
 offset_bottom = 424.0
 
 [node name="Label" type="Label" parent="SafeArea/MasteryPanel"]
@@ -141,9 +173,12 @@ text = "Mastery\n--"
 autowrap_mode = 2
 
 [node name="BreakdownPanel" type="PanelContainer" parent="SafeArea"]
-offset_left = 920.0
+layout_mode = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -352.0
 offset_top = 160.0
-offset_right = 1232.0
+offset_right = -40.0
 offset_bottom = 344.0
 
 [node name="Label" type="Label" parent="SafeArea/BreakdownPanel"]
@@ -151,9 +186,12 @@ text = "Success: --\nMana: --\nResources: --"
 autowrap_mode = 2
 
 [node name="WarningPanel" type="PanelContainer" parent="SafeArea"]
-offset_left = 920.0
+layout_mode = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -352.0
 offset_top = 360.0
-offset_right = 1232.0
+offset_right = -40.0
 offset_bottom = 464.0
 
 [node name="Label" type="Label" parent="SafeArea/WarningPanel"]
@@ -161,9 +199,12 @@ text = "READY: edit Main/Aux glyphs"
 autowrap_mode = 2
 
 [node name="FinalPreviewPanel" type="PanelContainer" parent="SafeArea"]
-offset_left = 920.0
+layout_mode = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -352.0
 offset_top = 16.0
-offset_right = 1232.0
+offset_right = -40.0
 offset_bottom = 144.0
 
 [node name="Label" type="Label" parent="SafeArea/FinalPreviewPanel"]
@@ -172,30 +213,45 @@ autowrap_mode = 2
 
 [node name="InsufficientManaState" type="PanelContainer" parent="SafeArea"]
 visible = false
-offset_left = 352.0
-offset_top = 16.0
-offset_right = 904.0
-offset_bottom = 72.0
+layout_mode = 1
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -260.0
+offset_top = -166.0
+offset_right = 260.0
+offset_bottom = -110.0
 
 [node name="Label" type="Label" parent="SafeArea/InsufficientManaState"]
 text = "INSUFFICIENT MANA"
 horizontal_alignment = 1
+vertical_alignment = 1
+autowrap_mode = 2
 
 [node name="UnstableCircuitState" type="PanelContainer" parent="SafeArea"]
 visible = false
-offset_left = 352.0
-offset_top = 80.0
-offset_right = 904.0
-offset_bottom = 136.0
+layout_mode = 1
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -260.0
+offset_top = -166.0
+offset_right = 260.0
+offset_bottom = -110.0
 
 [node name="Label" type="Label" parent="SafeArea/UnstableCircuitState"]
 text = "UNSTABLE CIRCUIT"
 horizontal_alignment = 1
+vertical_alignment = 1
+autowrap_mode = 2
 
 [node name="AccessibilityInputPanel" type="PanelContainer" parent="SafeArea"]
-offset_left = 16.0
+layout_mode = 1
+offset_left = 64.0
 offset_top = 440.0
-offset_right = 336.0
+offset_right = 352.0
 offset_bottom = 544.0
 
 [node name="Label" type="Label" parent="SafeArea/AccessibilityInputPanel"]
@@ -203,28 +259,43 @@ text = "ACCESSIBLE INPUT · Tap / Guided trace / Stylus"
 autowrap_mode = 2
 
 [node name="PreviewButton" type="Button" parent="SafeArea"]
-offset_left = 560.0
-offset_top = 600.0
-offset_right = 720.0
-offset_bottom = 656.0
+layout_mode = 1
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -100.0
+offset_top = -72.0
+offset_right = 100.0
+offset_bottom = -16.0
 custom_minimum_size = Vector2(48, 48)
 text = "PREVIEW CIRCUIT"
 tooltip_text = "Validate the selected star circuit before target selection"
 
 [node name="CancelButton" type="Button" parent="SafeArea"]
-offset_left = 920.0
-offset_top = 560.0
-offset_right = 1008.0
-offset_bottom = 624.0
+layout_mode = 1
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -352.0
+offset_top = -88.0
+offset_right = -240.0
+offset_bottom = -24.0
 custom_minimum_size = Vector2(48, 48)
 text = "CANCEL"
 tooltip_text = "Cancel without resource mutation and reset the demo"
 
 [node name="CommitButton" type="Button" parent="SafeArea"]
-offset_left = 1024.0
-offset_top = 560.0
-offset_right = 1216.0
-offset_bottom = 624.0
+layout_mode = 1
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -224.0
+offset_top = -88.0
+offset_right = -40.0
+offset_bottom = -24.0
 custom_minimum_size = Vector2(48, 48)
 disabled = true
 text = "COMMIT"

--- a/tests/integration/test_star_circuit_harness_scene.gd
+++ b/tests/integration/test_star_circuit_harness_scene.gd
@@ -23,6 +23,56 @@ func run(case) -> void:
     case.assert_true(scene.get_node_or_null("SafeArea/TargetKeywordPanel/Content/TargetButtons/FlowerButton") != null, "Flower target button exists")
     case.assert_true(scene.get_node_or_null("SafeArea/TargetKeywordPanel/Content/TargetButtons/WardButton") != null, "Ward target button exists")
     case.assert_true(scene.get_node_or_null("SafeArea/CommitButton") != null, "Explicit commit button exists")
+
+    var left_panel_paths := [
+        "SafeArea/CircuitPreviewPanel",
+        "SafeArea/TargetKeywordPanel",
+        "SafeArea/MasteryPanel",
+        "SafeArea/AccessibilityInputPanel",
+    ]
+    for path in left_panel_paths:
+        var panel := scene.get_node(path) as Control
+        case.assert_equal(0.0, panel.anchor_left, "%s remains anchored to the left edge" % path)
+        case.assert_equal(0.0, panel.anchor_right, "%s does not stretch from a fixed 1280 coordinate" % path)
+        case.assert_true(panel.offset_left >= 40.0, "%s preserves a visible left safe margin" % path)
+
+    var right_control_paths := [
+        "SafeArea/FinalPreviewPanel",
+        "SafeArea/BreakdownPanel",
+        "SafeArea/WarningPanel",
+        "SafeArea/CancelButton",
+        "SafeArea/CommitButton",
+    ]
+    for path in right_control_paths:
+        var control := scene.get_node(path) as Control
+        case.assert_equal(1.0, control.anchor_left, "%s follows the right viewport edge" % path)
+        case.assert_equal(1.0, control.anchor_right, "%s follows the right viewport edge" % path)
+        case.assert_true(control.offset_right <= -16.0, "%s preserves a visible right safe margin" % path)
+
+    var centered_paths := [
+        "SafeArea/CenterGlyph",
+        "SafeArea/PreviewButton",
+        "SafeArea/InsufficientManaState",
+        "SafeArea/UnstableCircuitState",
+    ]
+    for path in centered_paths:
+        var control := scene.get_node(path) as Control
+        case.assert_equal(0.5, control.anchor_left, "%s follows the horizontal center" % path)
+        case.assert_equal(0.5, control.anchor_right, "%s follows the horizontal center" % path)
+
+    for index in range(5):
+        var vertex := scene.get_node("SafeArea/StarVertices/Vertex%s" % index) as Control
+        case.assert_equal(0.5, vertex.anchor_left, "Vertex %s follows the horizontal center" % index)
+        case.assert_equal(0.5, vertex.anchor_right, "Vertex %s follows the horizontal center" % index)
+        case.assert_equal(0.5, vertex.anchor_top, "Vertex %s follows the vertical center" % index)
+        case.assert_equal(0.5, vertex.anchor_bottom, "Vertex %s follows the vertical center" % index)
+
+    var vertex_zero := scene.get_node("SafeArea/StarVertices/Vertex0") as Control
+    var unstable_state := scene.get_node("SafeArea/UnstableCircuitState") as Control
+    var vertex_zero_rect := Rect2(vertex_zero.position, vertex_zero.size)
+    var unstable_rect := Rect2(unstable_state.position, unstable_state.size)
+    case.assert_false(vertex_zero_rect.intersects(unstable_rect), "Unstable-circuit banner never covers A0")
+
     case.assert_true(scene.has_method("test_contract_snapshot"), "Harness exposes read-only test contract snapshot")
     if scene.has_method("test_contract_snapshot"):
         var snapshot: Dictionary = scene.test_contract_snapshot()


### PR DESCRIPTION
## 문제와 근본 원인

Godot 내장 실행창에서 좌측 정보 패널의 첫 글자가 잘리고, `UNSTABLE CIRCUIT` 배너가 A0 버튼을 덮었다.

원인은 Scene이 1280×720 절대 좌표에 의존하고, 상태 배너와 A0가 동일한 세로 영역을 점유한 것이다.

## 수정

- 좌측 정보 패널: left-edge anchor + 64px 내부 안전 여백
- 우측 정보·Commit 영역: right-edge anchor + 40px 안전 여백
- Main·별 꼭짓점·Preview: viewport center/bottom anchor
- `UnstableCircuitState`와 `InsufficientManaState`: A0와 Main 사이의 전용 중앙 상태 영역
- 상태 라벨 vertical alignment와 autowrap 보강
- 주문 계산·Typed Stock·Mana·Atomic Commit 로직 변경 없음

## TDD

```yaml
red_head: e6fdcf132c8d406033677eb6d0fa32c20690413f
red_run: 31070078025
red_result: 48 layout contract failures as expected
exact_head: b651188e8059f9832573b5087a5a19c2b328aace
star_runtime_run: 31070196376
planning_base_run: 31070196456
physical_pack_run: 31070196354
godot_toolchain_run: 31070196378
suites: 31
assertions: 1220
failures: 0
result: PASS
```

## 적대 검토 경계

- 변경 파일은 Scene과 레이아웃 회귀 테스트 2개뿐이다.
- 제품 공식·자원·Commit 경로는 수정하지 않았다.
- 리뷰 댓글과 미해결 스레드는 0건이다.
- Low-fi Harness이며 최종 아트·실기기·사람 검증 완료를 주장하지 않는다.