### PR TITLE
Use live GitHub readback for current main semantics

### DIFF
--- a/.github/workflows/validate-godot-authoring-gut-authority.yml
+++ b/.github/workflows/validate-godot-authoring-gut-authority.yml
@@ -30,3 +30,5 @@ jobs:
         run: python -m unittest tests.test_v4_4_formal_adoption_unresolved_reconciliation -v
       - name: Validate v4.4 post-merge canon synchronization
         run: python -m unittest tests.test_v4_4_post_merge_canon_sync -v
+      - name: Validate live GitHub main readback semantics
+        run: python -m unittest tests.test_v4_4_live_main_readback_semantics -v

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -5,7 +5,10 @@
 ```yaml
 active_contract: PROJECT_TOTAL_PLANNING_IMPLEMENTATION_AND_DELIVERY_INSTRUCTION_v4.4
 contract_binding_decision: GM-CONTRACT-V4-4-BINDING-01
-project_main: ea46923fa78c4fe7844ab6bf422e6716a3c785ed
+project_main_authority: LIVE_GITHUB_DEFAULT_BRANCH_READBACK
+gut_formal_adoption_main: ea46923fa78c4fe7844ab6bf422e6716a3c785ed
+post_merge_canon_sync_pr: 87
+post_merge_canon_sync_merge: ce01bb8caa5f1b224279d3fbf418eae29a88af7d
 gut_authority_decision: GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01
 gut_status: GUT_FORMALLY_ADOPTED
 gut_mode: CLI_ONLY_WITHOUT_EDITOR_PLUGIN
@@ -23,7 +26,9 @@ local_sync: LOCAL_SYNC_BLOCKED_NO_LOCAL_ACCESS
 godot_run: GODOT_RUN_BLOCKED_NO_LOCAL_ACCESS
 ```
 
-PR #85가 merged main `ea46923fa78c4fe7844ab6bf422e6716a3c785ed`에 반영되어 GUT 9.7.1 CLI/headless deterministic test authority는 정식 채택되었다. `GM-GUT-VENDOR-CRITICAL-RUNTIME-EQUIVALENCE-01`은 critical-runtime equivalence만 승인하며 full vendor-tree identity를 의미하지 않는다. GUT Editor Plugin은 계속 비활성이다.
+`project_main_authority`는 저장된 SHA가 아니라 GitHub 기본 브랜치 `main`의 live readback이다. `gut_formal_adoption_main`과 `post_merge_canon_sync_merge`는 각각 PR #85와 PR #87의 역사적 merged-main 증거이며 현재 main을 뜻하지 않는다.
+
+PR #85의 GUT 9.7.1 CLI/headless deterministic test authority는 정식 채택되었다. `GM-GUT-VENDOR-CRITICAL-RUNTIME-EQUIVALENCE-01`은 critical-runtime equivalence만 승인하며 full vendor-tree identity를 의미하지 않는다. GUT Editor Plugin은 계속 비활성이다.
 
 ## 제품 보존 정본
 

--- a/docs/ACTIVE_CONTEXT.md
+++ b/docs/ACTIVE_CONTEXT.md
@@ -5,7 +5,10 @@ project: "GRIMOIRE: 세계를 다시 쓰는 법"
 repository: alsdmlals4-eng/GRIMOIRE-
 active_contract: PROJECT_TOTAL_PLANNING_IMPLEMENTATION_AND_DELIVERY_INSTRUCTION_v4.4
 contract_binding_decision: GM-CONTRACT-V4-4-BINDING-01
-current_main: ea46923fa78c4fe7844ab6bf422e6716a3c785ed
+project_main_authority: LIVE_GITHUB_DEFAULT_BRANCH_READBACK
+gut_formal_adoption_main: ea46923fa78c4fe7844ab6bf422e6716a3c785ed
+post_merge_canon_sync_pr: 87
+post_merge_canon_sync_merge: ce01bb8caa5f1b224279d3fbf418eae29a88af7d
 preserved_runtime_decision: GM-STAR-CIRCUIT-MASTERY-BALANCE-01
 circuit_topology: FIVE_POINT_STAR
 product_decision: GM-SPELL-WORKFLOW-UI-V2-01
