### PR TITLE
feat: add glyph drawing workflow screen

### DIFF
--- a/artifacts/higodot/HIGODOT_AUTHORING_RECEIPT_TASK6_2026-08-10.json
+++ b/artifacts/higodot/HIGODOT_AUTHORING_RECEIPT_TASK6_2026-08-10.json
@@ -1,0 +1,59 @@
+{
+  "receipt_schema_version": 1,
+  "task": "Task 6: Incident Status, Explanation Overlay, and Glyph Drawing Screen",
+  "issue": 107,
+  "branch": "task6/incident-glyph-drawing",
+  "base_origin_main": "275ba48eb9c07ce24d4b17b2c57de66c98923e1a",
+  "authoring": {
+    "tool": "HiGodot",
+    "session_id": "task6-incident-glyph-drawing@7a9d",
+    "godot_version": "4.7.1",
+    "persistent_gd_authoring": "HiGodot only",
+    "fresh_readback_completed": true
+  },
+  "protected_delta": {
+    "allowed_paths": [
+      "src/ui/spell_workflow/components/incident_status_card.gd",
+      "src/ui/spell_workflow/components/incident_status_card.gd.uid",
+      "src/ui/spell_workflow/components/incident_status_card.tscn",
+      "src/ui/spell_workflow/components/incident_explanation_overlay.gd",
+      "src/ui/spell_workflow/components/incident_explanation_overlay.gd.uid",
+      "src/ui/spell_workflow/components/incident_explanation_overlay.tscn",
+      "src/ui/spell_workflow/glyph_drawing_screen.gd",
+      "src/ui/spell_workflow/glyph_drawing_screen.gd.uid",
+      "src/ui/spell_workflow/glyph_drawing_screen.tscn",
+      "tests/integration/test_glyph_drawing_workflow_screen.gd",
+      "tests/integration/test_glyph_drawing_workflow_screen.gd.uid",
+      "tests/test_runner.gd",
+      "artifacts/higodot/HIGODOT_AUTHORING_RECEIPT_TASK6_2026-08-10.json"
+    ],
+    "hera_source_delta": "NONE"
+  },
+  "fresh_readback": [
+    {"path":"src/ui/spell_workflow/components/incident_status_card.gd","sha256":"b285c805e729507f8c2a0d1959e7cc19709a5aa332f8edf26c0059346bfa26fa","physical_lines":33},
+    {"path":"src/ui/spell_workflow/components/incident_status_card.tscn","sha256":"781d780d25ae71e81da2ec2c10e81214d81b73bdae602fcdebbdce3e1546c816","physical_lines":38},
+    {"path":"src/ui/spell_workflow/components/incident_explanation_overlay.gd","sha256":"a819949a0e2b429fd986f3ac7f2238d2c8e5df65797607249c2acd75b24df4f9","physical_lines":40},
+    {"path":"src/ui/spell_workflow/components/incident_explanation_overlay.tscn","sha256":"81a80e983b10de09ff5b7555bfd45ca24e1275962e250f5524a99a3dd2f975a5","physical_lines":40},
+    {"path":"src/ui/spell_workflow/glyph_drawing_screen.gd","sha256":"c92683872c231f472afc93ac76be581775a7d8c022dbb31e100c06d65ba43e10","physical_lines":166},
+    {"path":"src/ui/spell_workflow/glyph_drawing_screen.tscn","sha256":"d7136e21f4b701494c6925c28faf76889bc4e5ef61961dc2809878529ad55573","physical_lines":91},
+    {"path":"tests/integration/test_glyph_drawing_workflow_screen.gd","sha256":"ecb1114d665446026743057e75e4510c7292749ca424b7fe2841061ec2c4e85d","physical_lines":99},
+    {"path":"tests/test_runner.gd","sha256":"7adb1011bf1d3424e2efcb7ffa6daf1ad14800230078986e4e098027f120688a","physical_lines":73}
+  ],
+  "editor_evidence": {
+    "task6_scene_contract_and_behavior": {"assertions":33,"failures":0},
+    "focus_scribe_recognition_regression": {"assertions":39,"failures":0},
+    "glyph_writing_view_model_regression": {"assertions":53,"failures":0},
+    "atomic_spell_use_regression": {"assertions":27,"failures":0},
+    "custom_scene_ui": {
+      "viewport":"1280x720 layout",
+      "retry_and_save_minimum_size":"1280x48 runtime rect; minimum size 48x48",
+      "incident_overlay":"Incident card and Incident button each opened a visible 1280x720 overlay"
+    }
+  },
+  "not_claimed": {
+    "headless_gut_cli": "NOT_RUN_AS_PASS",
+    "full_runner": "NOT_RUN_AS_PASS; evaluator batch compilation limitation",
+    "device_validation": "NOT_RUN",
+    "human_validation": "NOT_RUN"
+  }
+}

