### PR TITLE
feat: add immutable prepared spell inventory

### DIFF
--- a/artifacts/higodot/HIGODOT_AUTHORING_RECEIPT_TASK3_2026-08-09.json
+++ b/artifacts/higodot/HIGODOT_AUTHORING_RECEIPT_TASK3_2026-08-09.json
@@ -1,0 +1,77 @@
+{
+  "schema": "HIGODOT_AUTHORING_RECEIPT_V1",
+  "receipt_id": "GR-TASK3-HIGODOT-20260809-01",
+  "recorded_at": "2026-08-09T23:25:13.2199798+09:00",
+  "decision_id": "GM-SPELL-WORKFLOW-UI-V2-01",
+  "base_commit": "935d2484322f5cfb1649f089b10bc9f81bbb4bfd",
+  "result_commit": "66a5da4c527d6e161876ff01a0dde331d6d79d45",
+  "tool": {
+    "name": "Godot AI / HiGodot",
+    "godot_version": "4.7.1-stable (official)",
+    "plugin_version": "3.1.3",
+    "server_version": "3.1.3",
+    "session_id": "task3-prepared-spell-inventory@f879",
+    "project_path": "C:/Users/user/Documents/GitHub/Ninza/GRIMOIRE-/.worktrees/task3-prepared-spell-inventory/"
+  },
+  "changed_godot_artifacts": [
+    "res://src/core/spells/prepared_spell.gd",
+    "res://src/core/spells/prepared_spell.gd.uid",
+    "res://src/core/spells/prepared_spell_inventory.gd",
+    "res://src/core/spells/prepared_spell_inventory.gd.uid",
+    "res://tests/unit/test_prepared_spell_inventory.gd",
+    "res://tests/unit/test_prepared_spell_inventory.gd.uid",
+    "res://tests/test_runner.gd"
+  ],
+  "hash_evidence": {
+    "res://src/core/spells/prepared_spell.gd": {"before_sha256": "ABSENT", "after_sha256": "7A11181CDF2AB22D8264BCB000D9F2700D6D9EAE85B60A18616DDD468AD251A9"},
+    "res://src/core/spells/prepared_spell.gd.uid": {"before_sha256": "ABSENT", "after_sha256": "B21BDAB7396F2ECE839F96D8A8EED310F34B18E292DFBD087CAB46B74FFD8A5C"},
+    "res://src/core/spells/prepared_spell_inventory.gd": {"before_sha256": "ABSENT", "after_sha256": "48F692B8F766B5AA4B4EBE80879EB8D2767E6F9104B0581D5B9A54273B735847"},
+    "res://src/core/spells/prepared_spell_inventory.gd.uid": {"before_sha256": "ABSENT", "after_sha256": "5E3312B60A0F0BD37663CDE5D704CED3F7AEDF806779B7819E5BE17A77DF66F1"}
+  },
+  "operations": [
+    "script_create res://tests/unit/test_prepared_spell_inventory.gd before production implementation",
+    "script_patch res://tests/test_runner.gd to register only the Task 3 suite",
+    "TASK3_TDD_RED headless runner: two expected failures, missing PreparedSpell and PreparedSpellInventory",
+    "script_create res://src/core/spells/prepared_spell.gd and script_patch to self-path instantiate after diagnostic readback",
+    "script_create res://src/core/spells/prepared_spell_inventory.gd",
+    "filesystem scan and fresh script readback for both production scripts, the Task 3 suite, and test_runner"
+  ],
+  "readback_evidence": [
+    "PreparedSpell: 73 lines; create, from_serialized, spell_id, and serialize read back from res://.",
+    "PreparedSpellInventory: 180 lines; add_once, spell, mark_used_once, serialize, and validate-then-swap restore read back from res://.",
+    "Task 3 unit suite: 121 lines read back from res://tests/unit/.",
+    "test_runner: 68 lines read back; contains test_prepared_spell_inventory.gd."
+  ],
+  "delta_reconciliation": {
+    "status": "PROTECTED_TASK3_DELTA_COMPLETE",
+    "allowed_delta": [
+      "src/core/spells/prepared_spell.gd",
+      "src/core/spells/prepared_spell.gd.uid",
+      "src/core/spells/prepared_spell_inventory.gd",
+      "src/core/spells/prepared_spell_inventory.gd.uid",
+      "tests/unit/test_prepared_spell_inventory.gd",
+      "tests/unit/test_prepared_spell_inventory.gd.uid",
+      "tests/test_runner.gd"
+    ],
+    "restored_unrelated_editor_delta": [
+      "project.godot",
+      "addons/gut/**/*.import",
+      "addons/hera_agent_godot/assets/fonts/cormorant-italic.woff2.import",
+      "assets/art/ui/common/**/*.import",
+      "artifacts/foundation-poc/",
+      "unrelated generated .gd.uid files"
+    ],
+    "hera_source_delta": "NONE"
+  },
+  "validation": {
+    "task3_tdd_red": "RECORDED",
+    "headless_legacy_runner": "PASS: 35 suites, 1364 assertions, 0 failures",
+    "gut": "PENDING",
+    "python_contract": "PENDING",
+    "exact_head_ci": "PENDING"
+  },
+  "limitations": [
+    "Hera was not used for source mutation; it remains LIVE_QA_AND_OBSERVABILITY_ONLY.",
+    "Device, performance, accessibility, human, and full vertical-slice validation remain NOT_RUN."
+  ]
+}