@@ -30,6 +33,8 @@ local_sync: LOCAL_SYNC_BLOCKED_NO_LOCAL_ACCESS
 godot_run: GODOT_RUN_BLOCKED_NO_LOCAL_ACCESS
 ```
 
+`project_main_authority`는 매 작업에서 GitHub default branch를 다시 읽는 live 권위다. 역사 SHA는 역할명으로만 보존한다.
+
 ## 보존된 Star Circuit runtime authority
 
 ```yaml
@@ -51,7 +56,7 @@ v4.4/GUT 정본 갱신은 위 제품 runtime 결정과 검증 상태를 대체�
 
 ## GUT formal adoption readback
 
-PR #85는 exact head `fc178bdc7a3e12faf4ae7ae78fd1f92dd2735849`에서 current-head repository workflows를 통과한 뒤 squash merge되었다. merged main은 `ea46923fa78c4fe7844ab6bf422e6716a3c785ed`다.
+PR #85의 formal-adoption merge는 `gut_formal_adoption_main`으로 기록한다. PR #87의 current-canon sync는 `post_merge_canon_sync_merge`로 기록한다. 둘 다 live current-main SHA가 아니다.
 
 ```yaml
 gut_release: v9.7.1

--- a/docs/DEVELOPMENT_GATES.md
+++ b/docs/DEVELOPMENT_GATES.md
@@ -3,7 +3,10 @@
 ```yaml
 active_contract: PROJECT_TOTAL_PLANNING_IMPLEMENTATION_AND_DELIVERY_INSTRUCTION_v4.4
 contract_binding_decision: GM-CONTRACT-V4-4-BINDING-01
-current_main: ea46923fa78c4fe7844ab6bf422e6716a3c785ed
+project_main_authority: LIVE_GITHUB_DEFAULT_BRANCH_READBACK
+gut_formal_adoption_main: ea46923fa78c4fe7844ab6bf422e6716a3c785ed
+post_merge_canon_sync_pr: 87
+post_merge_canon_sync_merge: ce01bb8caa5f1b224279d3fbf418eae29a88af7d
 preserved_runtime_decision: GM-STAR-CIRCUIT-MASTERY-BALANCE-01
 circuit_topology: FIVE_POINT_STAR
 product_decision: GM-SPELL-WORKFLOW-UI-V2-01
@@ -16,13 +19,15 @@ review_model: GPT_ROLE_SEPARATED_PLUS_USER_DECISION_AUTHORITY
 implementation_entry: BLOCKED_BY_BROADER_PROJECT_GATES
 ```
 
+`project_main_authority`는 GitHub default branch live readback이다. `gut_formal_adoption_main`과 `post_merge_canon_sync_merge`는 역사 SHA다.
+
 ## Gate 0 — v4.4 Application Binding
 
 `PASS_MERGED_MAIN`
 
 - 바인딩: `docs/contracts/GRIMOIRE_PROJECT_CONTRACT_V4_4_BINDING.md`
 - Base current main observed: `fa69a77a14f923a756064f6ae151d34cadb374f7`; project pin은 9.4.3 그대로다.
-- Decision/미확정/이미지 Sheet readback을 작업 진입 때마다 다시 계산한다.
+- Decision/미확정/이미지 Sheet 및 GitHub live main을 작업 진입 때마다 다시 읽는다.
 
 ## 보존 Runtime Gate
 
@@ -33,20 +38,17 @@ product_implementation: STAR_RUNTIME_COMPLETION_AUTOMATED_PASS
 runtime_validation: AUTOMATED_HEADLESS_PASS
 ```
 
-v4.4 적용과 GUT formal adoption은 기존 Five-point Star 핵심 runtime 결정을 삭제하거나 약화하지 않는다.
-
 ## Gate 15.1 — HiGodot single authoring authority
 
-`BLOCKING_BEFORE_NEXT_PERSISTENT_GODOT_AUTHORING`
+`HIGODOT_VENDOR_TREE_MISMATCH_OFFICIAL_V3_1_2`
 
 ```yaml
 release: v3.1.2
 pinned_commit: 678b16a6a0a335cf80cbb7d3f85c183cd3e616de
-vendor_integrity: HIGODOT_VENDOR_TREE_MISMATCH_OFFICIAL_V3_1_2
 authority: SOLE_PERSISTENT_GODOT_AUTHORING_AUTHORITY
 ```
 