--- a/src/ui/spell_workflow/components/incident_explanation_overlay.gd
+++ b/src/ui/spell_workflow/components/incident_explanation_overlay.gd
@@ -1,0 +1,40 @@
+# 사건 설명을 잠시 열고 기존 작업 맥락을 손대지 않은 채 돌려주는 오버레이다.
+class_name IncidentExplanationOverlay
+extends PanelContainer
+
+signal closed(return_context: Dictionary)
+
+var _return_context: Dictionary = {}
+
+
+func _ready() -> void:
+    var close_button = get_node_or_null(NodePath("Content/CloseButton"))
+    if close_button != null:
+        close_button.pressed.connect(close)
+
+
+func present(incident: Dictionary, workflow_context: Dictionary) -> void:
+    _return_context = workflow_context.duplicate(true)
+    var problem_label = get_node_or_null(NodePath("Content/Problem"))
+    if problem_label != null:
+        problem_label.text = String(incident.get("problem", "사건 정보를 준비 중입니다."))
+    var danger_label = get_node_or_null(NodePath("Content/Danger"))
+    if danger_label != null:
+        danger_label.text = "위험: %s" % String(incident.get("danger", "미확인"))
+    var direction_label = get_node_or_null(NodePath("Content/Direction"))
+    if direction_label != null:
+        direction_label.text = "필요한 방향: %s" % String(incident.get("required_direction", "관찰 필요"))
+    var keywords_label = get_node_or_null(NodePath("Content/Keywords"))
+    if keywords_label != null:
+        var keywords: Array = Array(incident.get("observed_keywords", []))
+        keywords_label.text = "관찰 키워드: %s" % ", ".join(keywords)
+    visible = true
+
+
+func close() -> void:
+    visible = false
+    closed.emit(_return_context.duplicate(true))
+
+
+func return_context() -> Dictionary:
+    return _return_context.duplicate(true)

--- a/src/ui/spell_workflow/components/incident_explanation_overlay.gd.uid
+++ b/src/ui/spell_workflow/components/incident_explanation_overlay.gd.uid
@@ -1,0 +1,1 @@
+uid://4854yrrrntfq

