### PR TITLE
Harden Task3 immutable inventory contract

### DIFF
--- a/docs/planning/handoffs/2026-08-09-task3-higodot-execution-packet.md
+++ b/docs/planning/handoffs/2026-08-09-task3-higodot-execution-packet.md
@@ -85,20 +85,22 @@ All public reads return deep copies. `serialize()` emits deterministically sorte
 
 ### 3A. State-model hardening — `IMMUTABLE_PAYLOAD_INVENTORY_LIFECYCLE`
 
-This section resolves an implementation ambiguity without changing the approved product outcome.
+This section resolves implementation ambiguities without changing the approved product outcome.
 
 - `PreparedSpell payload remains immutable after creation`: the deep-copied spell payload stored at preparation time is never rewritten in place to represent later use.
 - `READY` versus `USED` is inventory-owned lifecycle state. `_use_transaction_by_spell_id` is the usage authority; it must not be replaced by mutating caller-owned or stored prepared-spell payload data.
 - A public `spell(spell_id)` read derives `USED` when `_use_transaction_by_spell_id` contains that spell ID, otherwise derives `READY`, and returns only a deep copy. The stored immutable payload remains the preparation-time value.
+- The serialized immutable spell payload must retain `status: READY`. `USED` is a derived public lifecycle status and must never be persisted by rewriting the immutable base payload.
 - `add_once()` rejects an empty `preparation_transaction_id` with no mutation. `mark_used_once()` rejects an empty `use_transaction_id` with no mutation. Empty `spell_id` remains invalid at `PreparedSpell.create()` and must not enter inventory state.
 - Retrying the same preparation transaction is idempotent even if the caller supplies a different candidate spell: the same preparation transaction with a different candidate spell returns the original first add result and does not replace or duplicate the stored spell.
 - A different preparation transaction attempting to reuse an existing `spell_id` fails closed and must not alter either transaction index or spell state.
 - Repeating the same `use_transaction_id` for the same spell returns the original first use outcome; a different use transaction after consumption returns `SPELL_ALREADY_USED`.
+- `USE_TRANSACTION_SINGLE_OWNER`: one non-empty use transaction may belong to exactly one spell in an inventory. The same `use_transaction_id` cannot be rebound to a different spell. If a transaction already belongs to another spell, `mark_used_once()` fails closed with `USE_TRANSACTION_CONFLICT` and leaves all inventory state unchanged. With the planned three-dictionary design, checking existing use-transaction values is sufficient; do not add a fourth persistent index solely for this rule.
 - `serialize()` must make all three indexes reconstructable and deterministic. Sort spell records by string form of `spell_id`, preparation mappings by string form of transaction ID, and use mappings by string form of `spell_id`; serialize deep copies only.
-- `restore()` is validate-then-swap: validate the entire candidate state in temporary structures before replacing live dictionaries. Any malformed type, empty identifier, duplicate/conflicting mapping, missing referenced spell, or inconsistent usage relationship returns `false` with the pre-call inventory state unchanged.
-- `restore()` must preserve the immutable-payload/inventory-lifecycle split after round-trip: restored public reads derive lifecycle status from the restored use index rather than trusting a caller-supplied mutable status override.
+- `restore()` is validate-then-swap: validate the entire candidate state in temporary structures before replacing live dictionaries. Any malformed type, empty identifier, duplicate/conflicting mapping, missing referenced spell, inconsistent usage relationship, or duplicated use transaction assigned to multiple spells returns `false` with the pre-call inventory state unchanged.
+- `restore()` rejects a serialized immutable spell payload whose base `status` is anything other than `READY`. It must preserve the immutable-payload/inventory-lifecycle split after round-trip: restored public reads derive lifecycle status from the restored use index rather than trusting a caller-supplied mutable status override.
 