-PR #85 자체는 protected product diff 0으로 `HiGodot Authoring Receipt Gate`를 통과했다. 이후 제품 Scene/Resource/script/project settings 저작은 HiGodot authority 경계와 vendor audit를 먼저 닫는다.
+PR #85 자체는 protected product diff 0으로 `HiGodot Authoring Receipt Gate`를 통과했다. 다음 persistent Godot authoring 전에 vendor audit를 닫는다.
 
 ## Gate 15.2–15.3 — GUT 9.7.1
 
@@ -55,7 +57,7 @@ PR #85 자체는 protected product diff 0으로 `HiGodot Authoring Receipt Gate`
 ```yaml
 spec_pr: 84
 implementation_pr: 85
-merged_main: ea46923fa78c4fe7844ab6bf422e6716a3c785ed
+gut_formal_adoption_main: ea46923fa78c4fe7844ab6bf422e6716a3c785ed
 release: v9.7.1
 pinned_commit: aeb5d4f3f7f0a6c9b5e178876d6c99b791fda605
 full_vendor_tree_identity: false
@@ -73,7 +75,7 @@ legacy_required_contract_parity: PASS
 
 `HERA_CLI_ADDON_PAIR_UNVERIFIED`
 
-Hera는 LIVE_QA_AND_OBSERVABILITY_ONLY다. exact CLI/addon pair·localhost/token·source-delta-none canary 검증 전 acceptance QA 권위로 사용하지 않는다.
+Hera는 LIVE_QA_AND_OBSERVABILITY_ONLY다.
 
 ## Gate 15.5 — PR #82 Task 2 entry
 
@@ -84,13 +86,9 @@ task2: NOT_STARTED_ON_BRANCH
 spell_workflow_task2_authorized: false
 ```
 
-GUT formal adoption blocker는 닫혔다. 다음 package가 실제 소비하는 HiGodot/Hera/visual/platform 선행 Gate가 닫히기 전에는 Task 2를 시작하지 않는다.
-
 ## Gate 16 — Windows·Android shared core
 
 `WINDOWS_ANDROID_SHARED_CORE_NOT_VALIDATED`
-
-Hosted Windows Godot/GUT 검증은 GUT formal-adoption 증거이며 Android export/device validation을 대신하지 않는다.
 
 ## Gate 17 — Visual·Audio
 
@@ -105,13 +103,9 @@ SPELL_WORKFLOW_THREE_SCREEN_RUNTIME_NOT_RUN
 
 `CI_MUTABLE_ACTION_TAGS_OUTSIDE_PR85_SCOPE`
 
-PR #85에서 수정한 GUT/authority workflows는 verified full SHA로 pin했다. 다른 기존 workflow의 mutable major tags는 별도 hardening 필요 상태로 남긴다.
-
 ## Delivery Gate
 
 ```text
 LOCAL_SYNC_BLOCKED_NO_LOCAL_ACCESS
 GODOT_RUN_BLOCKED_NO_LOCAL_ACCESS
 ```
-
-이 환경에서는 사용자 Windows checkout에 직접 접근할 수 없으므로 merged local main과 실제 Project Play 완료를 주장하지 않는다.

--- a/docs/planning/CANON_SYNC_STATE.json
+++ b/docs/planning/CANON_SYNC_STATE.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 18,
+  "schema_version": 19,
   "policy_id": "GM-CANON-SYNC-01",
   "project": "GRIMOIRE: 세계를 다시 쓰는 법",
   "repository": "alsdmlals4-eng/GRIMOIRE-",
@@ -11,15 +11,17 @@
     "binding_path": "docs/contracts/GRIMOIRE_PROJECT_CONTRACT_V4_4_BINDING.md",
     "status": "ACTIVE_MERGED_MAIN"
   },