--- a/src/ui/spell_workflow/components/incident_explanation_overlay.tscn
+++ b/src/ui/spell_workflow/components/incident_explanation_overlay.tscn
@@ -1,0 +1,40 @@
+[gd_scene format=3 uid="uid://ulvi3h08qf45"]
+
+[ext_resource type="Script" uid="uid://4854yrrrntfq" path="res://src/ui/spell_workflow/components/incident_explanation_overlay.gd" id="1_51ukj"]
+
+[node name="IncidentExplanationOverlay" type="PanelContainer" unique_id=78256000]
+script = ExtResource("1_51ukj")
+
+[node name="Content" type="VBoxContainer" parent="." unique_id=420964411]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="Heading" type="Label" parent="Content" unique_id=1840849747]
+layout_mode = 2
+theme_type_variation = &"StatusBanner"
+text = "사건 설명"
+
+[node name="Problem" type="Label" parent="Content" unique_id=1017581827]
+layout_mode = 2
+text = "사건 정보를 준비 중입니다."
+autowrap_mode = 2
+
+[node name="Danger" type="Label" parent="Content" unique_id=27109673]
+layout_mode = 2
+text = "위험: 미확인"
+
+[node name="Direction" type="Label" parent="Content" unique_id=917338232]
+layout_mode = 2
+text = "필요한 방향: 관찰 필요"
+
+[node name="CloseButton" type="Button" parent="Content" unique_id=942080499]
+custom_minimum_size = Vector2(48, 48)
+layout_mode = 2
+theme_type_variation = &"AcademyButton"
+text = "돌아가기"
+
+[node name="Keywords" type="Label" parent="Content" unique_id=984036350]
+layout_mode = 2
+theme_type_variation = &"AcademyBadge"
+text = "관찰 키워드: 준비 중"
+autowrap_mode = 2

--- a/src/ui/spell_workflow/components/incident_status_card.gd
+++ b/src/ui/spell_workflow/components/incident_status_card.gd
@@ -1,0 +1,33 @@
+# 사건의 즉시 위험과 필요한 방향을 읽기 쉽게 표시하는 카드다.
+class_name IncidentStatusCard
+extends PanelContainer
+
+var _incident: Dictionary = {}
+
+
+func bind_incident(incident_data: Dictionary) -> void:
+    _incident = incident_data.duplicate(true)
+    _refresh()
+
+
+func incident() -> Dictionary:
+    return _incident.duplicate(true)
+
+
+func _ready() -> void:
+    _refresh()
+
+
+func _refresh() -> void:
+    var problem_label = get_node_or_null(NodePath("Content/Problem"))
+    if problem_label != null:
+        problem_label.text = String(_incident.get("problem", "사건 정보를 준비 중입니다."))
+    var danger_label = get_node_or_null(NodePath("Content/Danger"))
+    if danger_label != null:
+        danger_label.text = "위험: %s" % String(_incident.get("danger", "미확인"))
+    var direction_label = get_node_or_null(NodePath("Content/Direction"))
+    if direction_label != null:
+        direction_label.text = "필요한 방향: %s" % String(_incident.get("required_direction", "관찰 필요"))
+    var urgency_label = get_node_or_null(NodePath("Content/Urgency"))
+    if urgency_label != null:
+        urgency_label.text = "긴급도: %s" % String(_incident.get("urgency", "보통"))

--- a/src/ui/spell_workflow/components/incident_status_card.gd.uid
+++ b/src/ui/spell_workflow/components/incident_status_card.gd.uid
@@ -1,0 +1,1 @@
+uid://ddoege75tsao

--- a/src/ui/spell_workflow/components/incident_status_card.tscn
+++ b/src/ui/spell_workflow/components/incident_status_card.tscn
@@ -1,0 +1,38 @@
+[gd_scene format=3 uid="uid://b1t3m5t3gruyy"]
+
+[ext_resource type="Script" uid="uid://ddoege75tsao" path="res://src/ui/spell_workflow/components/incident_status_card.gd" id="1_cmsec"]
+
+[node name="IncidentStatusCard" type="PanelContainer" unique_id=1323409017]
+script = ExtResource("1_cmsec")
+
+[node name="Content" type="VBoxContainer" parent="." unique_id=2084923753]
+layout_mode = 2
+theme_override_constants/separation = 6
+
+[node name="Heading" type="Label" parent="Content" unique_id=410118403]
+layout_mode = 2
+theme_type_variation = &"StatusBanner"
+text = "사건 현황"
+
+[node name="Problem" type="Label" parent="Content" unique_id=2087471097]
+layout_mode = 2
+text = "사건 정보를 준비 중입니다."
+autowrap_mode = 2
+
+[node name="Danger" type="Label" parent="Content" unique_id=430486716]
+layout_mode = 2
+text = "위험: 미확인"
+
+[node name="Direction" type="Label" parent="Content" unique_id=556365853]
+layout_mode = 2
+text = "필요한 방향: 관찰 필요"
+
+[node name="Urgency" type="Label" parent="Content" unique_id=822907233]
+layout_mode = 2
+theme_type_variation = &"AcademyBadge"
+text = "긴급도: 보통"
+
+[node name="TouchHint" type="Label" parent="Content" unique_id=262687710]
+layout_mode = 2
+theme_type_variation = &"StatusBanner"
+text = "터치 시 상황 설명"

