### PR TITLE
Keep Task3 entry gate future-compatible

### DIFF
--- a/tests/test_task3_continuous_entry_canon.py
+++ b/tests/test_task3_continuous_entry_canon.py
@@ -57,9 +57,10 @@ class Task3ContinuousEntryCanonTests(unittest.TestCase):
         for token in (SYNC, DECISION, "CONTINUOUS_WORK_ACTIVE", "DEFERRED_EXTERNAL_EXECUTOR"):
             self.assertIn(token, sync_text)
 
-    def test_task3_product_files_are_not_falsely_claimed_complete(self) -> None:
-        self.assertFalse((ROOT / "src/core/spells/prepared_spell.gd").exists())
-        self.assertFalse((ROOT / "src/core/spells/prepared_spell_inventory.gd").exists())
+    def test_entry_sync_records_that_pr101_itself_had_no_product_mutation(self) -> None:
+        sync_text = (ROOT / SYNC_DOC).read_text(encoding="utf-8")
+        self.assertIn("product_mutation_in_this_sync: NONE", sync_text)
+        self.assertIn("Task 3 product files are not created by this sync", sync_text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Decision: `GM-SPELL-WORKFLOW-UI-V2-01`

Follow-up to sync `GR-SYNC-20260809-08-SPELL-WORKFLOW-TASK3-CONTINUOUS-ENTRY`.

Adversarial post-merge review found a P1 in the permanent planning test added by PR #101: it asserted that Task3 product files must remain absent forever. That historical-entry assertion would incorrectly fail the legitimate future HiGodot Task3 implementation.

Fix:
- replace future filesystem-absence assertions with assertions that the historical sync08 checkpoint itself records `product_mutation_in_this_sync: NONE` and that Task3 product files were not created by that sync;
- preserve all existing Task3 readiness / HiGodot receipt authority checks.

Exact head: `9b37606cd480b8d8e26033d550c4bb948e79969d`

Exact-head validation:
- planning `31315138346`: PASS, including adversarial-gate PASS
- Godot Authoring/GUT Authority `31315138341`: PASS
- Star Physical `31315138325`: PASS
- Star Runtime `31315138342`: PASS
- Godot toolchain `31315138327`: PASS
- GUT Formal Adoption `31315138330`: expected SKIPPED

Review:
- changed files: 1 (`tests/test_task3_continuous_entry_canon.py`)
- protected Godot product/addon/config delta: NONE
- unresolved review threads: 0
- P0/P1 after fix: 0
- no Task3 product implementation is claimed by this PR.