+  "project_main_authority": "LIVE_GITHUB_DEFAULT_BRANCH_READBACK",
+  "gut_formal_adoption_main": "ea46923fa78c4fe7844ab6bf422e6716a3c785ed",
+  "post_merge_canon_sync": {
+    "pull_request": 87,
+    "merge_commit": "ce01bb8caa5f1b224279d3fbf418eae29a88af7d",
+    "role": "HISTORICAL_CANON_SYNC_EVIDENCE_NOT_CURRENT_MAIN"
+  },
   "base": {
     "project_pin": "9.4.3",
     "current_main_observed": "fa69a77a14f923a756064f6ae151d34cadb374f7",
     "pin_update": "NOT_APPROVED_NOT_PERFORMED"
-  },
-  "project_main": {
-    "sha": "ea46923fa78c4fe7844ab6bf422e6716a3c785ed",
-    "latest_merge": "PR85_GUT_FORMAL_ADOPTION",
-    "readback": "PASS"
   },
   "runtime_main": {
     "sync_id": "GR-SYNC-20260806-03-STAR-RUNTIME-COMPLETION-MAIN",
@@ -128,5 +130,5 @@
   "entry_reconciliation": "docs/planning/CURRENT_UNRESOLVED_GATES.md",
   "unresolved_gate_file": "docs/planning/CURRENT_UNRESOLVED_GATES.md",
   "merge_authorized": false,
-  "sheet_finalization_readback": "PENDING_POST_CANON_MERGE"
+  "sheet_finalization_readback": "PENDING_LIVE_MAIN_SEMANTICS_MERGE"
 }

--- a/docs/planning/CURRENT_CONFIRMED_DECISIONS.md
+++ b/docs/planning/CURRENT_CONFIRMED_DECISIONS.md
@@ -4,8 +4,12 @@
 status: ACTIVE_CANON_V4_4_GUT_FORMALLY_ADOPTED
 active_contract: PROJECT_TOTAL_PLANNING_IMPLEMENTATION_AND_DELIVERY_INSTRUCTION_v4.4
 contract_binding_decision: GM-CONTRACT-V4-4-BINDING-01
-current_main: ea46923fa78c4fe7844ab6bf422e6716a3c785ed
+project_main_authority: LIVE_GITHUB_DEFAULT_BRANCH_READBACK
+gut_formal_adoption_main: ea46923fa78c4fe7844ab6bf422e6716a3c785ed
+post_merge_canon_sync_pr: 87
+post_merge_canon_sync_merge: ce01bb8caa5f1b224279d3fbf418eae29a88af7d
 preserved_runtime_decision: GM-STAR-CIRCUIT-MASTERY-BALANCE-01
+circuit_topology: FIVE_POINT_STAR
 product_decision: GM-SPELL-WORKFLOW-UI-V2-01
 tool_authority_decision: GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01
 gut_vendor_equivalence_decision: GM-GUT-VENDOR-CRITICAL-RUNTIME-EQUIVALENCE-01
@@ -17,6 +21,8 @@ spell_workflow_task2_authorized: false
 review_model: GPT_ROLE_SEPARATED_PLUS_USER_DECISION_AUTHORITY
 visual_audio_status: APPROVED_DIRECTION_RUNTIME_NOT_RUN_VISUAL_AUDIO_INCOMPLETE
 ```
+
+현재 `main` 자체는 저장된 SHA가 아니라 `project_main_authority: LIVE_GITHUB_DEFAULT_BRANCH_READBACK`로 판정한다. `gut_formal_adoption_main`은 PR #85의 역사 merge, `post_merge_canon_sync_merge`는 PR #87의 역사 merge다.
 
 ## GM-CONTRACT-V4-4-BINDING-01
 
@@ -48,7 +54,7 @@ gut_release: v9.7.1
 gut_pinned_commit: aeb5d4f3f7f0a6c9b5e178876d6c99b791fda605
 gut_spec_pr: 84
 gut_implementation_pr: 85
-gut_merged_main: ea46923fa78c4fe7844ab6bf422e6716a3c785ed
+gut_formal_adoption_main: ea46923fa78c4fe7844ab6bf422e6716a3c785ed
 gut_formal_adoption: GUT_FORMALLY_ADOPTED
 gut_mode: CLI_ONLY_WITHOUT_EDITOR_PLUGIN
 gut_editor_plugin: DISABLED
@@ -61,13 +67,9 @@ product_mutation_hash_gate: PASS
 higodot_zero_protected_diff_gate: PASS
 ```
 
-`GM-GUT-VENDOR-CRITICAL-RUNTIME-EQUIVALENCE-01`은 critical runtime equivalence만 승인한다. official/project GUT subtree 전체 동일성을 주장하지 않는다.
-
-HiGodot은 persistent Godot authoring의 유일한 권위이며 project vendor integrity는 아직 `HIGODOT_VENDOR_TREE_MISMATCH_OFFICIAL_V3_1_2`다.
-
 ## Google Sheet
 
