### PR TITLE
Sync live Godot AI 3.1.3 Sheet readback into current canon

### DIFF
--- a/.github/workflows/validate-godot-authoring-gut-authority.yml
+++ b/.github/workflows/validate-godot-authoring-gut-authority.yml
@@ -40,6 +40,8 @@ jobs:
         run: python -m unittest tests.test_higodot_v3_1_2_vendor_integrity -v
       - name: Validate HiGodot v3.1.3 current tool-authority sync
         run: python -m unittest tests.test_higodot_v3_1_3_tool_authority_sync -v
+      - name: Validate HiGodot v3.1.3 post-merge canon sync
+        run: python -m unittest tests.test_higodot_v3_1_3_post_merge_canon_sync -v
       - name: Validate Hera v1.0.0 exact-pair contract
         run: python -m unittest tests.test_hera_v1_exact_pair_contract -v
       - name: Validate Hera live-canary canon reconciliation

--- a/docs/ACTIVE_CONTEXT.md
+++ b/docs/ACTIVE_CONTEXT.md
@@ -27,6 +27,9 @@ higodot_live_v3_1_3_tracked_vendor_sync: NOT_SYNCED_NOT_CLAIMED
 higodot_live_v3_1_3_evidence: docs/validation/HIGODOT_V3_1_3_VENDOR_INTEGRITY.json
 higodot_live_mcp_session: grimoire@9cc4
 higodot_live_mcp_readiness: ready
+higodot_live_state_sync: GR-SYNC-20260809-02-HIGODOT-V313-LIVE-PLUGIN-APPROVAL
+higodot_live_state_merged_main: 8422b1f506476117c876f909f986f08b94c5a543
+higodot_live_state_sheet_sync: SHEET_WRITE_READBACK_PASS
 live_gut_plugin: USER_CONFIRMED_ENABLED
 live_hera_plugin: USER_CONFIRMED_ENABLED
 tracked_project_godot_editor_plugins: GODOT_AI_ONLY_AT_GITHUB_MAIN_READBACK
@@ -86,6 +89,8 @@ v4.4/GUT/Hera/visual-platform/HiGodot live-version readback은 위 제품 runtim
 
 ```yaml
 sync_id: GR-SYNC-20260809-02-HIGODOT-V313-LIVE-PLUGIN-APPROVAL
+pr96_merged_main: 8422b1f506476117c876f909f986f08b94c5a543
+sheet_sync: SHEET_WRITE_READBACK_PASS
 tracked_release: v3.1.2
 tracked_plugin_cfg_version: 3.1.2
 tracked_plugin_subtree: a7d1e2fe8564cc385d683ec50d15fc66e1a17a35
@@ -106,7 +111,7 @@ v3_1_3_tracked_tree_identity: NOT_SYNCED_NOT_CLAIMED
 status: LIVE_VERSION_CONFIRMED_TRACKED_VENDOR_DIVERGENCE
 ```
 
-사용자 제공 Codex/Godot AI MCP readback은 Editor의 `grimoire@9cc4` 세션이 ready이고 Godot AI가 3.1.3임을 확인했다. 그러나 GitHub `main`의 `addons/godot_ai/plugin.cfg`는 3.1.2이고 tracked subtree도 v3.1.2 exact tree다. 따라서 **live 3.1.3과 tracked 3.1.2를 별도 증거로 유지**하며 v3.1.3 tracked vendor identity PASS를 주장하지 않는다. HiGodot은 계속 sole persistent-authoring authority이며 authoring receipt Gate를 유지한다.
+사용자 제공 Codex/Godot AI MCP readback은 Editor의 `grimoire@9cc4` 세션이 ready이고 Godot AI가 3.1.3임을 확인했다. 그러나 GitHub `main`의 `addons/godot_ai/plugin.cfg`는 3.1.2이고 tracked subtree도 v3.1.2 exact tree다. 따라서 **live 3.1.3과 tracked 3.1.2를 별도 증거로 유지**하며 v3.1.3 tracked vendor identity PASS를 주장하지 않는다. PR #96 merged-main `8422b1f506476117c876f909f986f08b94c5a543`과 Sheet four-surface readback은 `SHEET_WRITE_READBACK_PASS`로 확정됐다. HiGodot은 계속 sole persistent-authoring authority이며 authoring receipt Gate를 유지한다.
 
 ## GUT 9.7.1 / Hera 1.0.0 live plugin approval readback
 
@@ -126,6 +131,7 @@ hera_authority: LIVE_QA_AND_OBSERVABILITY_ONLY
 hera_persistent_source_mutation_authorized: false
 tracked_project_godot_editor_plugins: GODOT_AI_ONLY_AT_GITHUB_MAIN_READBACK
 tracked_config_matches_live_plugin_enablement: false
