### PR TITLE
Sync visual/platform merged-main Sheet readback into current canon

### DIFF
--- a/docs/planning/CANON_SYNC_STATE.json
+++ b/docs/planning/CANON_SYNC_STATE.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 23,
+  "schema_version": 24,
   "policy_id": "GM-CANON-SYNC-01",
   "project": "GRIMOIRE: 세계를 다시 쓰는 법",
   "repository": "alsdmlals4-eng/GRIMOIRE-",
@@ -24,6 +24,7 @@
     "current_main_observation_role": "V4_4_BINDING_HISTORICAL_OBSERVATION",
     "latest_main_observed_pr91": "eee98a930219065e30b4d7d14d99d5ac7db44c60",
     "latest_main_observed_visual_platform_gate": "a912cc001ff4d4e3415fb4b4931723c49eb08d9a",
+    "latest_main_observed_premerge": "cf4c7a60c5b31b042043f91b268f381372fec69a",
     "latest_observation_role": "LIVE_BASE_MAIN_READBACK_NOT_ADOPTED",
     "pin_update": "NOT_APPROVED_NOT_PERFORMED"
   },
@@ -142,13 +143,14 @@
     "sync_id": "GR-SYNC-20260808-07-VISUAL-PLATFORM-GATE-SEQUENCING",
     "decision_id": "GM-SPELL-WORKFLOW-UI-V2-01",
     "status": "WINDOWS_ANDROID_SHARED_CORE_STRUCTURAL_PASS",
+    "merged_main": "5016bd090ad09892d36a8b751c7a9649868b76d5",
     "evidence": "docs/validation/WINDOWS_ANDROID_SHARED_CORE_STRUCTURAL.json",
     "scope": "STRUCTURAL_ARCHITECTURE_AND_HOST_CONTRACT_ONLY",
     "windows_export": "NOT_RUN",
     "android_export": "NOT_RUN",
     "android_device": "NOT_RUN",
     "performance": "NOT_RUN",