--- a/src/ui/spell_workflow/glyph_drawing_screen.gd
+++ b/src/ui/spell_workflow/glyph_drawing_screen.gd
@@ -1,0 +1,166 @@
+# 사건 맥락을 유지하며 인식된 문양만 기존 예약 경로로 저장하는 작성 화면이다.
+class_name GlyphDrawingScreen
+extends Control
+
+signal glyph_saved(glyph_id: StringName)
+signal open_incident_requested
+signal continue_requested
+
+var _incident: Dictionary = {}
+var _recognition_service = null
+var _scribe_coordinator = null
+var _view_model = null
+var _workflow_context: Dictionary = {}
+var _workflow_state = null
+var _input_revision := 0
+var _accepted_candidate = null
+var _terminal_save_result: Dictionary = {}
+
+
+func _ready() -> void:
+    _connect_button("RetryButton", retry_recognition)
+    _connect_button("SaveButton", save_accepted_candidate)
+    _connect_button("IncidentButton", open_incident)
+    _connect_button("ContinueButton", continue_workflow)
+    var incident_status_card = get_node_or_null(NodePath("IncidentStatusCard"))
+    if incident_status_card != null and not incident_status_card.gui_input.is_connected(_on_incident_status_input):
+        incident_status_card.gui_input.connect(_on_incident_status_input)
+    var overlay = get_node_or_null(NodePath("IncidentExplanationOverlay"))
+    if overlay != null:
+        overlay.visible = false
+        if overlay.has_signal("closed") and not overlay.closed.is_connected(_restore_overlay_context):
+            overlay.closed.connect(_restore_overlay_context)
+
+
+func configure(
+    incident: Dictionary,
+    recognition_service,
+    scribe_coordinator,
+    view_model,
+    workflow_context: Dictionary = {},
+    input_revision: int = 0
+) -> void:
+    _incident = incident.duplicate(true)
+    _recognition_service = recognition_service
+    _scribe_coordinator = scribe_coordinator
+    _view_model = view_model
+    _workflow_state = workflow_context.get("workflow_state", null)
+    _workflow_context = workflow_context.duplicate(true)
+    _workflow_context.erase("workflow_state")
+    _input_revision = maxi(input_revision, 0)
+    var status_card = get_node_or_null(NodePath("IncidentStatusCard"))
+    if status_card != null and status_card.has_method("bind_incident"):
+        status_card.bind_incident(_incident)
+
+
+func submit_strokes(strokes: Array) -> Dictionary:
+    _accepted_candidate = null
+    if _recognition_service == null or not _recognition_service.has_method("recognize"):
+        return _show_recognition({"status": &"NO_VALID_INPUT", "candidates": []}, strokes.size())
+    var result: Dictionary = _recognition_service.recognize(strokes, _input_revision)
+    return _show_recognition(result, strokes.size())
+
+
+func set_input_revision(input_revision: int) -> void:
+    _input_revision = maxi(input_revision, 0)
+    _accepted_candidate = null
+
+
+func select_candidate(candidate) -> Dictionary:
+    if candidate == null:
+        return {"status": &"NO_VALID_INPUT"}
+    _accepted_candidate = candidate
+    return {"status": &"CANDIDATE_SELECTED", "input_revision": _input_revision}
+
+
+func save_accepted_candidate() -> Dictionary:
+    if not _terminal_save_result.is_empty():
+        return _terminal_save_result.duplicate(true)
+    if _scribe_coordinator == null or not _scribe_coordinator.has_method("accept_candidate"):
+        return {"status": &"INVALID_SCRIBE_RESERVATION"}
+    if _accepted_candidate == null:
+        return {"status": &"NO_VALID_INPUT"}
+
+    var result: Dictionary = _scribe_coordinator.accept_candidate(_accepted_candidate, _input_revision)
+    if result.get("status", &"") == &"VAULT_GLYPH_CREATED":
+        _terminal_save_result = result.duplicate(true)
+        glyph_saved.emit(StringName(_terminal_save_result.get("glyph_id", &"")))
+    return result.duplicate(true)
+
+
+func retry_recognition() -> void:
+    _accepted_candidate = null
+    _set_recognition_text("다시 그려 주세요. 아직 보관함에는 저장되지 않았습니다.")
+
+
+func cancel_scribing() -> Dictionary:
+    if _scribe_coordinator == null or not _scribe_coordinator.has_method("interrupt"):
+        return {"status": &"INVALID_SCRIBE_RESERVATION"}
+    return Dictionary(_scribe_coordinator.interrupt(&"CANCELLED")).duplicate(true)
+
+
+func open_incident() -> void:
+    var overlay = get_node_or_null(NodePath("IncidentExplanationOverlay"))
+    if overlay != null and overlay.has_method("present"):
+        overlay.present(_incident, _capture_overlay_context())
+    open_incident_requested.emit()
+
+
+func continue_workflow() -> void:
+    continue_requested.emit()
+
+
+func _on_incident_status_input(event: InputEvent) -> void:
+    if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
+        open_incident()
+    elif event is InputEventScreenTouch and event.pressed:
+        open_incident()
+
+
+func _capture_overlay_context() -> Dictionary:
+    var snapshot = _workflow_context.duplicate(true)
+    snapshot["selected_glyph_id"] = _selected_glyph_id()
+    snapshot["stroke_revision"] = _input_revision
+    if _workflow_state != null and _workflow_state.has_method("current_state"):
+        snapshot["current_state"] = _workflow_state.current_state()
+    if not snapshot.has("active_reservations"):
+        snapshot["active_reservations"] = []
+    var focus_owner = get_viewport().gui_get_focus_owner()
+    if focus_owner != null and is_ancestor_of(focus_owner):
+        snapshot["focus_owner_path"] = String(get_path_to(focus_owner))
+    return snapshot
+
+
+func _restore_overlay_context(return_context: Dictionary) -> void:
+    _workflow_context = return_context.duplicate(true)
+    _input_revision = maxi(int(return_context.get("stroke_revision", _input_revision)), 0)
+    var focus_path := NodePath(String(return_context.get("focus_owner_path", "")))
+    var focus_owner = get_node_or_null(focus_path)
+    if focus_owner != null and focus_owner.has_method("grab_focus"):
+        focus_owner.grab_focus()
+
+
+func _show_recognition(result: Dictionary, stroke_count: int) -> Dictionary:
+    var view = result.duplicate(true)
+    if _view_model != null and _view_model.has_method("from_result"):
+        view = _view_model.from_result(result, _selected_glyph_id(), stroke_count)
+    _set_recognition_text(String(view.get("primary_text", result.get("status", "NO_VALID_INPUT"))))
+    return result.duplicate(true)
+
+
+func _selected_glyph_id() -> StringName:
+    if _scribe_coordinator != null and _scribe_coordinator.has_method("selected_glyph_id"):
+        return StringName(_scribe_coordinator.selected_glyph_id())
+    return &""
+
+
+func _set_recognition_text(message: String) -> void:
+    var label = get_node_or_null(NodePath("RecognitionPanel/Message"))
+    if label != null:
+        label.text = message
+
+
+func _connect_button(path: String, callback: Callable) -> void:
+    var button = get_node_or_null(NodePath(path))
+    if button != null and not button.pressed.is_connected(callback):
+        button.pressed.connect(callback)

