### PR TITLE
docs: require prework benchmark and industry research

### DIFF
--- a/.github/workflows/validate-base-v9-adoption.yml
+++ b/.github/workflows/validate-base-v9-adoption.yml
@@ -19,6 +19,7 @@ jobs:
       - run: python -m unittest tests.test_world_character_three_year_story_contract -v
       - run: python -m unittest tests.test_year_one_growth_economy_test_values_contract -v
       - run: python -m unittest tests.test_frostbloom_internal_vertical_slice_contract -v
+      - run: python -m unittest tests.test_prework_benchmark_industry_research_contract -v
       - name: Validate JSON
         run: |
           python - <<'PY'

--- a/docs/planning/CURRENT_CONFIRMED_DECISIONS.md
+++ b/docs/planning/CURRENT_CONFIRMED_DECISIONS.md
@@ -10,6 +10,10 @@ base_snapshot_policy: ALWAYS_REFETCH_CURRENT_MAIN_BEFORE_WORK
 base_repository_review_policy: RECURSIVE_INVENTORY_THEN_RELEVANCE_DRIVEN_DEEP_READ
 adapter_policy: THIN_ADAPTER_DO_NOT_DUPLICATE_BASE_CANON
 external_process_policy: EXTERNAL_PROCESS_OVERLAY
+prework_research_decision: GM-PREWORK-BENCHMARK-INDUSTRY-RESEARCH-01
+prework_research_sync: GR-SYNC-20260811-13-PREWORK-BENCHMARK-INDUSTRY-RESEARCH
+prework_research_gate: REQUIRED_BEFORE_NEW_SUBSTANTIVE_WORK_UNIT
+prework_research_same_work_unit_receipt_reuse: ALLOWED_IF_SCOPE_AND_KEY_ASSUMPTIONS_UNCHANGED
 base_current_main_observed: 315c66eea9614c284b9c11c4d522141065dfa4b0
 current_state_sync: GR-SYNC-20260811-01-SPELL-WORKFLOW-TASK7-CURRENT-STATE
 product_decision: GM-SPELL-WORKFLOW-UI-V2-01
@@ -34,7 +38,7 @@ frostbloom_result_dimensions: FACILITY_LIFE_SPIRIT_RELATIONSHIP_DISCOVERY
 frostbloom_implementation_plan: docs/superpowers/plans/2026-08-11-frostbloom-internal-vertical-slice-implementation-plan.md
 frostbloom_runtime_implementation: BLOCKED_BY_HIGODOT_EXECUTOR_AND_TASK8_DEPENDENCY
 next_planning_axis: D_RUNTIME_IMPLEMENTATION_BLOCKED_BY_TASK8_HIGODOT
-next_process_axis: PREWORK_BENCHMARK_INDUSTRY_RESEARCH_CANON
+current_process_axis: PREWORK_BENCHMARK_INDUSTRY_RESEARCH_ACTIVE
 github_actions_decision: GM-PUBLIC-REPO-FREE-GITHUB-ACTIONS-01
 repo_wide_actions_full_sha: PASS
 latest_product_main: fcb5dbe1cbbb23ef195633b1f6680f45d46c5a3f