-`GM-CONTRACT-V4-4-BINDING-01`의 PR #85 exact-head checkpoint는 Sheet write/readback PASS다. post-merge canon-sync PR이 병합되면 merged-main SHA를 같은 Decision ID로 최종 readback한다.
+`GM-CONTRACT-V4-4-BINDING-01`은 Sheet write/readback PASS다. 현재 main SHA는 GitHub default branch live readback으로 판정하고 Sheet에는 PR #85/#87/이후 canon semantics merge를 역사 증거로 기록한다.
 
 ## 현재 남은 Gate
 

--- a/docs/planning/CURRENT_UNRESOLVED_GATES.md
+++ b/docs/planning/CURRENT_UNRESOLVED_GATES.md
@@ -5,7 +5,10 @@ active_contract: PROJECT_TOTAL_PLANNING_IMPLEMENTATION_AND_DELIVERY_INSTRUCTION_
 contract_version: "4.4"
 contract_binding_decision_id: GM-CONTRACT-V4-4-BINDING-01
 decision_id: GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01
-current_main: ea46923fa78c4fe7844ab6bf422e6716a3c785ed
+project_main_authority: LIVE_GITHUB_DEFAULT_BRANCH_READBACK
+gut_formal_adoption_main: ea46923fa78c4fe7844ab6bf422e6716a3c785ed
+post_merge_canon_sync_pr: 87
+post_merge_canon_sync_merge: ce01bb8caa5f1b224279d3fbf418eae29a88af7d
 status: GUT_FORMAL_ADOPTION_COMPLETE_BROADER_PROJECT_BLOCKERS_REMAIN
 formal_adoption_scope: MERGED_MAIN_VERIFIED
 gut_implementation_pr: 85
@@ -18,6 +21,8 @@ spell_workflow_status: PAUSED_AFTER_TASK1_GREEN
 spell_workflow_task2_authorized: false
 review_model: GPT_ROLE_SEPARATED_PLUS_USER_DECISION_AUTHORITY
 ```
+
+현재 main은 `project_main_authority`에 따라 GitHub default branch를 live readback한다. 위 두 SHA는 PR #85/#87의 역사 merge 증거다.
 
 ## 닫힌 GUT formal-adoption Gate
 
@@ -34,22 +39,20 @@ ROLE_SEPARATED_REVIEW_P0_P1_ZERO
 PR85_MERGED_MAIN_VERIFIED
 ```
 
-`GM-GUT-VENDOR-CRITICAL-RUNTIME-EQUIVALENCE-01`에 따라 GUT full vendor-tree identity는 계속 false다. 이는 CLI/headless formal test authority의 승인된 critical-runtime equivalence와 구분한다.
-
 ## broader project blockers
 