+sheet_sync: SHEET_WRITE_READBACK_PASS
 ```
 
 현재 GitHub `project.godot` readback에는 `[editor_plugins]`가 `res://addons/godot_ai/plugin.cfg`만 포함한다. 따라서 GUT/Hera의 live enablement를 tracked config sync 완료로 과장하지 않는다. 이후 persistent `project.godot` 또는 Godot addon source 변경이 필요하면 HiGodot authoring 경로와 receipt Gate를 사용해야 한다.

--- a/docs/planning/CANON_SYNC_STATE.json
+++ b/docs/planning/CANON_SYNC_STATE.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 25,
+  "schema_version": 26,
   "policy_id": "GM-CANON-SYNC-01",
   "project": "GRIMOIRE: 세계를 다시 쓰는 법",
   "repository": "alsdmlals4-eng/GRIMOIRE-",
@@ -25,6 +25,7 @@
     "latest_main_observed_pr91": "eee98a930219065e30b4d7d14d99d5ac7db44c60",
     "latest_main_observed_visual_platform_gate": "a912cc001ff4d4e3415fb4b4931723c49eb08d9a",
     "latest_main_observed_premerge": "cf4c7a60c5b31b042043f91b268f381372fec69a",
+    "latest_main_observed": "2a6ced23f6d6de1fb6e0a281c7138beb03f1a13b",
     "latest_observation_role": "LIVE_BASE_MAIN_READBACK_NOT_ADOPTED",
     "pin_update": "NOT_APPROVED_NOT_PERFORMED"
   },