--- a/src/ui/spell_workflow/glyph_drawing_screen.gd.uid
+++ b/src/ui/spell_workflow/glyph_drawing_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://b77gqykljc14r

--- a/src/ui/spell_workflow/glyph_drawing_screen.tscn
+++ b/src/ui/spell_workflow/glyph_drawing_screen.tscn
@@ -1,0 +1,91 @@
+[gd_scene format=3 uid="uid://dhkd7pos74iaa"]
+
+[ext_resource type="Script" uid="uid://b77gqykljc14r" path="res://src/ui/spell_workflow/glyph_drawing_screen.gd" id="1_pprrx"]
+[ext_resource type="PackedScene" uid="uid://b1t3m5t3gruyy" path="res://src/ui/spell_workflow/components/incident_status_card.tscn" id="2_h8dqw"]
+[ext_resource type="PackedScene" uid="uid://ulvi3h08qf45" path="res://src/ui/spell_workflow/components/incident_explanation_overlay.tscn" id="3_pq1il"]
+
+[node name="GlyphDrawingScreen" type="VBoxContainer" unique_id=2079873807]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+theme_type_variation = &"AcademyPanel"
+theme_override_constants/separation = 12
+script = ExtResource("1_pprrx")
+
+[node name="IncidentStatusCard" parent="." unique_id=1323409017 instance=ExtResource("2_h8dqw")]
+layout_mode = 2
+
+[node name="IncidentExplanationOverlay" parent="." unique_id=78256000 instance=ExtResource("3_pq1il")]
+top_level = true
+custom_minimum_size = Vector2(1280, 720)
+layout_mode = 2
+theme_type_variation = &"AcademyPanel"
+
+[node name="CharacterPanel" type="PanelContainer" parent="." unique_id=373044996]
+layout_mode = 2
+theme_type_variation = &"AcademyPanel"
+
+[node name="CharacterName" type="Label" parent="CharacterPanel" unique_id=1317275060]
+layout_mode = 2
+text = "기록관 견습생 · 문양 작성"
+
+[node name="GlyphProgressPanel" type="PanelContainer" parent="." unique_id=1473993656]
+layout_mode = 2
+theme_type_variation = &"AcademyPanel"
+
+[node name="Progress" type="Label" parent="GlyphProgressPanel" unique_id=1040321608]
+layout_mode = 2
+text = "문양 1개를 안전하게 기록하세요."
+
+[node name="WritingCanvas" type="PanelContainer" parent="." unique_id=780384574]
+custom_minimum_size = Vector2(0, 220)
+layout_mode = 2
+theme_type_variation = &"AcademyPanel"
+
+[node name="CanvasHint" type="Label" parent="WritingCanvas" unique_id=992261367]
+layout_mode = 2
+text = "여기에 문양을 그립니다."
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="GlyphInfoPanel" type="PanelContainer" parent="." unique_id=1377955341]
+layout_mode = 2
+theme_type_variation = &"AcademyPanel"
+
+[node name="Hint" type="Label" parent="GlyphInfoPanel" unique_id=788909649]
+layout_mode = 2
+text = "관찰한 방향을 바탕으로 문양을 그려 보세요."
+autowrap_mode = 2
+
+[node name="RecognitionPanel" type="PanelContainer" parent="." unique_id=825918465]
+layout_mode = 2
+theme_type_variation = &"AcademyPanel"
+
+[node name="Message" type="Label" parent="RecognitionPanel" unique_id=1928711037]
+layout_mode = 2
+text = "획을 그린 뒤 인식 결과를 확인합니다."
+autowrap_mode = 2
+
+[node name="RetryButton" type="Button" parent="." unique_id=1905593916]
+custom_minimum_size = Vector2(48, 48)
+layout_mode = 2
+theme_type_variation = &"AcademyButton"
+text = "다시 그리기"
+
+[node name="SaveButton" type="Button" parent="." unique_id=783030606]
+custom_minimum_size = Vector2(48, 48)
+layout_mode = 2
+theme_type_variation = &"AcademyButton"
+text = "인식된 문양 저장"
+
+[node name="IncidentButton" type="Button" parent="." unique_id=599394259]
+custom_minimum_size = Vector2(48, 48)
+layout_mode = 2
+theme_type_variation = &"AcademyButton"
+text = "사건 설명"
+
+[node name="ContinueButton" type="Button" parent="." unique_id=1189460826]
+custom_minimum_size = Vector2(48, 48)
+layout_mode = 2
+theme_type_variation = &"AcademyButton"
+text = "계속"