-The Task 3 GDScript tests must exercise these rules in addition to the eight minimum cases above. In particular, include mutation-after-add/read checks, empty idempotency-key checks, same-preparation/different-candidate replay, malformed restore atomicity, and READY→USED derived-status round-trip.
+The Task 3 GDScript tests must exercise these rules in addition to the eight minimum cases above. In particular, include mutation-after-add/read checks, empty idempotency-key checks, same-preparation/different-candidate replay, cross-spell same-use-transaction collision, malformed restore atomicity, non-READY base-payload restore rejection, and READY→USED derived-status round-trip.
 
 ### 4. Regression verification
 

--- a/docs/planning/handoffs/2026-08-09-task3-higodot-execution-packet.md
+++ b/docs/planning/handoffs/2026-08-09-task3-higodot-execution-packet.md
@@ -83,6 +83,23 @@ _use_transaction_by_spell_id
 
 All public reads return deep copies. `serialize()` emits deterministically sorted arrays. `restore()` fails closed on malformed/conflicting state. Do not introduce Stage 3 target selection or mana mutation here.
 
+### 3A. State-model hardening — `IMMUTABLE_PAYLOAD_INVENTORY_LIFECYCLE`
+
+This section resolves an implementation ambiguity without changing the approved product outcome.
+
+- `PreparedSpell payload remains immutable after creation`: the deep-copied spell payload stored at preparation time is never rewritten in place to represent later use.
+- `READY` versus `USED` is inventory-owned lifecycle state. `_use_transaction_by_spell_id` is the usage authority; it must not be replaced by mutating caller-owned or stored prepared-spell payload data.
+- A public `spell(spell_id)` read derives `USED` when `_use_transaction_by_spell_id` contains that spell ID, otherwise derives `READY`, and returns only a deep copy. The stored immutable payload remains the preparation-time value.
+- `add_once()` rejects an empty `preparation_transaction_id` with no mutation. `mark_used_once()` rejects an empty `use_transaction_id` with no mutation. Empty `spell_id` remains invalid at `PreparedSpell.create()` and must not enter inventory state.
+- Retrying the same preparation transaction is idempotent even if the caller supplies a different candidate spell: the same preparation transaction with a different candidate spell returns the original first add result and does not replace or duplicate the stored spell.
+- A different preparation transaction attempting to reuse an existing `spell_id` fails closed and must not alter either transaction index or spell state.
+- Repeating the same `use_transaction_id` for the same spell returns the original first use outcome; a different use transaction after consumption returns `SPELL_ALREADY_USED`.
+- `serialize()` must make all three indexes reconstructable and deterministic. Sort spell records by string form of `spell_id`, preparation mappings by string form of transaction ID, and use mappings by string form of `spell_id`; serialize deep copies only.
+- `restore()` is validate-then-swap: validate the entire candidate state in temporary structures before replacing live dictionaries. Any malformed type, empty identifier, duplicate/conflicting mapping, missing referenced spell, or inconsistent usage relationship returns `false` with the pre-call inventory state unchanged.
+- `restore()` must preserve the immutable-payload/inventory-lifecycle split after round-trip: restored public reads derive lifecycle status from the restored use index rather than trusting a caller-supplied mutable status override.
+
+The Task 3 GDScript tests must exercise these rules in addition to the eight minimum cases above. In particular, include mutation-after-add/read checks, empty idempotency-key checks, same-preparation/different-candidate replay, malformed restore atomicity, and READY→USED derived-status round-trip.
+
 ### 4. Regression verification
 
 Run the full deterministic legacy/headless suite and the adopted GUT suites. Existing Task 1/2, star runtime, typed stock, reservation recovery, and exactly-once tests must stay green. Run the applicable Python contract tests as well.

--- a/tests/test_task3_continuous_entry_canon.py
+++ b/tests/test_task3_continuous_entry_canon.py
@@ -62,6 +62,22 @@ class Task3ContinuousEntryCanonTests(unittest.TestCase):
         self.assertIn("product_mutation_in_this_sync: NONE", sync_text)
         self.assertIn("Task 3 product files are not created by this sync", sync_text)
 