@@ -75,13 +76,18 @@
   },
   "tool_authority": {
     "sync_id": "GR-SYNC-20260808-04-HIGODOT-VENDOR-INTEGRITY",
+    "live_tool_state_sync_id": "GR-SYNC-20260809-02-HIGODOT-V313-LIVE-PLUGIN-APPROVAL",
     "decision_id": "GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01",
     "contract_binding_decision_id": "GM-CONTRACT-V4-4-BINDING-01",
     "design_pull_request": 83,
     "adoption_spec_pull_request": 84,
     "implementation_pull_request": 85,
     "merged_main": "ea46923fa78c4fe7844ab6bf422e6716a3c785ed",
+    "live_tool_state_pull_request": 96,
+    "live_tool_state_merged_main": "8422b1f506476117c876f909f986f08b94c5a543",
+    "live_tool_state_sheet_sync": "SHEET_WRITE_READBACK_PASS",
     "status": "GUT_FORMALLY_ADOPTED_MERGED_MAIN_VERIFIED",
+    "current_tool_sync_status": "LIVE_HIGODOT_V3_1_3_TRACKED_V3_1_2_DIVERGENCE_SHEET_READBACK_PASS",
     "review_model": "GPT_ROLE_SEPARATED_PLUS_USER_DECISION_AUTHORITY",
     "current_gate": "BROADER_PROJECT_GATES_REMAIN",
     "higodot": {
@@ -97,7 +103,24 @@
       "vendor_integrity": "PASS_EXACT_TREE_IDENTITY",
       "integrity_evidence": "docs/validation/HIGODOT_V3_1_2_VENDOR_INTEGRITY.json",
       "project_plugin_enabled": true,
-      "authoring_receipt_gate": "IMPLEMENTED_ZERO_PROTECTED_DIFF_GATE"
+      "authoring_receipt_gate": "IMPLEMENTED_ZERO_PROTECTED_DIFF_GATE",
+      "live_release": "v3.1.3",
+      "live_mcp_session": "grimoire@9cc4",
+      "live_mcp_readiness": "ready",
+      "live_version_readback": "PASS_V3_1_3",
+      "live_v3_1_3": {
+        "official_tag_commit": "22678e5f9b038d7203d6b43b0aae20a5417c500e",
+        "official_repository_tree": "053131dbd726ebd492824cea9488ffeae3f2645b",
+        "official_plugin_wrapper_tree": "8d492ca096a51cdf7f01f22acf2b7f055c592ca5",
+        "official_addons_tree": "b98da7a58dbb5decf67fa759f1ab8a0b32e6d52a",
+        "official_plugin_subtree": "94be4fb34d49243375c592e17a1021c8c6fcbcf2",
+        "project_tracked_plugin_subtree": "a7d1e2fe8564cc385d683ec50d15fc66e1a17a35",
+        "project_tracked_plugin_cfg_version": "3.1.2",
+        "tracked_vendor_synced": false,
+        "tracked_tree_identity": "NOT_SYNCED_NOT_CLAIMED",
+        "status": "LIVE_VERSION_CONFIRMED_TRACKED_VENDOR_DIVERGENCE",
+        "evidence": "docs/validation/HIGODOT_V3_1_3_VENDOR_INTEGRITY.json"
+      }
     },
     "gut": {
       "canonical_repository": "bitwes/Gut",
@@ -110,6 +133,9 @@
       "godot_compatibility": "4.7.1_RUNTIME_CI_PASS",
       "adoption_mode": "CLI_ONLY_WITHOUT_EDITOR_PLUGIN",
       "project_plugin_enabled": false,
+      "tracked_editor_plugin_enablement": "DISABLED_AT_GITHUB_MAIN_READBACK",
+      "user_plugin_approval": true,
+      "live_editor_plugin_state": "USER_CONFIRMED_ENABLED",
       "current_consumption": "GUT_FORMALLY_ADOPTED",
       "target_authority": "FORMAL_TEST_AUTHORITY",
       "formal_installation_authorized": true,
@@ -118,6 +144,15 @@
       "product_mutation_hash_gate": "PASS",
       "legacy_coverage_parity": "PASS"
     },
+    "hera": {
+      "release": "v1.0.0",
+      "role": "LIVE_QA_AND_OBSERVABILITY_ONLY",
+      "tracked_editor_plugin_enablement": "DISABLED_AT_GITHUB_MAIN_READBACK",
+      "user_plugin_approval": true,
+      "live_editor_plugin_state": "USER_CONFIRMED_ENABLED",
+      "persistent_source_mutation_authorized": false
+    },
+    "tracked_project_godot_editor_plugins": "GODOT_AI_ONLY_AT_GITHUB_MAIN_READBACK",
     "sheet_write": "PASS",
     "sheet_readback": "PASS",
     "merge_authorized": true

--- a/docs/planning/CURRENT_CONFIRMED_DECISIONS.md
+++ b/docs/planning/CURRENT_CONFIRMED_DECISIONS.md
@@ -153,6 +153,25 @@ HiGodot의 과거 mismatch는 official `plugin/` wrapper와 project plugin subtr
 
 최신 Base `main@cf4c7a60...`에서 재확인한 current toolchain/PC·Android 계약은 Hera exact pair·localhost-only·shared token·persistent write 금지·source-delta `NONE`, 그리고 shared core/platform adapter 분리를 유지한다. GRIMOIRE Base release pin 9.4.3은 갱신되지 않았다.
 
+### Live Editor/MCP tool state — 2026-08-09
+
+```yaml
+sync_id: GR-SYNC-20260809-02-HIGODOT-V313-LIVE-PLUGIN-APPROVAL
+pr96_merged_main: 8422b1f506476117c876f909f986f08b94c5a543
+base_latest_main_observed: 2a6ced23f6d6de1fb6e0a281c7138beb03f1a13b
+sheet_sync: SHEET_WRITE_READBACK_PASS
+tracked_higodot_release: v3.1.2
+tracked_higodot_plugin_subtree: a7d1e2fe8564cc385d683ec50d15fc66e1a17a35
+live_higodot_release: v3.1.3
+live_higodot_official_plugin_subtree: 94be4fb34d49243375c592e17a1021c8c6fcbcf2
+live_higodot_tracked_vendor_state: NOT_SYNCED_NOT_CLAIMED
+gut_live_editor_plugin_state: USER_CONFIRMED_ENABLED
+hera_live_editor_plugin_state: USER_CONFIRMED_ENABLED
+tracked_project_godot_editor_plugins: GODOT_AI_ONLY_AT_GITHUB_MAIN_READBACK
+```
+
+사용자가 Godot AI v3.1.3 업데이트와 GUT/Hera live plugin 활성화를 명시적으로 승인·확인했다. 이 live 상태는 기존 권위 경계를 바꾸지 않는다: HiGodot은 persistent Godot authoring의 단일 권위, GUT은 deterministic GDScript test 권위, Hera는 `LIVE_QA_AND_OBSERVABILITY_ONLY`이며 persistent source mutation은 금지된다. 또한 live Editor의 활성화와 GitHub tracked `project.godot`/vendor tree의 동기화를 같은 것으로 간주하지 않는다.
+
 ## GM-PUBLIC-REPO-FREE-GITHUB-ACTIONS-01
 
 ```yaml
@@ -171,6 +190,8 @@ normal_pr_gate: Validate Godot Authoring and GUT Authority Gate
 Visual/platform sequencing 결과는 동일 `GM-SPELL-WORKFLOW-UI-V2-01`로 Hub row2·Decision row68·Audit row79·ImageReview row6·History row115에 동기화됐고 두 번의 readback으로 `SHEET_WRITE_READBACK_PASS`를 확인했다. PR #93 merged-main 증거는 `5016bd090ad09892d36a8b751c7a9649868b76d5`다.
 
 Task 2 사용자 승인도 동일 Decision ID `GM-SPELL-WORKFLOW-UI-V2-01`로 GitHub canon에 기록하며, 이 canon-sync PR merge 후 Sheet에 동일 sync id `GR-SYNC-20260809-01-TASK2-USER-APPROVAL`로 write/readback한다.
+
+Godot AI v3.1.3 live Editor/MCP 상태와 사용자 승인된 GUT/Hera live plugin 활성화는 `GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01` / `GR-SYNC-20260809-02-HIGODOT-V313-LIVE-PLUGIN-APPROVAL`로 Sheet readback `SHEET_WRITE_READBACK_PASS`까지 확인했다. tracked HiGodot v3.1.2 exact-tree 증거와 live v3.1.3 상태는 의도적으로 구분한다.
 
 ## 현재 남은 Gate
 

--- a/docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE.json
+++ b/docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 17,
+  "schema_version": 18,
   "contract": {
     "name": "PROJECT_TOTAL_PLANNING_IMPLEMENTATION_AND_DELIVERY_INSTRUCTION",
     "version": "4.4",
@@ -10,6 +10,8 @@
   "decision_id": "GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01",
   "status": "GUT_FORMALLY_ADOPTED_MERGED_MAIN_VERIFIED",
   "current_tool_sync_status": "LIVE_HIGODOT_V3_1_3_TRACKED_V3_1_2_DIVERGENCE_RECORDED",
+  "current_tool_state_merged_main": "8422b1f506476117c876f909f986f08b94c5a543",
+  "current_tool_sync_sheet_status": "SHEET_WRITE_READBACK_PASS",
   "design_review": "USER_APPROVED_2026-08-06",
   "source_main": "ea46923fa78c4fe7844ab6bf422e6716a3c785ed",
   "base_policy_observation": {
@@ -24,6 +26,7 @@
     "model": "GPT_ROLE_SEPARATED_PLUS_USER_DECISION_AUTHORITY",
     "external_independent_reviewer": "NOT_PLANNED_SOLO_DEVELOPMENT",
     "result": "PR85_EXACT_HEAD_P0_P1_ZERO_MERGED",
+    "current_tool_sync_result": "PR96_EXACT_HEAD_APPLICABLE_CI_PASS_P0_P1_ZERO_MERGED",
     "current_sync_scope": "LIVE_HIGODOT_V3_1_3_AND_USER_APPROVED_LIVE_GUT_HERA_STATE_WITH_TRACKED_DIVERGENCE"
   },
   "higodot": {
@@ -201,11 +204,14 @@
   "sheet_sync": {
     "spreadsheet_id": "19FftrZ4WzB-CXa9Q-y25iKMhmEs1Ip4Ea3ramf2xKqM",
     "sync_id": "GR-SYNC-20260808-07-VISUAL-PLATFORM-GATE-SEQUENCING",
+    "current_tool_sync_id": "GR-SYNC-20260809-02-HIGODOT-V313-LIVE-PLUGIN-APPROVAL",
     "write": "SHEET_WRITE_READBACK_PASS",
     "readback": "SHEET_WRITE_READBACK_PASS",
     "higodot_integrity_sync": "PASS",
     "higodot_integrity_sync_scope": "TRACKED_V3_1_2",
-    "higodot_v3_1_3_live_sync": "PENDING_PR96_MERGE_AND_SHEET_READBACK",
+    "higodot_v3_1_3_live_sync": "SHEET_WRITE_READBACK_PASS",
+    "gut_hera_live_plugin_sync": "SHEET_WRITE_READBACK_PASS",
+    "current_tool_state_merged_main": "8422b1f506476117c876f909f986f08b94c5a543",
     "hera_exact_pair_sync": "SHEET_WRITE_READBACK_PASS",
     "visual_platform_gate_sync": "SHEET_WRITE_READBACK_PASS"
   },

--- a/tests/test_higodot_v3_1_3_post_merge_canon_sync.py
+++ b/tests/test_higodot_v3_1_3_post_merge_canon_sync.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+AUTHORITY = ROOT / "docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE.json"
+CANON = ROOT / "docs/planning/CANON_SYNC_STATE.json"
+DECISIONS = ROOT / "docs/planning/CURRENT_CONFIRMED_DECISIONS.md"
+ACTIVE = ROOT / "docs/ACTIVE_CONTEXT.md"
+
+DECISION = "GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01"
+SYNC = "GR-SYNC-20260809-02-HIGODOT-V313-LIVE-PLUGIN-APPROVAL"
+PR96_MAIN = "8422b1f506476117c876f909f986f08b94c5a543"
+BASE_MAIN = "2a6ced23f6d6de1fb6e0a281c7138beb03f1a13b"
+TRACKED_TREE = "a7d1e2fe8564cc385d683ec50d15fc66e1a17a35"
+LIVE_V313_TREE = "94be4fb34d49243375c592e17a1021c8c6fcbcf2"
+
+
+class HiGodotV313PostMergeCanonSyncTests(unittest.TestCase):
+    def test_authority_promotes_pr96_sheet_readback(self) -> None:
+        data = json.loads(AUTHORITY.read_text(encoding="utf-8"))
+        self.assertEqual(DECISION, data["decision_id"])
+        self.assertEqual(PR96_MAIN, data["current_tool_state_merged_main"])
+        self.assertEqual(SYNC, data["sheet_sync"]["current_tool_sync_id"])
+        self.assertEqual("SHEET_WRITE_READBACK_PASS", data["sheet_sync"]["higodot_v3_1_3_live_sync"])
+        self.assertEqual("SHEET_WRITE_READBACK_PASS", data["sheet_sync"]["gut_hera_live_plugin_sync"])
+        self.assertEqual(BASE_MAIN, data["base_policy_observation"]["latest_main_observed"])
+
+    def test_canon_records_live_vs_tracked_state_without_rewriting_history(self) -> None:
+        data = json.loads(CANON.read_text(encoding="utf-8"))
+        self.assertEqual(BASE_MAIN, data["base"]["latest_main_observed"])
+        tool = data["tool_authority"]
+        self.assertEqual(DECISION, tool["decision_id"])
+        self.assertEqual(SYNC, tool["live_tool_state_sync_id"])
+        self.assertEqual(PR96_MAIN, tool["live_tool_state_merged_main"])
+        self.assertEqual("SHEET_WRITE_READBACK_PASS", tool["live_tool_state_sheet_sync"])
+        self.assertEqual("v3.1.2", tool["higodot"]["release"])
+        self.assertEqual(TRACKED_TREE, tool["higodot"]["project_plugin_subtree"])
+        self.assertEqual("v3.1.3", tool["higodot"]["live_release"])
+        self.assertEqual(LIVE_V313_TREE, tool["higodot"]["live_v3_1_3"]["official_plugin_subtree"])
+        self.assertFalse(tool["higodot"]["live_v3_1_3"]["tracked_vendor_synced"])
+        self.assertEqual("USER_CONFIRMED_ENABLED", tool["gut"]["live_editor_plugin_state"])
+        self.assertEqual("USER_CONFIRMED_ENABLED", tool["hera"]["live_editor_plugin_state"])
+        self.assertEqual("GODOT_AI_ONLY_AT_GITHUB_MAIN_READBACK", tool["tracked_project_godot_editor_plugins"])
+
+    def test_current_decision_surfaces_record_merged_main_and_sheet_pass(self) -> None:
+        decisions = DECISIONS.read_text(encoding="utf-8")
+        active = ACTIVE.read_text(encoding="utf-8")
+        for text in (decisions, active):
+            self.assertIn(SYNC, text)
+            self.assertIn(PR96_MAIN, text)
+            self.assertIn("SHEET_WRITE_READBACK_PASS", text)
+            self.assertIn("v3.1.2", text)
+            self.assertIn("v3.1.3", text)
+            self.assertIn("NOT_SYNCED_NOT_CLAIMED", text)
+            self.assertIn("USER_CONFIRMED_ENABLED", text)
+        self.assertIn(BASE_MAIN, decisions)
+        self.assertIn(BASE_MAIN, active)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Decision: `GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01`

Purpose:
- reconcile PR #96 merged main `8422b1f506476117c876f909f986f08b94c5a543` with the verified Sheet readback for `GR-SYNC-20260809-02-HIGODOT-V313-LIVE-PLUGIN-APPROVAL`;
- preserve tracked HiGodot v3.1.2 exact-tree history while recording live Editor/MCP Godot AI v3.1.3, live user-approved GUT/Hera plugin state, and tracked-config divergence;
- refresh current canon only; no Godot product/addon/config mutation.

TDD RED: this PR begins with a new current-canon contract test before canon promotion. The authority workflow is expected to fail until current canon records PR96 merged-main and Sheet `SHEET_WRITE_READBACK_PASS`.