--- a/tests/integration/test_glyph_drawing_workflow_screen.gd
+++ b/tests/integration/test_glyph_drawing_workflow_screen.gd
@@ -1,0 +1,99 @@
+# Task 6 Glyph Drawing Screen의 장면 계약과 안전한 저장 진입점을 검증한다.
+extends RefCounted
+
+
+class FakeScribeCoordinator:
+    extends RefCounted
+
+    var accept_calls := 0
+    var interrupt_calls := 0
+
+    func selected_glyph_id() -> StringName:
+        return &"HEAT"
+
+    func accept_candidate(_candidate, input_revision: int) -> Dictionary:
+        accept_calls += 1
+        return {
+            "status": &"VAULT_GLYPH_CREATED",
+            "glyph_id": &"HEAT",
+            "input_revision": input_revision,
+            "reservation_id": &"scribe-test",
+        }
+
+    func interrupt(_reason: StringName) -> Dictionary:
+        interrupt_calls += 1
+        return {"status": &"SCRIBE_INTERRUPTED"}
+
+
+const SCREEN_PATH := "res://src/ui/spell_workflow/glyph_drawing_screen.tscn"
+const SCREEN_SCRIPT_PATH := "res://src/ui/spell_workflow/glyph_drawing_screen.gd"
+const STATUS_CARD_PATH := "res://src/ui/spell_workflow/components/incident_status_card.gd"
+const OVERLAY_PATH := "res://src/ui/spell_workflow/components/incident_explanation_overlay.gd"
+const REQUIRED_NODES := [
+    "CharacterPanel",
+    "IncidentStatusCard",
+    "GlyphProgressPanel",
+    "WritingCanvas",
+    "GlyphInfoPanel",
+    "RecognitionPanel",
+    "RetryButton",
+    "SaveButton",
+]
+
+
+func run(case) -> void:
+    for script_path in [SCREEN_SCRIPT_PATH, STATUS_CARD_PATH, OVERLAY_PATH]:
+        case.assert_true(FileAccess.file_exists(script_path), "Task 6 script must exist: %s" % script_path)
+    case.assert_true(FileAccess.file_exists(SCREEN_PATH), "Task 6 glyph drawing screen must exist")
+    if not FileAccess.file_exists(SCREEN_PATH):
+        return
+
+    var packed_scene = load(SCREEN_PATH)
+    case.assert_true(packed_scene != null and packed_scene.can_instantiate(), "glyph drawing screen must load")
+    if packed_scene == null or not packed_scene.can_instantiate():
+        return
+
+    var screen = packed_scene.instantiate()
+    case.assert_true(screen.has_method("configure"), "screen accepts incident and recognition context")
+    case.assert_true(screen.has_method("save_accepted_candidate"), "screen exposes explicit accepted-save boundary")
+    case.assert_true(screen.has_method("cancel_scribing"), "screen releases an interrupted reservation explicitly")
+    case.assert_true(screen.has_method("_on_incident_status_input"), "incident status card has an explicit touch path to its explanation")
+    for node_name in REQUIRED_NODES:
+        case.assert_true(screen.has_node(NodePath(node_name)), "screen exposes required node: %s" % node_name)
+    for action_name in ["RetryButton", "SaveButton"]:
+        var action = screen.get_node_or_null(NodePath(action_name))
+        case.assert_true(action != null, "%s exists" % action_name)
+        if action != null:
+            case.assert_true(action.custom_minimum_size.x >= 48.0, "%s width is touch safe" % action_name)
+            case.assert_true(action.custom_minimum_size.y >= 48.0, "%s height is touch safe" % action_name)
+    case.assert_true(screen.has_node(NodePath("IncidentStatusCard/Content/Urgency")), "status card exposes urgency")
+    case.assert_true(screen.has_node(NodePath("IncidentStatusCard/Content/TouchHint")), "status card explains its touch affordance")
+    case.assert_true(FileAccess.file_exists("res://src/ui/spell_workflow/components/incident_explanation_overlay.tscn"), "incident overlay scene exists")
+    _assert_explicit_save_replays_once(case, screen)
+    _assert_incident_overlay_preserves_context(case)
+    screen.queue_free()
+
+
+func _assert_explicit_save_replays_once(case, screen) -> void:
+    var coordinator = FakeScribeCoordinator.new()
+    screen.configure({}, null, coordinator, null, {"selected_glyph_id": &"HEAT"}, 3)
+    screen.select_candidate(RefCounted.new())
+    var first: Dictionary = screen.save_accepted_candidate()
+    var replay: Dictionary = screen.save_accepted_candidate()
+    case.assert_equal(&"VAULT_GLYPH_CREATED", first.get("status", &""), "accepted save reaches the existing coordinator")
+    case.assert_equal(first, replay, "same save request replays its terminal result")
+    case.assert_equal(1, coordinator.accept_calls, "screen does not create a second Vault write")
+    var interrupted: Dictionary = screen.cancel_scribing()
+    case.assert_equal(&"SCRIBE_INTERRUPTED", interrupted.get("status", &""), "cancel is an explicit coordinator interruption")
+    case.assert_equal(1, coordinator.interrupt_calls, "cancel does not write a glyph")
+
+
+func _assert_incident_overlay_preserves_context(case) -> void:
+    var overlay_scene = load("res://src/ui/spell_workflow/components/incident_explanation_overlay.tscn")
+    var overlay = overlay_scene.instantiate()
+    var context := {"current_state": &"DRAWING", "stroke_revision": 3}
+    overlay.present({"problem": "불안정한 열기", "observed_keywords": ["열기", "흐름"]}, context)
+    case.assert_true(overlay.has_node(NodePath("Content/Keywords")), "overlay renders observed keywords without a solution list")
+    overlay.close()
+    case.assert_equal(context, overlay.return_context(), "incident overlay returns the supplied workflow context unchanged")
+    overlay.queue_free()

--- a/tests/integration/test_glyph_drawing_workflow_screen.gd.uid
+++ b/tests/integration/test_glyph_drawing_workflow_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://bl5jcmucnlcq7

--- a/tests/test_runner.gd
+++ b/tests/test_runner.gd
@@ -43,6 +43,7 @@ const SUITES: Array[String] = [
     "res://tests/integration/test_star_ui_kit_scene.gd",
     "res://tests/integration/test_star_circuit_end_to_end.gd",
     "res://tests/integration/test_frostbloom_star_ux_map.gd",
+    "res://tests/integration/test_glyph_drawing_workflow_screen.gd",
 ]
 
 


### PR DESCRIPTION
Implements approved Task 6 / Issue #107.\n\n- Adds incident status card, non-mutating explanation overlay, and glyph drawing screen.\n- Uses FocusScribeRecognitionCoordinator for the explicit exactly-once save boundary.\n- Adds scene and behavior regression coverage.\n\nEditor evidence: Task 6 33 assertions; focus-scribe 39; glyph writing ViewModel 53; atomic spell use 27 — all 0 failures.\n\nNot claimed: headless/GUT CLI pass, device or human validation.