@@ -76,6 +80,40 @@ merge_authority: APPROVED_ITEM_INHERITS_MERGE_AUTHORITY
 ```
 
 v4.5 r2는 Base current canon을 복제하지 않는 thin adapter다. Base는 매 작업 `main`과 Registry/관련 owner를 다시 읽는다. Superpowers 같은 process framework는 `EXTERNAL_PROCESS_OVERLAY`이며 프로젝트/Base canon을 소유하지 않는다.
+
+## GM-PREWORK-BENCHMARK-INDUSTRY-RESEARCH-01 — current process gate
+
+```yaml
+decision_id: GM-PREWORK-BENCHMARK-INDUSTRY-RESEARCH-01
+sync_id: GR-SYNC-20260811-13-PREWORK-BENCHMARK-INDUSTRY-RESEARCH
+approval: USER_APPROVED_ACTIVE
+canon_document: docs/planning/PREWORK_BENCHMARK_INDUSTRY_RESEARCH_01_APPROVAL_2026-08-11.md
+scope: PROJECT_PROCESS_ONLY
+trigger: BEFORE_EVERY_NEW_SUBSTANTIVE_WORK_UNIT
+required_steps:
+  - FRESH_BASE_PROJECT_SHEET
+  - DEFINE_WORK_QUESTION
+  - BENCHMARK_AND_INDUSTRY_RESEARCH
+  - SOURCE_ROLE_FRESHNESS_APPLICABILITY
+  - EXISTING_SOLUTION_FIRST
+  - DISPOSITION
+  - ADVERSARIAL_REVIEW
+  - WORK
+  - EXACT_HEAD_AND_READBACK
+required_dispositions:
+  - ADOPT
+  - ADAPT
+  - TEST
+  - AVOID
+  - IGNORE
+  - REFERENCE_ONLY
+same_work_unit_receipt_reuse: ALLOWED_ONLY_IF_SCOPE_PRODUCT_DECISION_KEY_ASSUMPTIONS_UNCHANGED
+competitor_expression_copying: FORBIDDEN
+product_decision_mutation: NONE
+persistent_godot_source_mutation: NONE
+```
+
+이 Gate는 Base current Source Context 흐름을 프로젝트 작업 시작 조건으로 연결하는 thin adapter다. 비교군의 콘텐츠를 복제하지 않고 패턴·제약·실패모드·검증방법만 사용한다. 범위나 핵심 가정이 바뀌면 같은 대화 안에서도 새 work unit으로 보고 fresh research를 다시 수행한다.
 
 ## GM-YEAR-ONE-CHAPTER-CURRICULUM-01 — approved Year-One planning decision
 

--- a/docs/planning/PREWORK_BENCHMARK_INDUSTRY_RESEARCH_01_APPROVAL_2026-08-11.md
+++ b/docs/planning/PREWORK_BENCHMARK_INDUSTRY_RESEARCH_01_APPROVAL_2026-08-11.md
@@ -1,0 +1,176 @@
+# GM-PREWORK-BENCHMARK-INDUSTRY-RESEARCH-01 — 작업 전 벤치마킹·현업조사 Gate
+
+## 1. 상태
+
+```yaml
+decision_id: GM-PREWORK-BENCHMARK-INDUSTRY-RESEARCH-01
+sync_id: GR-SYNC-20260811-13-PREWORK-BENCHMARK-INDUSTRY-RESEARCH
+status: USER_APPROVED_ACTIVE
+approved_at: 2026-08-11T09:49+09:00
+scope: PROJECT_PROCESS_ONLY
+product_decision_mutation: NONE
+persistent_godot_source_mutation: NONE
+```
+
+사용자 지시: **앞으로 모든 새 작업 단위는 작업을 시작하기 전에 벤치마킹과 현업조사를 먼저 수행한 뒤 진행한다.**
+
+이 Decision은 제품/세계관/밸런스 정본을 바꾸지 않는다. 작업을 시작하기 전에 최신 외부 근거와 현재 프로젝트 상태를 대조하도록 강제하는 품질 Gate다.
+
+## 2. Base 정합성
+
+현재 Base main `315c66eea9614c284b9c11c4d522141065dfa4b0`의 Source Context 운용은 다음을 요구한다.
+
+```text
+current Base / PR overlap 확인
+→ original source backtrace
+→ source role / evidence tier
+→ freshness / scope 확인
+→ SOURCE_CONTEXT_PACKET
+→ Existing Solution First
+→ adversarial attack / critique validation
+→ ADOPT | ADAPT | TEST | AVOID | IGNORE | REFERENCE_ONLY
+→ exact-head validation
+```
+
+프로젝트 Gate는 이 Base 흐름을 복제하지 않고 **작업 시작 조건**으로 연결하는 thin adapter다.
+
+## 3. 모든 새 작업 단위의 선행 순서
+
+```text
+1. Base current main / relevant owners 재조회
+2. GRIMOIRE default branch / latest commit / open PR 재조회
+3. Google Sheet current data 재조회
+4. 이번 작업 질문과 비교 대상 정의
+5. 벤치마킹 + 현업조사 수행
+6. 출처 역할·권위·freshness·적용조건 기록
+7. 프로젝트와 비교해 disposition 판정
+8. 적대검토 + Existing Solution First
+9. 그 뒤에만 설계·계획·구현·정본 편집 시작
+10. exact-head 검증 + GitHub/Sheet readback
+```
+
+1~3은 기존 GRIMOIRE 시작 규칙이며, 4~8이 이번 Decision이 추가하는 선행 Gate다.
+
+## 4. 무엇을 벤치마킹하는가
+
+작업 성격에 맞는 비교군을 고른다.
+
+- 게임 디자인/콘텐츠: 유사 장르의 공식 제품·매뉴얼·개발자 발표·GDC/플랫폼 개발자료.
+- UX/UI/접근성: 플랫폼 공식 HIG, 접근성 가이드, 실제 인접 게임 패턴.
+- 기술/엔진/API: 공식 문서·release notes·원 연구/표준을 우선.
+- 제작/운영/마케팅: Steamworks·플랫폼 공식 문서와 방법·표본이 공개된 현업 자료.
+- 서사/게임라이팅: 실제 상호작용형 서사 사례와 전문 게임라이팅 자료를 우선.
+- 프로세스/CI: Base current canon, GitHub/플랫폼 공식 문서, 현재 저장소 회귀 패턴.
+
+단순히 유명한 게임을 고르는 것이 아니라 **이번 결정에 실제로 영향을 줄 비교군**을 고른다.
+
+## 5. Source 권위
+
+기본 우선순위:
+
+```text
+공식/원출처·표준·플랫폼 문서
+> 개발사/개발자 1차 자료·GDC 등 전문 발표
+> 방법과 표본을 공개한 현업 자료
+> 관찰/분석 자료
+> 발견용 큐레이션
+```
+
+- 제3자 요약은 원출처를 대체하지 않는다.
+- 최신성이 중요한 항목은 현재 날짜 기준으로 다시 확인한다.
+- 오래됐어도 설계 원리의 정적 Reference로 유효하면 `STATIC_REFERENCE`라고 명시한다.
+- 외부 자료가 현재 프로젝트에 직접 적용되지 않으면 적용조건과 한계를 기록한다.
+
+## 6. 필수 판정
+
+각 핵심 비교 결과에는 최소 하나의 disposition을 붙인다.
+
+```yaml
+disposition:
+  - ADOPT          # 그대로 적용 가능한 원칙/제약
+  - ADAPT          # 프로젝트 문맥에 맞게 변형
+  - TEST           # 플레이테스트/실험 전에는 채택하지 않음
+  - AVOID          # 프로젝트 목표와 충돌해 피함
+  - IGNORE         # 현재 작업 의사결정에는 의미 없음
+  - REFERENCE_ONLY # 비교·설명용, 정본 소유권 없음
+```
+
+숫자·성공사례를 보편 정답으로 승격하지 않는다.
+
+## 7. Existing Solution First
+
+외부 사례가 좋아 보여도 먼저 현재 GRIMOIRE에 이미 같은 책임을 소유한 시스템이 있는지 확인한다.
+
+```text
+ALREADY_COVERED / PARTIAL
+→ 기존 owner 흡수 우선
+→ 누락된 test / guardrail / source / condition만 보강
+→ 새 시스템·새 화폐·새 메뉴·새 서비스는 마지막 선택
+```
+
+경쟁작의 기능을 추가하는 것 자체가 목표가 아니다. GRIMOIRE의 현재 약속을 더 잘 증명하는 데 필요한 최소 차이만 채택한다.
+
+## 8. 복제 금지
+
+벤치마킹은 패턴·제약·실패모드·검증방법을 배우기 위한 것이다.
+
+- 경쟁작의 대사·서사 사건·캐릭터·레벨·UI 표현·아트 스타일·코드·에셋을 복제하지 않는다.
+- “Persona처럼”, “Dishonored처럼” 같은 모호한 구현 지시를 남기지 않는다.
+- 항상 `무엇을 ADAPT하고 무엇을 REJECT/AVOID하는지` GRIMOIRE 언어로 번역한다.
+
+## 9. 작업 산출물의 Research Receipt
+
+모든 **새 substantive work unit**은 작업 산출물 또는 연결된 benchmark 문서에 다음을 남긴다.
+
+```yaml
+prework_research:
+  checked_at:
+  work_question:
+  current_base:
+  current_project_main:
+  sheet_readback:
+  sources:
+    - source:
+      role:
+      freshness:
+      fact_or_practice:
+      applicability:
+      disposition:
+  existing_solution_check:
+  adversarial_notes:
+  decision_delta:
+```
+
+같은 work unit 안의 CI 재실행·readback·오타 수정처럼 질문과 비교군이 바뀌지 않는 후속 동작은 **그 work unit의 Research Receipt를 재사용**할 수 있다. 범위·제품 결정·핵심 가정이 달라지면 새 work unit으로 간주해 다시 조사한다.
+
+## 10. Stop Gate
+
+다음 중 하나면 본 작업을 시작하지 않는다.
+
+- 최신성이 필요한 핵심 사실을 과거 기억만으로 가정함.
+- 유사 사례를 조사하지 않고 새로운 시스템/콘텐츠 방향을 확정함.
+- 현업 수치/성공사례의 표본·조건을 무시하고 목표치로 고정함.
+- 현재 Base/GRIMOIRE owner보다 경쟁작 패턴을 우선함.
+- 비교군을 조사했지만 ADOPT/ADAPT/TEST/AVOID 판정이 없음.
+- 외부 표현을 복제하려 함.
+- 조사 결과와 현재 정본이 충돌하는데 보고하지 않음.
+
+## 11. 이번 D 작업 적용 증거
+
+`GM-FROSTBLOOM-INTERNAL-VERTICAL-SLICE-01`의 written-spec 승인 이후 writing-plans를 시작하기 전에 다음을 실제 수행했다.
+
+- Witchbrook / Persona 5 Royal: 학교생활·자유시간 시장/구조 비교.
+- Atelier Ryza: 제작 선택과 사용 결과 연결.
+- Dishonored 2: 실제 systemic choice와 가짜 선택 배제.
+- Steamworks: 장르/태그가 고객 설명과 추천에 미치는 역할.
+- Microsoft/ID@Xbox: vertical slice를 작은 가설 검증·고유 핵심 표현으로 다루는 현업 관점.
+- Base current Source Context rule: freshness, Existing Solution First, disposition, exact-head.
+
+D benchmark receipt:
+`docs/planning/FROSTBLOOM_INTERNAL_VERTICAL_SLICE_IMPLEMENTATION_BENCHMARK_2026-08-11.md`
+
+즉 이 프로세스 Decision은 앞으로의 규칙을 만들면서, 이번 작업에서도 이미 요구 행동을 선행 실행한 상태다.
+
+## 12. 증거 한계
+
+이 Gate는 좋은 게임·좋은 설계를 자동 보장하지 않는다. 조사 품질과 프로젝트 적합성을 높이는 절차이며 최종 판단은 사용자 승인, 테스트, 실제 플레이 증거에 따른다.

--- a/docs/planning/sync/GR-SYNC-20260811-13-PREWORK-BENCHMARK-INDUSTRY-RESEARCH.md
+++ b/docs/planning/sync/GR-SYNC-20260811-13-PREWORK-BENCHMARK-INDUSTRY-RESEARCH.md
@@ -1,0 +1,54 @@
+# GR-SYNC-20260811-13-PREWORK-BENCHMARK-INDUSTRY-RESEARCH
+
+```yaml
+sync_id: GR-SYNC-20260811-13-PREWORK-BENCHMARK-INDUSTRY-RESEARCH
+decision_id: GM-PREWORK-BENCHMARK-INDUSTRY-RESEARCH-01
+status: USER_APPROVED_ACTIVE
+scope: PROJECT_PROCESS_ONLY
+product_decision_mutation: NONE
+persistent_godot_source_mutation: NONE
+```
+
+## Trigger
+
+사용자가 `앞으로 항상 작업전에 벤치마킹,현업조사 진행 후 작업 진행해`라고 명시했다.
+
+## Fresh-start evidence
+
+- Base current main: `315c66eea9614c284b9c11c4d522141065dfa4b0`
+- GRIMOIRE current main at entry: `80e4b0eff9bf23117f91bb5be718c746bde5aea0`
+- Open project PR: #116 Task8 Draft/ON_HOLD only
+- Sheet current planning decision: `GM-FROSTBLOOM-INTERNAL-VERTICAL-SLICE-01` / Sync12 / readback PASS
+
+## Benchmark / industry research
+
+The process rule was itself researched before canonization.
+
+- Base current Source Context contract: original-source backtrace, source role, freshness, Existing Solution First, `ADOPT | ADAPT | TEST | AVOID | IGNORE | REFERENCE_ONLY`, adversarial review, exact-head validation.
+- GitHub official docs: pull-request checks/reviews/merge state are explicit quality signals and required checks must pass when protected rules require them.
+- Steamworks official docs: tags and store metadata describe the product and influence discovery/recommendation, supporting evidence-driven market classification rather than memory-only genre labels.
+- Microsoft Game Dev/ID@Xbox: vertical slices are game-specific and should prove a focused hypothesis or show what makes the game unique, supporting decision-specific benchmark selection instead of generic feature checklists.
+
+## Project adaptation
+
+```text
+Fresh project context
+→ work question
+→ relevant benchmarks + professional practice
+→ source role / freshness / applicability
+→ Existing Solution First
+→ ADOPT / ADAPT / TEST / AVOID / IGNORE / REFERENCE_ONLY
+→ adversarial review
+→ only then substantive work
+→ exact-head + readback
+```
+
+A research receipt may be reused for mechanical follow-ups inside the **same unchanged work unit**. A changed scope, product decision, key assumption, or comparison set creates a new work unit and requires a fresh scan.
+
+## Canon
+
+`docs/planning/PREWORK_BENCHMARK_INDUSTRY_RESEARCH_01_APPROVAL_2026-08-11.md`
+
+## Validation boundary
+
+This is a process contract. It does not claim that benchmarking guarantees quality, nor does it authorize product/Godot mutation.

--- a/tests/test_prework_benchmark_industry_research_contract.py
+++ b/tests/test_prework_benchmark_industry_research_contract.py
@@ -1,0 +1,57 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CANON = ROOT / "docs/planning/PREWORK_BENCHMARK_INDUSTRY_RESEARCH_01_APPROVAL_2026-08-11.md"
+SYNC = ROOT / "docs/planning/sync/GR-SYNC-20260811-13-PREWORK-BENCHMARK-INDUSTRY-RESEARCH.md"
+CURRENT = ROOT / "docs/planning/CURRENT_CONFIRMED_DECISIONS.md"
+
+
+class PreworkBenchmarkIndustryResearchContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.canon = CANON.read_text(encoding="utf-8")
+        cls.sync = SYNC.read_text(encoding="utf-8")
+        cls.current = CURRENT.read_text(encoding="utf-8")
+
+    def test_user_approved_process_decision_is_canonical(self):
+        self.assertIn("decision_id: GM-PREWORK-BENCHMARK-INDUSTRY-RESEARCH-01", self.canon)
+        self.assertIn("sync_id: GR-SYNC-20260811-13-PREWORK-BENCHMARK-INDUSTRY-RESEARCH", self.canon)
+        self.assertIn("status: USER_APPROVED_ACTIVE", self.canon)
+        self.assertIn("scope: PROJECT_PROCESS_ONLY", self.canon)
+
+    def test_prework_order_requires_fresh_context_and_research_before_work(self):
+        for token in (
+            "Base current main / relevant owners 재조회",
+            "GRIMOIRE default branch / latest commit / open PR 재조회",
+            "Google Sheet current data 재조회",
+            "벤치마킹 + 현업조사 수행",
+            "그 뒤에만 설계·계획·구현·정본 편집 시작",
+        ):
+            self.assertIn(token, self.canon)
+
+    def test_required_dispositions_and_existing_solution_first_are_present(self):
+        for token in ("ADOPT", "ADAPT", "TEST", "AVOID", "IGNORE", "REFERENCE_ONLY", "Existing Solution First"):
+            self.assertIn(token, self.canon)
+
+    def test_copying_competitor_expression_is_forbidden(self):
+        self.assertIn("복제 금지", self.canon)
+        self.assertIn("경쟁작의 대사·서사 사건·캐릭터·레벨·UI 표현·아트 스타일·코드·에셋을 복제하지 않는다", self.canon)
+
+    def test_same_work_unit_research_receipt_reuse_is_bounded(self):
+        self.assertIn("같은 work unit", self.canon)
+        self.assertIn("범위·제품 결정·핵심 가정이 달라지면 새 work unit", self.canon)
+
+    def test_current_snapshot_exposes_active_process_gate(self):
+        self.assertIn("prework_research_decision: GM-PREWORK-BENCHMARK-INDUSTRY-RESEARCH-01", self.current)
+        self.assertIn("prework_research_sync: GR-SYNC-20260811-13-PREWORK-BENCHMARK-INDUSTRY-RESEARCH", self.current)
+        self.assertIn("prework_research_gate: REQUIRED_BEFORE_NEW_SUBSTANTIVE_WORK_UNIT", self.current)
+
+    def test_sync_preserves_product_and_godot_boundaries(self):
+        self.assertIn("product_decision_mutation: NONE", self.sync)
+        self.assertIn("persistent_godot_source_mutation: NONE", self.sync)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Decision

Canonicalizes the user-approved project process rule `GM-PREWORK-BENCHMARK-INDUSTRY-RESEARCH-01` under `GR-SYNC-20260811-13-PREWORK-BENCHMARK-INDUSTRY-RESEARCH`.

## User requirement

Before every new substantive work unit, perform fresh benchmarking and current industry/professional research before doing the substantive work.

## Base alignment

This is a thin project adapter over current Base Source Context practice: fresh source role/freshness/applicability, original-source preference, Existing Solution First, explicit `ADOPT / ADAPT / TEST / AVOID / IGNORE / REFERENCE_ONLY`, adversarial review, and exact-head validation.

## Operational boundary

- Fresh Base/project/Sheet reads remain required first.
- Same unchanged work unit may reuse its Research Receipt for mechanical CI/readback/typo follow-ups.
- Scope, product decision, key assumption, or comparison-set changes create a new work unit and require fresh research.
- Competitor dialogue/story/characters/levels/UI expression/art style/code/assets may not be copied.
- External benchmarks/numbers are not universal targets.

## Scope

Project process only. No product decision, balance, world, runtime, or persistent Godot authoring authority changes.

## Validation

Adds an executable planning contract and explicit CI invocation. The same Decision/Sync ID is written to the live Google Sheet and has explicit `SHEET_WRITE_READBACK_PASS`.