-    "sheet_sync": "PENDING_PR93_MERGE"
+    "sheet_sync": "SHEET_WRITE_READBACK_PASS"
   },
   "ci_supply_chain": {
     "decision_id": "GM-PUBLIC-REPO-FREE-GITHUB-ACTIONS-01",

--- a/docs/planning/CURRENT_CONFIRMED_DECISIONS.md
+++ b/docs/planning/CURRENT_CONFIRMED_DECISIONS.md
@@ -29,11 +29,13 @@ windows_android_shared_core: WINDOWS_ANDROID_SHARED_CORE_STRUCTURAL_PASS
 visual_automated_layout_baseline: VISUAL_AUTOMATED_LAYOUT_BASELINE_PASS
 three_screen_runtime: THREE_SCREEN_RUNTIME_AWAITING_TASKS_2_9
 three_screen_runtime_gate_role: SPELL_WORKFLOW_THREE_SCREEN_RUNTIME_POST_IMPLEMENTATION_ACCEPTANCE
+visual_platform_merged_main: 5016bd090ad09892d36a8b751c7a9649868b76d5
+visual_platform_sheet_sync: SHEET_WRITE_READBACK_PASS
 review_model: GPT_ROLE_SEPARATED_PLUS_USER_DECISION_AUTHORITY
 visual_audio_status: APPROVED_DIRECTION_RUNTIME_NOT_RUN_VISUAL_AUDIO_INCOMPLETE
 ```
 
-현재 `main` 자체는 저장된 SHA가 아니라 `project_main_authority: LIVE_GITHUB_DEFAULT_BRANCH_READBACK`로 판정한다. `gut_formal_adoption_main`은 PR #85의 역사 merge, `post_merge_canon_sync_merge`는 PR #87의 역사 merge, `hera_merged_main`은 PR #91 Hera Gate가 처음 merged-main에 들어간 증거다.
+현재 `main` 자체는 저장된 SHA가 아니라 `project_main_authority: LIVE_GITHUB_DEFAULT_BRANCH_READBACK`로 판정한다. `gut_formal_adoption_main`은 PR #85의 역사 merge, `post_merge_canon_sync_merge`는 PR #87의 역사 merge, `hera_merged_main`은 PR #91 Hera Gate가 처음 merged-main에 들어간 증거, `visual_platform_merged_main`은 PR #93 visual/platform Gate가 처음 merged-main에 들어간 역사 증거다.
 
 ## GM-CONTRACT-V4-4-BINDING-01
 
@@ -47,7 +49,8 @@ godot_project_path: C:/Users/user/Documents/GitHub/Ninza/GRIMOIRE-
 project_google_sheet: 19FftrZ4WzB-CXa9Q-y25iKMhmEs1Ip4Ea3ramf2xKqM
 base_binding_main_observed: fa69a77a14f923a756064f6ae151d34cadb374f7
 base_latest_main_observed_pr91: eee98a930219065e30b4d7d14d99d5ac7db44c60
-base_latest_main_observed_visual_platform_gate: a912cc001ff4d4e3415fb4b4931723c49eb08d9a
+base_main_observed_visual_platform_entry: a912cc001ff4d4e3415fb4b4931723c49eb08d9a
+base_latest_main_observed_premerge: cf4c7a60c5b31b042043f91b268f381372fec69a
 base_release_pin: 9.4.3
 base_pin_update: NOT_APPROVED_NOT_PERFORMED
 codex_handoff: NOT_REQUESTED
@@ -70,6 +73,8 @@ shared_core_evidence: docs/validation/WINDOWS_ANDROID_SHARED_CORE_STRUCTURAL.jso
 visual_automated_layout_baseline: VISUAL_AUTOMATED_LAYOUT_BASELINE_PASS
 three_screen_runtime: THREE_SCREEN_RUNTIME_AWAITING_TASKS_2_9
 three_screen_runtime_gate_role: SPELL_WORKFLOW_THREE_SCREEN_RUNTIME_POST_IMPLEMENTATION_ACCEPTANCE
+merged_main: 5016bd090ad09892d36a8b751c7a9649868b76d5
+sheet_sync: SHEET_WRITE_READBACK_PASS
 windows_export: NOT_RUN
 android_export: NOT_RUN
 android_device: NOT_RUN
@@ -126,7 +131,7 @@ hera_sheet_sync: SHEET_WRITE_READBACK_PASS
 
 HiGodot의 과거 mismatch는 official `plugin/` wrapper와 project plugin subtree를 비교한 scope 오류로 교정됐다. GUT의 full vendor-tree mismatch/critical-runtime equivalence는 별도 판정으로 그대로다. Hera canary는 임시 Godot 프로젝트에서 official CLI와 exact addon pair를 검증했고 persistent GRIMOIRE source authoring 권위를 획득하지 않는다.
 
-최신 Base `main@a912cc001...`에서 재확인한 current toolchain/PC·Android 계약은 Hera exact pair·localhost-only·shared token·persistent write 금지·source-delta `NONE`, 그리고 shared core/platform adapter 분리를 유지한다. GRIMOIRE Base release pin 9.4.3은 갱신되지 않았다.
+최신 Base `main@cf4c7a60...`에서 재확인한 current toolchain/PC·Android 계약은 Hera exact pair·localhost-only·shared token·persistent write 금지·source-delta `NONE`, 그리고 shared core/platform adapter 분리를 유지한다. GRIMOIRE Base release pin 9.4.3은 갱신되지 않았다.
 
 ## GM-PUBLIC-REPO-FREE-GITHUB-ACTIONS-01
 
@@ -141,9 +146,9 @@ normal_pr_gate: Validate Godot Authoring and GUT Authority Gate
 
 ## Google Sheet
 
-`GM-CONTRACT-V4-4-BINDING-01`과 `GM-PUBLIC-REPO-FREE-GITHUB-ACTIONS-01`은 Sheet write/readback PASS다. HiGodot 교정과 Hera exact-pair 결과는 동일 `GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01` 아래에서 동기화됐고, Hub row2·Decision row69·Audit row76·History row113의 최종 readback은 `SHEET_WRITE_READBACK_PASS`다. Hera merged-main 증거는 `a35baed94fe064e57529ffee7b8c48e14ac5e1bb`이다.
+`GM-CONTRACT-V4-4-BINDING-01`과 `GM-PUBLIC-REPO-FREE-GITHUB-ACTIONS-01`은 Sheet write/readback PASS다. HiGodot 교정과 Hera exact-pair 결과는 동일 `GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01` 아래에서 동기화돼 있다.
 
-이번 visual/platform sequencing 결과는 PR #93 merged-main readback 후 동일 제품 Decision ID `GM-SPELL-WORKFLOW-UI-V2-01`로 Sheet에 최종 동기화한다. 그 전에는 이 새 결과의 Sheet 완료를 주장하지 않는다.
+Visual/platform sequencing 결과는 동일 `GM-SPELL-WORKFLOW-UI-V2-01`로 Hub row2·Decision row68·Audit row79·ImageReview row6·History row115에 동기화됐고 두 번의 readback으로 `SHEET_WRITE_READBACK_PASS`를 확인했다. PR #93 merged-main 증거는 `5016bd090ad09892d36a8b751c7a9649868b76d5`다.
 
 ## 현재 남은 Gate
 

--- a/docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE.json
+++ b/docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 14,
+  "schema_version": 15,
   "contract": {
     "name": "PROJECT_TOTAL_PLANNING_IMPLEMENTATION_AND_DELIVERY_INSTRUCTION",
     "version": "4.4",
@@ -14,6 +14,7 @@
   "base_policy_observation": {
     "current_main": "fa69a77a14f923a756064f6ae151d34cadb374f7",
     "latest_main_observed": "a912cc001ff4d4e3415fb4b4931723c49eb08d9a",
+    "latest_main_observed_premerge": "cf4c7a60c5b31b042043f91b268f381372fec69a",
     "project_pin": "9.4.3",
     "pin_update": "NOT_APPROVED_NOT_PERFORMED"
   },
@@ -143,6 +144,7 @@
     "decision_id": "GM-SPELL-WORKFLOW-UI-V2-01",
     "sync_id": "GR-SYNC-20260808-07-VISUAL-PLATFORM-GATE-SEQUENCING",
     "status": "WINDOWS_ANDROID_SHARED_CORE_STRUCTURAL_PASS",
+    "merged_main": "5016bd090ad09892d36a8b751c7a9649868b76d5",
     "evidence": "docs/validation/WINDOWS_ANDROID_SHARED_CORE_STRUCTURAL.json",
     "windows_export": "NOT_RUN",
     "android_export": "NOT_RUN",
@@ -161,12 +163,12 @@
   },
   "sheet_sync": {
     "spreadsheet_id": "19FftrZ4WzB-CXa9Q-y25iKMhmEs1Ip4Ea3ramf2xKqM",
-    "sync_id": "GR-SYNC-20260808-05-HERA-V1-EXACT-PAIR",
+    "sync_id": "GR-SYNC-20260808-07-VISUAL-PLATFORM-GATE-SEQUENCING",
     "write": "SHEET_WRITE_READBACK_PASS",
     "readback": "SHEET_WRITE_READBACK_PASS",
     "higodot_integrity_sync": "PASS",
     "hera_exact_pair_sync": "SHEET_WRITE_READBACK_PASS",
-    "visual_platform_gate_sync": "PENDING_PR93_MERGE"
+    "visual_platform_gate_sync": "SHEET_WRITE_READBACK_PASS"
   },
   "validation": {
     "actions_mode": "PUBLIC_REPO_STANDARD_GITHUB_HOSTED",

--- a/docs/planning/GRILL_ME_BATCH_MERGE_STATE.json
+++ b/docs/planning/GRILL_ME_BATCH_MERGE_STATE.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 25,
+  "schema_version": 26,
   "policy_decision_id": "GM-GRILL-MERGE-CADENCE-01",
   "status": "USER_APPROVED_ACTIVE",
   "repository": "alsdmlals4-eng/GRIMOIRE-",
@@ -22,7 +22,7 @@
     "pending_decision_ids": []
   },
   "current_work": {
-    "status": "VISUAL_PLATFORM_GATE_SEQUENCING_STRUCTURAL_PASS_PENDING_PR93",
+    "status": "VISUAL_PLATFORM_GATE_SEQUENCING_STRUCTURAL_PASS_MERGED_SHEET_SYNCED",
     "gate": "READY_FOR_HIGODOT_AUTHORING_WITH_POST_IMPLEMENTATION_ACCEPTANCE",
     "latest_approved_decision_id": "GM-SPELL-WORKFLOW-UI-V2-01",
     "default_branch": "main",
@@ -52,12 +52,13 @@
     "visual_automated_layout_baseline": "VISUAL_AUTOMATED_LAYOUT_BASELINE_PASS",
     "three_screen_runtime": "THREE_SCREEN_RUNTIME_AWAITING_TASKS_2_9",
     "three_screen_runtime_gate_role": "SPELL_WORKFLOW_THREE_SCREEN_RUNTIME_POST_IMPLEMENTATION_ACCEPTANCE",
+    "visual_platform_merged_main": "5016bd090ad09892d36a8b751c7a9649868b76d5",
     "review_model": "GPT_ROLE_SEPARATED_PLUS_USER_DECISION_AUTHORITY",
     "visual_audio_status": "APPROVED_DIRECTION_RUNTIME_NOT_RUN_VISUAL_AUDIO_INCOMPLETE",
     "audio_vault": "BLOCKED_UNVERIFIED",
     "sheet_write": "SHEET_WRITE_READBACK_PASS",
     "sheet_readback": "SHEET_WRITE_READBACK_PASS",
-    "visual_platform_sheet_sync": "PENDING_PR93_MERGE",
+    "visual_platform_sheet_sync": "SHEET_WRITE_READBACK_PASS",
     "merge_authorized": true,
     "next_priority": "HIGODOT_TASK2_AUTHORING_THEN_THREE_SCREEN_ACCEPTANCE"
   },
@@ -67,6 +68,7 @@
     "current_main_observation_role": "V4_4_BINDING_HISTORICAL_OBSERVATION",
     "latest_main_observed_pr91": "eee98a930219065e30b4d7d14d99d5ac7db44c60",
     "latest_main_observed_visual_platform_gate": "a912cc001ff4d4e3415fb4b4931723c49eb08d9a",
+    "latest_main_observed_premerge": "cf4c7a60c5b31b042043f91b268f381372fec69a",
     "latest_observation_role": "LIVE_BASE_MAIN_READBACK_NOT_ADOPTED",
     "pin_update": "NOT_APPROVED_NOT_PERFORMED"
   },

--- a/docs/validation/WINDOWS_ANDROID_SHARED_CORE_STRUCTURAL.json
+++ b/docs/validation/WINDOWS_ANDROID_SHARED_CORE_STRUCTURAL.json
@@ -5,6 +5,7 @@
   "decision_id": "GM-SPELL-WORKFLOW-UI-V2-01",
   "project": "GRIMOIRE: 세계를 다시 쓰는 법",
   "baseline_main": "5ca877a392373211c0fc397e815310f26bb80c02",
+  "merged_main": "5016bd090ad09892d36a8b751c7a9649868b76d5",
   "base_release_pin": "9.4.3",
   "base_main_observed_at_entry": "a912cc001ff4d4e3415fb4b4931723c49eb08d9a",
   "base_latest_main_observed_premerge": "cf4c7a60c5b31b042043f91b268f381372fec69a",
@@ -78,6 +79,6 @@
     "p1": 0,
     "review_threads": 0,
     "protected_godot_product_source_delta": "NONE",
-    "sheet_sync": "PENDING_MERGED_MAIN"
+    "sheet_sync": "SHEET_WRITE_READBACK_PASS"
   }
 }

--- a/tests/test_visual_platform_gate_sequencing.py
+++ b/tests/test_visual_platform_gate_sequencing.py
@@ -11,6 +11,9 @@ MOBILE_ROOT = ROOT / "src/ui/mobile_safe_root.gd"
 MOBILE_TEST = ROOT / "tests/integration/test_mobile_safe_root.gd"
 UNRESOLVED = ROOT / "docs/planning/CURRENT_UNRESOLVED_GATES.md"
 CONFIRMED = ROOT / "docs/planning/CURRENT_CONFIRMED_DECISIONS.md"
+CANON = ROOT / "docs/planning/CANON_SYNC_STATE.json"
+AUTHORITY = ROOT / "docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE.json"
+GRILL = ROOT / "docs/planning/GRILL_ME_BATCH_MERGE_STATE.json"
 CURRENT = [
     ROOT / "START_HERE.md",
     ROOT / "docs/ACTIVE_CONTEXT.md",
@@ -22,6 +25,8 @@ STRUCTURAL_PASS = "WINDOWS_ANDROID_SHARED_CORE_STRUCTURAL_PASS"
 THREE_SCREEN_ROLE = "SPELL_WORKFLOW_THREE_SCREEN_RUNTIME_POST_IMPLEMENTATION_ACCEPTANCE"
 THREE_SCREEN_PENDING = "THREE_SCREEN_RUNTIME_AWAITING_TASKS_2_9"
 LAYOUT_PASS = "VISUAL_AUTOMATED_LAYOUT_BASELINE_PASS"
+SHEET_PASS = "SHEET_WRITE_READBACK_PASS"
+MERGED_MAIN = "5016bd090ad09892d36a8b751c7a9649868b76d5"
 
 
 class VisualPlatformGateSequencingTests(unittest.TestCase):
@@ -103,6 +108,25 @@ class VisualPlatformGateSequencingTests(unittest.TestCase):
         self.assertIn("python -m unittest tests.test_visual_platform_gate_sequencing -v", workflow)
         self.assertIn("actions/checkout@11d5960a326750d5838078e36cf38b85af677262", workflow)
         self.assertIn("actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065", workflow)
+
+    def test_merged_main_and_sheet_readback_are_promoted_to_current_canon(self):
+        evidence = json.loads(EVIDENCE.read_text(encoding="utf-8"))
+        canon = json.loads(CANON.read_text(encoding="utf-8"))
+        authority = json.loads(AUTHORITY.read_text(encoding="utf-8"))
+        grill = json.loads(GRILL.read_text(encoding="utf-8"))
+        confirmed = CONFIRMED.read_text(encoding="utf-8")
+
+        self.assertEqual(MERGED_MAIN, evidence["merged_main"])
+        self.assertEqual(SHEET_PASS, evidence["review"]["sheet_sync"])
+        self.assertEqual(MERGED_MAIN, canon["platform_validation"]["merged_main"])
+        self.assertEqual(SHEET_PASS, canon["platform_validation"]["sheet_sync"])
+        self.assertEqual(MERGED_MAIN, authority["platform_validation"]["merged_main"])
+        self.assertEqual(SHEET_PASS, authority["sheet_sync"]["visual_platform_gate_sync"])
+        self.assertEqual(MERGED_MAIN, grill["current_work"]["visual_platform_merged_main"])
+        self.assertEqual(SHEET_PASS, grill["current_work"]["visual_platform_sheet_sync"])
+        self.assertIn(MERGED_MAIN, confirmed)
+        self.assertIn(SHEET_PASS, confirmed)
+        self.assertNotIn("PENDING_PR93_MERGE", confirmed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Purpose
Post-merge reconciliation for `GM-SPELL-WORKFLOW-UI-V2-01` after PR #93 merged to `5016bd090ad09892d36a8b751c7a9649868b76d5` and Google Sheet Hub/Decision/Audit/ImageReview/History read back `SHEET_WRITE_READBACK_PASS`.

## TDD RED
Current branch contains only the new reconciliation assertion. It requires current GitHub canon to record:
- PR #93 merged main `5016bd090ad09892d36a8b751c7a9649868b76d5`
- visual/platform Sheet sync `SHEET_WRITE_READBACK_PASS`
- no stale `PENDING_PR93_MERGE` in current confirmed canon

The visual/platform workflow is expected to fail at this new assertion until canon is promoted.

## Boundaries
No product/addon/project.godot mutation. `spell_workflow_task2_authorized` remains false; three-screen runtime remains post-implementation acceptance; exports/device/audio/human/local completion remain unclaimed.