-| ID | 상태 | 다음 해소 조건 |
-|---|---|---|
-| `HIGODOT_VENDOR_TREE_MISMATCH_OFFICIAL_V3_1_2` | `BLOCKING_BEFORE_PERSISTENT_AUTHORING` | official v3.1.2 release archive와 project vendor audit 또는 승인된 교체 |
-| `HERA_CLI_ADDON_PAIR_UNVERIFIED` | `BLOCKING_BEFORE_HERA_ACCEPTANCE_QA` | exact CLI/addon pair + localhost/token + zero-source-delta canary |
-| `WINDOWS_ANDROID_SHARED_CORE_NOT_VALIDATED` | `BLOCKING_FOR_PRODUCT_PLATFORM_COMPLETION` | 공용 core + Windows/Android export/smoke |
-| `AUDIO_VAULT_PATH_UNVERIFIED` | `BLOCKED_NO_LOCAL_ACCESS` | shared audio vault inventory |
-| `AUDIO_RIGHTS_UNVERIFIED` | `BLOCKING_FOR_AUDIO_INGESTION` | 선택 파일 권리·출처·hash |
-| `VISUAL_AUDIO_COMPLETE_NOT_PROVEN` | `BLOCKING_FOR_VISUAL_AUDIO_COMPLETION` | visual/audio requirement 승인·promotion 또는 not-required 근거 |
-| `SPELL_WORKFLOW_THREE_SCREEN_RUNTIME_NOT_RUN` | `BLOCKING_FOR_VISUAL_COMPLETION` | 실제 3-screen Godot render/interaction |
-| `CI_MUTABLE_ACTION_TAGS_OUTSIDE_PR85_SCOPE` | `BLOCKING_FOR_REPO_WIDE_SUPPLY_CHAIN_COMPLETE` | 남은 active workflows를 verified full SHA로 pin |
-| `LOCAL_SYNC_BLOCKED_NO_LOCAL_ACCESS` | `DELIVERY_BLOCKING` | 사용자 로컬 main Fetch/Pull SHA readback |
-| `GODOT_RUN_BLOCKED_NO_LOCAL_ACCESS` | `DELIVERY_BLOCKING` | merged local main clean import + Project Play smoke |
+| ID | 상태 |
+|---|---|
+| `HIGODOT_VENDOR_TREE_MISMATCH_OFFICIAL_V3_1_2` | `BLOCKING_BEFORE_PERSISTENT_AUTHORING` |
+| `HERA_CLI_ADDON_PAIR_UNVERIFIED` | `BLOCKING_BEFORE_HERA_ACCEPTANCE_QA` |
+| `WINDOWS_ANDROID_SHARED_CORE_NOT_VALIDATED` | `BLOCKING_FOR_PRODUCT_PLATFORM_COMPLETION` |
+| `AUDIO_VAULT_PATH_UNVERIFIED` | `BLOCKED_NO_LOCAL_ACCESS` |
+| `AUDIO_RIGHTS_UNVERIFIED` | `BLOCKING_FOR_AUDIO_INGESTION` |
+| `VISUAL_AUDIO_COMPLETE_NOT_PROVEN` | `BLOCKING_FOR_VISUAL_AUDIO_COMPLETION` |
+| `SPELL_WORKFLOW_THREE_SCREEN_RUNTIME_NOT_RUN` | `BLOCKING_FOR_VISUAL_COMPLETION` |
+| `CI_MUTABLE_ACTION_TAGS_OUTSIDE_PR85_SCOPE` | `BLOCKING_FOR_REPO_WIDE_SUPPLY_CHAIN_COMPLETE` |
+| `LOCAL_SYNC_BLOCKED_NO_LOCAL_ACCESS` | `DELIVERY_BLOCKING` |
+| `GODOT_RUN_BLOCKED_NO_LOCAL_ACCESS` | `DELIVERY_BLOCKING` |
 
 ## Asset Vault
 

--- a/docs/planning/GRILL_ME_BATCH_MERGE_STATE.json
+++ b/docs/planning/GRILL_ME_BATCH_MERGE_STATE.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 21,
+  "schema_version": 22,
   "policy_decision_id": "GM-GRILL-MERGE-CADENCE-01",
   "status": "USER_APPROVED_ACTIVE",
   "repository": "alsdmlals4-eng/GRIMOIRE-",
@@ -26,7 +26,10 @@
     "gate": "BLOCKED_BY_BROADER_PROJECT_GATES",
     "latest_approved_decision_id": "GM-CONTRACT-V4-4-BINDING-01",
     "default_branch": "main",
-    "project_main": "ea46923fa78c4fe7844ab6bf422e6716a3c785ed",
+    "project_main_authority": "LIVE_GITHUB_DEFAULT_BRANCH_READBACK",
+    "gut_formal_adoption_main": "ea46923fa78c4fe7844ab6bf422e6716a3c785ed",
+    "post_merge_canon_sync_pr": 87,
+    "post_merge_canon_sync_merge": "ce01bb8caa5f1b224279d3fbf418eae29a88af7d",
     "gut_formal_adoption": "GUT_FORMALLY_ADOPTED",
     "gut_implementation_pull_request": 85,
     "gut_exact_head": "fc178bdc7a3e12faf4ae7ae78fd1f92dd2735849",