--- a/artifacts/higodot/HIGODOT_AUTHORING_RECEIPT_TASK3_2026-08-09.json
+++ b/artifacts/higodot/HIGODOT_AUTHORING_RECEIPT_TASK3_2026-08-09.json
@@ -66,8 +66,8 @@
   "validation": {
     "task3_tdd_red": "RECORDED",
     "headless_legacy_runner": "PASS: 35 suites, 1364 assertions, 0 failures",
-    "gut": "PENDING",
-    "python_contract": "PENDING",
+    "gut": "PASS: GUT 9.7.1, 7 tests, 25 asserts, 0 failures",
+    "python_contract": "PASS: 16 Task 3 / HiGodot authority contract tests",
     "exact_head_ci": "PENDING"
   },
   "limitations": [

--- a/src/core/spells/prepared_spell.gd
+++ b/src/core/spells/prepared_spell.gd
@@ -1,0 +1,72 @@
+# 준비된 주문의 불변 payload 값을 보관한다.
+class_name PreparedSpell
+extends RefCounted
+
+const SELF_PATH := "res://src/core/spells/prepared_spell.gd"
+
+var _payload: Dictionary = {}
+
+
+static func create(
+    spell_id: StringName,
+    main: Dictionary,
+    auxiliaries: Array,
+    base_preview: Dictionary,
+    source_records: Array
+):
+    if String(spell_id).is_empty():
+        return null
+    if main.is_empty():
+        return null
+    if auxiliaries.size() > 5:
+        return null
+    if not base_preview.has("success_percent") or not base_preview.has("final_mana"):
+        return null
+
+    var script = load(SELF_PATH)
+    if script == null or not script.can_instantiate():
+        return null
+    var prepared = script.new()
+    prepared._payload = {
+        "spell_id": spell_id,
+        "layout": &"FIVE_POINT_STAR",
+        "main": main.duplicate(true),
+        "auxiliaries": auxiliaries.duplicate(true),
+        "base_preview": base_preview.duplicate(true),
+        "source_records": source_records.duplicate(true),
+        "status": &"READY",
+    }
+    return prepared
+
+
+static func from_serialized(payload: Dictionary):
+    if payload.get("status", StringName()) != &"READY":
+        return null
+    if not payload.has("spell_id") or not payload.has("main"):
+        return null
+    if not payload.has("auxiliaries") or not payload.has("base_preview") or not payload.has("source_records"):
+        return null
+    if typeof(payload.main) != TYPE_DICTIONARY or typeof(payload.auxiliaries) != TYPE_ARRAY:
+        return null
+    if typeof(payload.base_preview) != TYPE_DICTIONARY or typeof(payload.source_records) != TYPE_ARRAY:
+        return null
+    var prepared = create(
+        StringName(String(payload.spell_id)),
+        payload.main,
+        payload.auxiliaries,
+        payload.base_preview,
+        payload.source_records
+    )
+    if prepared == null:
+        return null
+    if payload.get("layout", StringName()) != &"FIVE_POINT_STAR":
+        return null
+    return prepared
+
+
+func spell_id() -> StringName:
+    return _payload.spell_id
+
+
+func serialize() -> Dictionary:
+    return _payload.duplicate(true)

--- a/src/core/spells/prepared_spell.gd.uid
+++ b/src/core/spells/prepared_spell.gd.uid
@@ -1,0 +1,1 @@
+uid://uyt3i7y1ekls

--- a/src/core/spells/prepared_spell_inventory.gd
+++ b/src/core/spells/prepared_spell_inventory.gd
@@ -1,0 +1,179 @@
+# 준비된 주문의 불변 payload와 정확히 한 번 사용 수명주기를 관리한다.
+class_name PreparedSpellInventory
+extends RefCounted
+
+const PREPARED_SPELL_PATH := "res://src/core/spells/prepared_spell.gd"
+
+var _spells_by_id: Dictionary = {}
+var _spell_id_by_preparation_transaction: Dictionary = {}
+var _use_transaction_by_spell_id: Dictionary = {}
+
+
+func add_once(preparation_transaction_id: StringName, spell) -> Dictionary:
+    var preparation_key := String(preparation_transaction_id)
+    if preparation_key.is_empty():
+        return {"ok": false, "code": &"PREPARATION_TRANSACTION_ID_REQUIRED"}
+    if _spell_id_by_preparation_transaction.has(preparation_key):
+        return _add_success(StringName(_spell_id_by_preparation_transaction[preparation_key]))
+
+    if spell == null or not spell.has_method("serialize"):
+        return {"ok": false, "code": &"INVALID_PREPARED_SPELL"}
+    var payload: Dictionary = spell.serialize()
+    var PreparedSpell = load(PREPARED_SPELL_PATH)
+    if PreparedSpell == null:
+        return {"ok": false, "code": &"INVALID_PREPARED_SPELL"}
+    var validated = PreparedSpell.from_serialized(payload)
+    if validated == null:
+        return {"ok": false, "code": &"INVALID_PREPARED_SPELL"}
+
+    var spell_key := String(validated.spell_id())
+    if _spells_by_id.has(spell_key):
+        return {"ok": false, "code": &"SPELL_ID_CONFLICT"}
+    _spells_by_id[spell_key] = validated.serialize().duplicate(true)
+    _spell_id_by_preparation_transaction[preparation_key] = spell_key
+    return _add_success(StringName(spell_key))
+
+
+func spell(spell_id: StringName) -> Dictionary:
+    var spell_key := String(spell_id)
+    if not _spells_by_id.has(spell_key):
+        return {}
+    var public_payload: Dictionary = _spells_by_id[spell_key].duplicate(true)
+    public_payload["status"] = &"USED" if _use_transaction_by_spell_id.has(spell_key) else &"READY"
+    return public_payload
+
+
+func mark_used_once(spell_id: StringName, use_transaction_id: StringName) -> Dictionary:
+    var spell_key := String(spell_id)
+    var use_key := String(use_transaction_id)
+    if spell_key.is_empty():
+        return {"ok": false, "code": &"SPELL_ID_REQUIRED"}
+    if use_key.is_empty():
+        return {"ok": false, "code": &"USE_TRANSACTION_ID_REQUIRED"}
+    if not _spells_by_id.has(spell_key):
+        return {"ok": false, "code": &"SPELL_NOT_FOUND"}
+
+    if _use_transaction_by_spell_id.has(spell_key):
+        if _use_transaction_by_spell_id[spell_key] == use_key:
+            return _use_success(StringName(spell_key), StringName(use_key))
+        return {"ok": false, "code": &"SPELL_ALREADY_USED"}
+
+    for owned_use_transaction in _use_transaction_by_spell_id.values():
+        if owned_use_transaction == use_key:
+            return {"ok": false, "code": &"USE_TRANSACTION_CONFLICT"}
+
+    _use_transaction_by_spell_id[spell_key] = use_key
+    return _use_success(StringName(spell_key), StringName(use_key))
+
+
+func serialize() -> Dictionary:
+    var spell_keys := _spells_by_id.keys()
+    spell_keys.sort()
+    var spells: Array = []
+    for spell_key in spell_keys:
+        spells.append({
+            "spell_id": StringName(spell_key),
+            "payload": _spells_by_id[spell_key].duplicate(true),
+        })
+
+    var preparation_keys := _spell_id_by_preparation_transaction.keys()
+    preparation_keys.sort()
+    var preparations: Array = []
+    for preparation_key in preparation_keys:
+        preparations.append({
+            "preparation_transaction_id": StringName(preparation_key),
+            "spell_id": StringName(_spell_id_by_preparation_transaction[preparation_key]),
+        })
+
+    var use_spell_keys := _use_transaction_by_spell_id.keys()
+    use_spell_keys.sort()
+    var uses: Array = []
+    for spell_key in use_spell_keys:
+        uses.append({
+            "spell_id": StringName(spell_key),
+            "use_transaction_id": StringName(_use_transaction_by_spell_id[spell_key]),
+        })
+
+    return {
+        "spells": spells,
+        "preparation_transactions": preparations,
+        "use_transactions": uses,
+    }
+
+
+func restore(value: Dictionary) -> bool:
+    if not value.has("spells") or not value.has("preparation_transactions") or not value.has("use_transactions"):
+        return false
+    if typeof(value.spells) != TYPE_ARRAY or typeof(value.preparation_transactions) != TYPE_ARRAY or typeof(value.use_transactions) != TYPE_ARRAY:
+        return false
+
+    var PreparedSpell = load(PREPARED_SPELL_PATH)
+    if PreparedSpell == null:
+        return false
+    var candidate_spells: Dictionary = {}
+    for spell_record in value.spells:
+        if typeof(spell_record) != TYPE_DICTIONARY or not spell_record.has("spell_id") or not spell_record.has("payload"):
+            return false
+        var spell_key := String(spell_record.spell_id)
+        if spell_key.is_empty() or candidate_spells.has(spell_key) or typeof(spell_record.payload) != TYPE_DICTIONARY:
+            return false
+        var prepared = PreparedSpell.from_serialized(spell_record.payload)
+        if prepared == null or String(prepared.spell_id()) != spell_key:
+            return false
+        candidate_spells[spell_key] = prepared.serialize().duplicate(true)
+
+    var candidate_preparations: Dictionary = {}
+    var prepared_spell_ids: Dictionary = {}
+    for preparation_record in value.preparation_transactions:
+        if typeof(preparation_record) != TYPE_DICTIONARY or not preparation_record.has("preparation_transaction_id") or not preparation_record.has("spell_id"):
+            return false
+        var preparation_key := String(preparation_record.preparation_transaction_id)
+        var prepared_spell_key := String(preparation_record.spell_id)
+        if preparation_key.is_empty() or prepared_spell_key.is_empty():
+            return false
+        if candidate_preparations.has(preparation_key) or prepared_spell_ids.has(prepared_spell_key):
+            return false
+        if not candidate_spells.has(prepared_spell_key):
+            return false
+        candidate_preparations[preparation_key] = prepared_spell_key
+        prepared_spell_ids[prepared_spell_key] = true
+    if candidate_preparations.size() != candidate_spells.size():
+        return false
+
+    var candidate_uses: Dictionary = {}
+    var owned_use_transactions: Dictionary = {}
+    for use_record in value.use_transactions:
+        if typeof(use_record) != TYPE_DICTIONARY or not use_record.has("spell_id") or not use_record.has("use_transaction_id"):
+            return false
+        var used_spell_key := String(use_record.spell_id)
+        var use_key := String(use_record.use_transaction_id)
+        if used_spell_key.is_empty() or use_key.is_empty():
+            return false
+        if candidate_uses.has(used_spell_key) or owned_use_transactions.has(use_key):
+            return false
+        if not candidate_spells.has(used_spell_key):
+            return false
+        candidate_uses[used_spell_key] = use_key
+        owned_use_transactions[use_key] = true
+
+    _spells_by_id = candidate_spells.duplicate(true)
+    _spell_id_by_preparation_transaction = candidate_preparations.duplicate(true)
+    _use_transaction_by_spell_id = candidate_uses.duplicate(true)
+    return true
+
+
+func _add_success(spell_id: StringName) -> Dictionary:
+    return {
+        "ok": true,
+        "code": &"PREPARED_SPELL_STORED",
+        "spell": spell(spell_id),
+    }
+
+
+func _use_success(spell_id: StringName, use_transaction_id: StringName) -> Dictionary:
+    return {
+        "ok": true,
+        "code": &"SPELL_MARKED_USED",
+        "spell_id": spell_id,
+        "use_transaction_id": use_transaction_id,
+    }

--- a/src/core/spells/prepared_spell_inventory.gd.uid
+++ b/src/core/spells/prepared_spell_inventory.gd.uid
@@ -1,0 +1,1 @@
+uid://qxfodmunbpp8

--- a/tests/test_runner.gd
+++ b/tests/test_runner.gd
@@ -14,6 +14,7 @@ const SUITES: Array[String] = [
     "res://tests/unit/test_focus_scribing_session.gd",
     "res://tests/unit/test_atomic_result_ledger.gd",
     "res://tests/unit/test_atomic_spell_commit_service.gd",
+    "res://tests/unit/test_prepared_spell_inventory.gd",
     "res://tests/unit/test_glyph_resource_snapshot.gd",
     "res://tests/integration/test_glyph_resource_lifecycle.gd",
     "res://tests/unit/test_glyph_resource_view_model.gd",

--- a/tests/unit/test_prepared_spell_inventory.gd
+++ b/tests/unit/test_prepared_spell_inventory.gd
@@ -1,0 +1,120 @@
+# 준비 마법 주문 보관함 불변성과 정확히 한 번 수명주기를 검증한다.
+extends RefCounted
+
+const PREPARED_SPELL_PATH := "res://src/core/spells/prepared_spell.gd"
+const INVENTORY_PATH := "res://src/core/spells/prepared_spell_inventory.gd"
+
+
+func _make_spell(PreparedSpell, spell_id: StringName, main_value := &"MAIN"):
+    return PreparedSpell.create(
+        spell_id,
+        {
+            "glyph_id": main_value,
+            "nested": {"value": 1},
+        },
+        [
+            {
+                "glyph_id": &"AUXILIARY",
+                "nested": {"value": 2},
+            },
+        ],
+        {
+            "success_percent": 75,
+            "final_mana": 12,
+            "nested": {"value": 3},
+        },
+        [
+            {
+                "record_id": &"source-1",
+                "nested": {"value": 4},
+            },
+        ]
+    )
+
+
+func run(case) -> void:
+    case.assert_true(FileAccess.file_exists(PREPARED_SPELL_PATH), "PreparedSpell implementation must exist")
+    case.assert_true(FileAccess.file_exists(INVENTORY_PATH), "PreparedSpellInventory implementation must exist")
+    if not FileAccess.file_exists(PREPARED_SPELL_PATH) or not FileAccess.file_exists(INVENTORY_PATH):
+        return
+
+    var PreparedSpell = load(PREPARED_SPELL_PATH)
+    var PreparedSpellInventory = load(INVENTORY_PATH)
+    case.assert_true(PreparedSpell != null and PreparedSpell.can_instantiate(), "PreparedSpell must compile")
+    case.assert_true(PreparedSpellInventory != null and PreparedSpellInventory.can_instantiate(), "PreparedSpellInventory must compile")
+    if PreparedSpell == null or PreparedSpellInventory == null:
+        return
+    if not PreparedSpell.can_instantiate() or not PreparedSpellInventory.can_instantiate():
+        return
+
+    var main := {"glyph_id": &"MAIN", "nested": {"value": 1}}
+    var auxiliaries := [{"glyph_id": &"AUXILIARY", "nested": {"value": 2}}]
+    var preview := {"success_percent": 75, "final_mana": 12, "nested": {"value": 3}}
+    var sources := [{"record_id": &"source-1", "nested": {"value": 4}}]
+    var immutable_spell = PreparedSpell.create(&"spell-immutable", main, auxiliaries, preview, sources)
+    case.assert_true(immutable_spell != null, "valid immutable prepared spell is created")
+    if immutable_spell == null:
+        return
+    main.nested.value = 99
+    auxiliaries[0].nested.value = 99
+    preview.nested.value = 99
+    sources[0].nested.value = 99
+    var immutable_payload = immutable_spell.serialize()
+    case.assert_equal(1, immutable_payload.main.nested.value, "main is deep copied at creation")
+    case.assert_equal(2, immutable_payload.auxiliaries[0].nested.value, "auxiliaries are deep copied at creation")
+    case.assert_equal(3, immutable_payload.base_preview.nested.value, "preview is deep copied at creation")
+    case.assert_equal(4, immutable_payload.source_records[0].nested.value, "source records are deep copied at creation")
+    case.assert_true(PreparedSpell.create(&"", {}, [], {"success_percent": 1, "final_mana": 1}, []) == null, "empty spell ID is rejected")
+    case.assert_true(PreparedSpell.create(&"missing-main", {}, [], {"success_percent": 1, "final_mana": 1}, []) == null, "missing main is rejected")
+    case.assert_true(PreparedSpell.create(&"too-many", {"glyph_id": &"MAIN"}, [{}, {}, {}, {}, {}, {}], {"success_percent": 1, "final_mana": 1}, []) == null, "more than five auxiliaries is rejected")
+    case.assert_true(PreparedSpell.create(&"missing-preview-key", {"glyph_id": &"MAIN"}, [], {"success_percent": 1}, []) == null, "incomplete preview is rejected")
+
+    var inventory = PreparedSpellInventory.new()
+    var add_first = inventory.add_once(&"prepare-1", immutable_spell)
+    case.assert_true(add_first.ok, "first preparation is stored")
+    var changed_candidate = _make_spell(PreparedSpell, &"spell-different", &"OTHER")
+    var add_replay = inventory.add_once(&"prepare-1", changed_candidate)
+    case.assert_true(add_replay.ok, "same preparation transaction is idempotent")
+    case.assert_equal(&"spell-immutable", add_replay.spell.spell_id, "same preparation transaction returns the original stored spell")
+    case.assert_false(inventory.add_once(&"", changed_candidate).ok, "empty preparation transaction is rejected without mutation")
+    case.assert_false(inventory.add_once(&"prepare-2", immutable_spell).ok, "a different preparation transaction cannot reuse a spell ID")
+
+    var public_spell = inventory.spell(&"spell-immutable")
+    public_spell.main.nested.value = 777
+    case.assert_equal(1, inventory.spell(&"spell-immutable").main.nested.value, "public spell reads are deep copies")
+    case.assert_equal(&"READY", inventory.spell(&"spell-immutable").status, "unconsumed public spell is READY")
+
+    var use_first = inventory.mark_used_once(&"spell-immutable", &"use-1")
+    case.assert_true(use_first.ok, "prepared spell can be marked used once")
+    var use_replay = inventory.mark_used_once(&"spell-immutable", &"use-1")
+    case.assert_true(use_replay.ok, "same use transaction returns its original idempotent outcome")
+    case.assert_equal(use_first, use_replay, "same use transaction returns the original result")
+    case.assert_false(inventory.mark_used_once(&"spell-immutable", &"use-2").ok, "different use transaction after consumption is rejected")
+    case.assert_equal(&"SPELL_ALREADY_USED", inventory.mark_used_once(&"spell-immutable", &"use-2").code, "post-consumption rejection is explicit")
+    case.assert_false(inventory.mark_used_once(&"spell-immutable", &"").ok, "empty use transaction is rejected without mutation")
+    case.assert_equal(&"USED", inventory.spell(&"spell-immutable").status, "public lifecycle status is derived from use ownership")
+
+    var second_spell = _make_spell(PreparedSpell, &"spell-second")
+    case.assert_true(inventory.add_once(&"prepare-3", second_spell).ok, "second spell is stored")
+    var use_collision = inventory.mark_used_once(&"spell-second", &"use-1")
+    case.assert_false(use_collision.ok, "one use transaction cannot belong to two spells")
+    case.assert_equal(&"USE_TRANSACTION_CONFLICT", use_collision.code, "cross-spell use transaction collision fails closed")
+    case.assert_equal(&"READY", inventory.spell(&"spell-second").status, "collision leaves second spell READY")
+
+    var saved = inventory.serialize()
+    case.assert_equal(&"READY", saved.spells[0].payload.status, "serialized immutable payload remains READY")
+    var restored = PreparedSpellInventory.new()
+    case.assert_true(restored.restore(saved), "valid serialized state restores")
+    case.assert_equal(&"USED", restored.spell(&"spell-immutable").status, "restore derives USED from use index")
+    case.assert_equal(&"READY", restored.serialize().spells[0].payload.status, "restore does not rewrite immutable payload status")
+    case.assert_equal(saved, restored.serialize(), "serialize is deterministic after round trip")
+
+    var before_bad_restore = restored.serialize()
+    var malformed = restored.serialize()
+    malformed.use_transactions.append({"spell_id": &"spell-second", "use_transaction_id": &"use-1"})
+    case.assert_false(restored.restore(malformed), "conflicting restore is rejected")
+    case.assert_equal(before_bad_restore, restored.serialize(), "failed restore is atomic")
+    var non_ready = restored.serialize()
+    non_ready.spells[0].payload.status = &"USED"
+    case.assert_false(restored.restore(non_ready), "non-READY immutable payload is rejected")
+    case.assert_equal(before_bad_restore, restored.serialize(), "non-READY restore failure is atomic")

--- a/tests/unit/test_prepared_spell_inventory.gd.uid
+++ b/tests/unit/test_prepared_spell_inventory.gd.uid
@@ -1,0 +1,1 @@
+uid://b1m4my7n8jup2


### PR DESCRIPTION
## Task 3 — Immutable Prepared Spell and Exactly-once Inventory

Implements `GM-SPELL-WORKFLOW-UI-V2-01` Task 3:

- immutable PreparedSpell payloads with deep-copy reads
- inventory-owned READY/USED lifecycle and exactly-once use ownership
- deterministic serialize and validate-then-swap restore
- TDD suite registered in the deterministic runner
- fresh HiGodot 3.1.3 authoring receipt and protected-delta reconciliation

Validation recorded:

- TASK3_TDD_RED recorded (missing implementation only)
- headless runner: 35 suites, 1,364 assertions, 0 failures
- GUT 9.7.1: 7 tests, 25 asserts, 0 failures
- Task 3 / HiGodot authority Python contracts: 16 passed
- Hera source delta: NONE

Known repository-baseline observation: two unrelated global GUT formal-adoption canon tests remain inconsistent with the current `project.godot`/entry-gate state; no Task 3 files address them.