+    def test_executor_packet_pins_immutable_payload_and_atomic_restore_contract(self) -> None:
+        handoff_text = (ROOT / HANDOFF).read_text(encoding="utf-8")
+        for token in (
+            "IMMUTABLE_PAYLOAD_INVENTORY_LIFECYCLE",
+            "PreparedSpell payload remains immutable after creation",
+            "inventory-owned lifecycle state",
+            "empty `preparation_transaction_id`",
+            "empty `use_transaction_id`",
+            "validate-then-swap",
+            "pre-call inventory state unchanged",
+            "same preparation transaction",
+            "different candidate spell",
+            "public `spell(spell_id)` read derives `USED`",
+        ):
+            self.assertIn(token, handoff_text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_task3_continuous_entry_canon.py
+++ b/tests/test_task3_continuous_entry_canon.py
@@ -75,6 +75,9 @@ class Task3ContinuousEntryCanonTests(unittest.TestCase):
             "same preparation transaction",
             "different candidate spell",
             "public `spell(spell_id)` read derives `USED`",
+            "USE_TRANSACTION_SINGLE_OWNER",
+            "same `use_transaction_id` cannot be rebound to a different spell",
+            "serialized immutable spell payload must retain `status: READY`",
         ):
             self.assertIn(token, handoff_text)
 


### PR DESCRIPTION
## What changed
- Adds a planning-contract regression test for the already approved Task 3 execution packet.
- Hardens the executor handoff with an explicit immutable PreparedSpell payload / inventory-owned lifecycle boundary.
- Pins non-empty idempotency keys, same-preparation replay behavior, deterministic serialization, and atomic validate-then-swap restore semantics.
- Pins `USE_TRANSACTION_SINGLE_OWNER`: one use transaction cannot be rebound across different prepared spells, while serialized immutable spell payloads remain `status: READY` and public USED state is derived from inventory lifecycle state.

## Why
The Task 3 packet called PreparedSpell immutable while later Task 5 expects the spell lifecycle to become USED. It also did not explicitly prohibit cross-spell reuse of one `use_transaction_id`. Without these boundaries, a HiGodot executor could choose incompatible exactly-once implementations. This PR resolves those implementation ambiguities without changing the approved product outcome or authoring authority.

## TDD evidence
- RED #1 head `9ecda4f832f7d600075c6b392edc2972253681d4`: planning CI failed exactly because `IMMUTABLE_PAYLOAD_INVENTORY_LIFECYCLE` was absent.
- GREEN #1 head `518f06c6b6b23b225937fcacd06e4b61f9127e20`: the first contract hardening passed all applicable exact-head workflows.
- RED #2 head `4df3b195b408f16e8a48e02996db87b45af5cb3d`: planning CI failed exactly because `USE_TRANSACTION_SINGLE_OWNER` was absent.
- FINAL GREEN head `0179f8ca40f2a9fe6e5d8da21bafd23808e22301`: planning `ci-gate` + `adversarial-gate`, Star Runtime, Godot authoring/GUT authority, physical validation, and Godot 4.7.1 toolchain all PASS. GUT Formal Adoption is skipped for this docs-only diff.

## Scope boundary
The full diff is limited to the Task 3 HiGodot handoff and its Python canon test. No persistent `.gd`, scene, `project.godot`, UI, mana, Stage 3 service, or unrelated runtime file is modified.

## Authority
Decision remains `GM-SPELL-WORKFLOW-UI-V2-01`; persistent Godot authoring remains `HIGODOT_ONLY_WITH_AUTHORING_RECEIPT_GATE`. Task 3 product implementation remains `DEFERRED_EXTERNAL_EXECUTOR` until a callable HiGodot executor records `TASK3_TDD_RED` and a fresh authoring receipt.