--- a/tests/test_v4_4_live_main_readback_semantics.py
+++ b/tests/test_v4_4_live_main_readback_semantics.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GUT_FORMAL_ADOPTION_MAIN = "ea46923fa78c4fe7844ab6bf422e6716a3c785ed"
+POST_MERGE_CANON_SYNC_MAIN = "ce01bb8caa5f1b224279d3fbf418eae29a88af7d"
+CURRENT_DOCS = [
+    ROOT / "START_HERE.md",
+    ROOT / "docs/ACTIVE_CONTEXT.md",
+    ROOT / "docs/DEVELOPMENT_GATES.md",
+    ROOT / "docs/planning/CURRENT_CONFIRMED_DECISIONS.md",
+    ROOT / "docs/planning/CURRENT_UNRESOLVED_GATES.md",
+]
+CANON = ROOT / "docs/planning/CANON_SYNC_STATE.json"
+GRILL = ROOT / "docs/planning/GRILL_ME_BATCH_MERGE_STATE.json"
+
+
+class V44LiveMainReadbackSemanticsTests(unittest.TestCase):
+    def test_current_docs_use_live_github_main_authority_not_a_frozen_current_sha(self) -> None:
+        for path in CURRENT_DOCS:
+            text = path.read_text(encoding="utf-8")
+            self.assertIn("project_main_authority: LIVE_GITHUB_DEFAULT_BRANCH_READBACK", text, str(path))
+            self.assertIn(f"gut_formal_adoption_main: {GUT_FORMAL_ADOPTION_MAIN}", text, str(path))
+            self.assertIn(f"post_merge_canon_sync_merge: {POST_MERGE_CANON_SYNC_MAIN}", text, str(path))
+            self.assertNotIn(f"current_main: {GUT_FORMAL_ADOPTION_MAIN}", text, str(path))
+            self.assertNotIn(f"project_main: {GUT_FORMAL_ADOPTION_MAIN}", text, str(path))
+
+    def test_machine_state_names_historical_merge_shas_by_role(self) -> None:
+        canon = json.loads(CANON.read_text(encoding="utf-8"))
+        grill = json.loads(GRILL.read_text(encoding="utf-8"))
+
+        self.assertEqual("LIVE_GITHUB_DEFAULT_BRANCH_READBACK", canon["project_main_authority"])
+        self.assertNotIn("project_main", canon)
+        self.assertEqual(GUT_FORMAL_ADOPTION_MAIN, canon["gut_formal_adoption_main"])
+        self.assertEqual(87, canon["post_merge_canon_sync"]["pull_request"])
+        self.assertEqual(POST_MERGE_CANON_SYNC_MAIN, canon["post_merge_canon_sync"]["merge_commit"])
+
+        work = grill["current_work"]
+        self.assertEqual("LIVE_GITHUB_DEFAULT_BRANCH_READBACK", work["project_main_authority"])
+        self.assertNotIn("project_main", work)
+        self.assertEqual(GUT_FORMAL_ADOPTION_MAIN, work["gut_formal_adoption_main"])
+        self.assertEqual(87, work["post_merge_canon_sync_pr"])
+        self.assertEqual(POST_MERGE_CANON_SYNC_MAIN, work["post_merge_canon_sync_merge"])
+
+    def test_protected_decisions_and_broader_blockers_remain_unchanged(self) -> None:
+        combined = "\n".join(path.read_text(encoding="utf-8") for path in CURRENT_DOCS)
+        for token in (
+            "GM-STAR-CIRCUIT-MASTERY-BALANCE-01",
+            "FIVE_POINT_STAR",
+            "GUT_FORMALLY_ADOPTED",
+            "spell_workflow_task2_authorized: false",
+            "HIGODOT_VENDOR_TREE_MISMATCH_OFFICIAL_V3_1_2",
+            "HERA_CLI_ADDON_PAIR_UNVERIFIED",
+            "WINDOWS_ANDROID_SHARED_CORE_NOT_VALIDATED",
+            "VISUAL_AUDIO_COMPLETE_NOT_PROVEN",
+            "LOCAL_SYNC_BLOCKED_NO_LOCAL_ACCESS",
+            "GODOT_RUN_BLOCKED_NO_LOCAL_ACCESS",
+        ):
+            self.assertIn(token, combined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_v4_4_post_merge_canon_sync.py
+++ b/tests/test_v4_4_post_merge_canon_sync.py
@@ -6,7 +6,8 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-MERGED_MAIN = "ea46923fa78c4fe7844ab6bf422e6716a3c785ed"
+GUT_FORMAL_ADOPTION_MAIN = "ea46923fa78c4fe7844ab6bf422e6716a3c785ed"
+POST_MERGE_CANON_SYNC_MAIN = "ce01bb8caa5f1b224279d3fbf418eae29a88af7d"
 STATE = ROOT / "docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE.json"
 CURRENT_DOCS = [
     ROOT / "START_HERE.md",
@@ -24,7 +25,7 @@ class V44PostMergeCanonSyncTests(unittest.TestCase):
         data = json.loads(STATE.read_text(encoding="utf-8"))
         self.assertEqual("4.4", data["contract"]["version"])
         self.assertEqual("ACTIVE_MERGED_MAIN", data["contract"]["status"])
-        self.assertEqual(MERGED_MAIN, data["source_main"])
+        self.assertEqual(GUT_FORMAL_ADOPTION_MAIN, data["source_main"])
         self.assertEqual("GUT_FORMALLY_ADOPTED_MERGED_MAIN_VERIFIED", data["status"])
         self.assertEqual("FORMALLY_ADOPTED_ACTIVE", data["gut"]["current_consumption"])
         self.assertEqual("MERGED_MAIN_VERIFIED", data["gut"]["implementation_branch_status"])
@@ -38,26 +39,32 @@ class V44PostMergeCanonSyncTests(unittest.TestCase):
         self.assertTrue(data["claims"]["gut_github_actions_pass"])
         self.assertFalse(data["claims"]["spell_workflow_task2_authorized"])
 
-    def test_current_cold_start_docs_point_to_v4_4_merged_state(self) -> None:
+    def test_current_cold_start_docs_keep_historical_merge_roles_and_live_main_authority(self) -> None:
         for path in CURRENT_DOCS:
             text = path.read_text(encoding="utf-8")
             self.assertIn("v4.4", text, str(path))
             self.assertIn("GM-CONTRACT-V4-4-BINDING-01", text, str(path))
-            self.assertIn(MERGED_MAIN, text, str(path))
+            self.assertIn("project_main_authority: LIVE_GITHUB_DEFAULT_BRANCH_READBACK", text, str(path))
+            self.assertIn(f"gut_formal_adoption_main: {GUT_FORMAL_ADOPTION_MAIN}", text, str(path))
+            self.assertIn(f"post_merge_canon_sync_merge: {POST_MERGE_CANON_SYNC_MAIN}", text, str(path))
             self.assertIn("GUT_FORMALLY_ADOPTED", text, str(path))
             self.assertIn("spell_workflow_task2_authorized: false", text, str(path))
             self.assertNotIn("BLOCKED_BY_GUT_ADOPTION_SPEC", text, str(path))
 
-    def test_machine_current_state_surfaces_are_v4_4_post_merge(self) -> None:
+    def test_machine_current_state_surfaces_use_live_main_authority(self) -> None:
         canon = json.loads(CANON.read_text(encoding="utf-8"))
         grill = json.loads(GRILL.read_text(encoding="utf-8"))
         self.assertEqual("4.4", canon["active_contract"]["version"])
-        self.assertEqual(MERGED_MAIN, canon["project_main"]["sha"])
+        self.assertEqual("LIVE_GITHUB_DEFAULT_BRANCH_READBACK", canon["project_main_authority"])
+        self.assertEqual(GUT_FORMAL_ADOPTION_MAIN, canon["gut_formal_adoption_main"])
+        self.assertEqual(POST_MERGE_CANON_SYNC_MAIN, canon["post_merge_canon_sync"]["merge_commit"])
         self.assertEqual("GUT_FORMALLY_ADOPTED_MERGED_MAIN_VERIFIED", canon["tool_authority"]["status"])
         self.assertFalse(canon["spell_workflow_main"]["spell_workflow_task2_authorized"])
         self.assertEqual("4.4", grill["active_contract"]["version"])
         self.assertEqual(0, grill["current_count"])
-        self.assertEqual(MERGED_MAIN, grill["current_work"]["project_main"])
+        self.assertEqual("LIVE_GITHUB_DEFAULT_BRANCH_READBACK", grill["current_work"]["project_main_authority"])
+        self.assertEqual(GUT_FORMAL_ADOPTION_MAIN, grill["current_work"]["gut_formal_adoption_main"])
+        self.assertEqual(POST_MERGE_CANON_SYNC_MAIN, grill["current_work"]["post_merge_canon_sync_merge"])
         self.assertEqual("GUT_FORMALLY_ADOPTED", grill["current_work"]["gut_formal_adoption"])
         self.assertFalse(grill["current_work"]["spell_workflow_task2_authorized"])
 


### PR DESCRIPTION
Final v4.4 canon-semantics cleanup after PR #87. This removes self-stale `current_main/project_main` SHA semantics from current-state canon and instead makes the live GitHub default-branch readback authoritative, while retaining historical PR85/PR87 merge SHAs by role.

Scope: docs/JSON/tests/workflow only. No product/Godot authoring changes. RED test first: `tests/test_v4_4_live_main_readback_semantics.py`.