### PR TITLE
docs: resume Task 8 with HiGodot v3.1.4 preflight

### DIFF
--- a/docs/planning/research/2026-08-11-task8-resume-v314-research-receipt.md
+++ b/docs/planning/research/2026-08-11-task8-resume-v314-research-receipt.md
@@ -1,0 +1,105 @@
+# Task 8 Spell Use Screen — Resume Research Receipt (HiGodot v3.1.4)
+
+```yaml
+work_unit: TASK8_SPELL_USE_SCREEN_RESUME
+work_question: How should Task 8 resume on current main without duplicating Stage 3 authority, while reconciling user-reported HiGodot v3.1.4 against tracked v3.1.3 canon?
+decision_id: GM-SPELL-WORKFLOW-UI-V2-01
+sync_id: GR-SYNC-20260811-17-TASK8-RESUME-V314-PREFLIGHT
+observed_at: 2026-08-11
+base_main: 315c66eea9614c284b9c11c4d522141065dfa4b0
+project_main: 8b3a82576bce2961fe104dc430c2d9c9e0831e06
+project_open_pr: 116_DRAFT_STALE_HANDOFF
+tracked_higodot: v3.1.3
+user_reported_live_higodot: v3.1.4
+official_v3_1_4_release_verified: true
+official_v3_1_4_tag_commit: 96cc8b8c3d25ce487e24801d01d5214fea150349
+official_v3_1_4_plugin_zip_sha256: 77d5bc7f8e0062f88aef08f3471cc6e4546a0d71d18813752781689ab6ce4848
+persistent_godot_mutation_in_this_preflight: NONE
+```
+
+## Fresh authority read
+
+- Base current main remains `315c66eea9614c284b9c11c4d522141065dfa4b0`; current external-source policy requires source-role/freshness/applicability, Existing Solution First, disposition, adversarial review, and exact-head/readback.
+- GRIMOIRE current main is `8b3a82576bce2961fe104dc430c2d9c9e0831e06` after Frostbloom Internal Graybox Pack completion. The next product work unit is Task 8.
+- Open PR #116 is a historical docs-only Task 8 handoff based on an older main and HiGodot v3.1.3. It MUST NOT be merged as-is.
+- Current Sheet still preserves Task 8 `ON_HOLD_USER_REQUEST_COST_DEPENDENCY` and HiGodot v3.1.3 as tracked canon. Later current rows already queue Task 8 resume after Graybox. The user's current instruction resumes work and reports live Godot AI v3.1.4.
+
+## Existing Solution First
+
+Task 8 is a thin UI consumer. Current product code already owns Stage 3 semantics:
+
+```text
+SpellWorkflowCoordinator.select_prepared_spell(spell_id)
+→ SpellWorkflowCoordinator.prepare_target_preview(target_keyword, target, payload)
+→ SpellWorkflowCoordinator.request_use_confirmation()
+→ SpellWorkflowCoordinator.confirm_use(use_transaction_id)
+→ AtomicSpellUseService.use(...)
+```
+
+`prepare_target_preview()` calculates preview and prepares an internal use plan without spending Mana or consuming the prepared spell. `confirm_use()` delegates the commit to the existing atomic service. `AtomicSpellUseService` owns spend / mark-used-once / result-commit-once / rollback and idempotency.
+
+Task 6 and Task 7 establish the local UI pattern: `Control` roots, explicit intent signals, Button semantics, reusable panels/components, state rendered from supplied data, and domain mutation delegated to existing coordinators/services. Task 7 explicitly contains no target-selection UI, so Task 8 is the correct first owner of target selection.
+
+## Fresh benchmark / professional research
+
+| Source | role | freshness / applicability | Task 8 use | disposition |
+|---|---|---|---|---|
+| Godot 4.7 `Control` / GUI navigation / focus docs | AUTHORITY_TARGET | exact engine major/minor family; directly applicable | use Control/Button focus semantics and visible keyboard/gamepad focus | ADOPT |
+| Godot 4.7 InputMap | AUTHORITY_TARGET | current engine docs; directly applicable | one semantic confirm/cancel action can map multiple physical inputs | ADOPT |
+| Android Developers accessibility touch-target guidance | AUTHORITY_TARGET | current Android guidance; platform-specific | protect physical touch usability; map 48dp principle through verified project scaling | ADAPT |
+| Microsoft Xbox Accessibility Guidelines 107/112/113/114 | AUTHORITY_TARGET | current game accessibility guidance; cross-platform design reference | predictable navigation, visible focus, input equivalence, context before activation | ADAPT |
+| Base current UX/UI system design | PROJECT_BASE_AUTHORITY | current Base main | UI receives display state and returns intent; no domain recomputation; Containers/layout/focus/accessibility gates | ADOPT |
+| Existing GRIMOIRE Task 5/6/7 implementation/tests | PROJECT_AUTHORITY | current main | reuse exact Stage 3 authority and local screen conventions | ADOPT |
+| Competitor interaction expression | REFERENCE_ONLY | not needed for implementation correctness | no visual/mechanical expression copying | REFERENCE_ONLY |
+
+### Primary external references
+
+- https://docs.godotengine.org/en/4.7/classes/class_control.html
+- https://docs.godotengine.org/en/4.7/classes/class_inputmap.html
+- https://developer.android.com/guide/topics/ui/accessibility/apps
+- https://learn.microsoft.com/en-us/gaming/accessibility/xbox-accessibility-guidelines/107
+- https://learn.microsoft.com/en-us/gaming/accessibility/xbox-accessibility-guidelines/112
+- https://learn.microsoft.com/en-us/gaming/accessibility/xbox-accessibility-guidelines/113
+- https://learn.microsoft.com/en-us/gaming/accessibility/xbox-accessibility-guidelines/114
+- https://github.com/hi-godot/godot-ai/releases/tag/v3.1.4
+
+## HiGodot v3.1.4 source-state distinction
+
+Official upstream v3.1.4 exists and was published on 2026-08-10. The official tag resolves to commit `96cc8b8c3d25ce487e24801d01d5214fea150349`. The release API reports `godot-ai-plugin.zip` digest `sha256:77d5bc7f8e0062f88aef08f3471cc6e4546a0d71d18813752781689ab6ce4848`.
+
+This does **not** prove the GRIMOIRE tracked `addons/godot_ai` subtree is already v3.1.4. Current tracked evidence remains v3.1.3. Therefore:
+
+```yaml
+live_version_claim: USER_REPORTED_V3_1_4
+upstream_release_claim: VERIFIED_OFFICIAL_V3_1_4
+tracked_project_vendor_claim: V3_1_3_UNTIL_NEW_EXACT_RECONCILIATION
+required_before_persistent_task8_authoring: FRESH_V3_1_4_LIVE_AND_TRACKED_ALIGNMENT_READBACK_OR_EXPLICIT_SEPARATION_OF_VENDOR_DELTA
+```
+
+Vendor alignment and Task 8 product authoring must not be conflated. If a vendor update is still untracked, reconcile that tool-state delta first or isolate it from the Task 8 product delta with exact evidence.
+
+## Adversarial preflight
+
+Fail closed on any of these:
+
+1. Task 8 creates a second target/use transaction authority.
+2. preview, hover, focus, target browsing, or screen open mutates Mana/inventory/result/world.
+3. first/nearest target is silently selected or confirmed.
+4. repeated confirm can double-spend or double-apply results.
+5. target becomes invalid between preview and commit and local UI partially commits anyway.
+6. cancel/back invents a restore policy competing with current workflow state.
+7. touch uses a separate semantic code path from keyboard/gamepad activation.
+8. a fixed absolute layout blocks Task 9 responsive work.
+9. local v3.1.4 is promoted to tracked-vendor PASS without exact evidence.
+10. GitHub text writes are used to bypass HiGodot for protected persistent Godot source.
+11. automated checks are promoted to human/device/performance/full-slice evidence.
+
+## Research conclusion
+
+```yaml
+product_direction_change: NONE
+implementation_direction: THIN_UI_ADAPTER_OVER_EXISTING_STAGE3_AUTHORITY
+preflight_status: PASS_WITH_HIGODOT_V3_1_4_ALIGNMENT_GATE
+next_authorized_action: V314_ALIGNMENT_READBACK_THEN_TASK8_HIGODOT_TDD_RED
+research_receipt_reuse: SAME_WORK_UNIT_ONLY_IF_SCOPE_PRODUCT_DECISION_KEY_ASSUMPTIONS_UNCHANGED
+```

--- a/docs/planning/sync/GR-SYNC-20260811-17-TASK8-RESUME-V314-PREFLIGHT.md
+++ b/docs/planning/sync/GR-SYNC-20260811-17-TASK8-RESUME-V314-PREFLIGHT.md
@@ -1,0 +1,160 @@
+# GR-SYNC-20260811-17 — Task 8 Resume / HiGodot v3.1.4 Preflight
+
+```yaml
+sync_id: GR-SYNC-20260811-17-TASK8-RESUME-V314-PREFLIGHT
+decision_id: GM-SPELL-WORKFLOW-UI-V2-01
+status: TASK8_RESUMED_PREFLIGHT_ACTIVE
+scope: PRODUCT_EXECUTION_PREFLIGHT_ONLY
+product_decision_changed: false
+base_main_observed: 315c66eea9614c284b9c11c4d522141065dfa4b0
+project_main_observed: 8b3a82576bce2961fe104dc430c2d9c9e0831e06
+frostbloom_graybox_dependency: INTERNAL_PACK_PASS
+next_product_task: TASK8_SPELL_USE_SCREEN
+historical_task8_pr: 116
+historical_task8_hold: SUPERSEDED_BY_USER_RESUME_IN_THIS_SYNC
+tracked_higodot_before_sync: v3.1.3
+user_reported_live_higodot: v3.1.4
+official_higodot_v3_1_4_release: VERIFIED
+tracked_higodot_v3_1_4: NOT_YET_VERIFIED
+persistent_godot_authoring_this_sync: NONE
+```
+
+## Resume reason
+
+The user instructed the project to continue and reported that Godot AI is now v3.1.4. This resumes Task 8 at the work-unit/process level. It does not by itself prove that the repository-tracked HiGodot vendor subtree has been reconciled to v3.1.4.
+
+PR #116 remains valuable historical evidence of the paused executor package, but it is based on an older main and v3.1.3 assumptions and must not be merged as-is.
+
+## Fresh prework gate completed
+
+This work unit completed the project-required fresh start gate:
+
+```text
+fresh Base current main/structure
+→ fresh GRIMOIRE current main/open PR/latest
+→ fresh Google Sheet current/work-order/tool rows
+→ define Task 8 resume question
+→ fresh benchmark + professional/platform research
+→ source role/freshness/applicability
+→ Existing Solution First
+→ disposition
+→ adversarial preflight
+```
+
+Research receipt:
+
+`docs/planning/research/2026-08-11-task8-resume-v314-research-receipt.md`
+
+Updated execution plan:
+
+`docs/superpowers/plans/2026-08-11-task8-spell-use-screen.md`
+
+## Current authority and conflicts
+
+### No product-authority conflict
+
+Task 8 still implements the approved third screen:
+
+```text
+글자 그리기 → 회로 배치 → 주문 사용
+```
+
+It remains a consumer of the current Stage 3 authority. No new product decision is introduced.
+
+### Operational/tool-state conflict to reconcile
+
+Current tracked project/Sheet evidence still says:
+
+```yaml
+task8: ON_HOLD_USER_REQUEST_COST_DEPENDENCY
+higodot: v3.1.3
+```
+
+Current user/live information says:
+
+```yaml
+task8: RESUME
+higodot: v3.1.4
+```
+
+Official upstream v3.1.4 is independently verified. The correct disposition is not to overwrite historical v3.1.3 evidence, but to add a new current resume checkpoint and require exact v3.1.4 live/tracked alignment before persistent Task 8 authoring.
+
+## Existing Solution First result
+
+Current main already provides the authority chain Task 8 needs:
+
+```text
+SpellWorkflowCoordinator.select_prepared_spell
+→ prepare_target_preview
+→ request_use_confirmation
+→ confirm_use
+→ AtomicSpellUseService.use
+```
+
+Therefore Task 8 MUST remain a thin UI adapter. New local transaction, Mana, inventory, result, rollback, or save authority is forbidden.
+
+## Research dispositions
+
+```yaml
+ADOPT:
+  - existing Stage3 coordinator/service authority
+  - Godot Control/Button/InputMap semantic input/focus model
+  - Base UI intent-only/domain-separation rule
+ADAPT:
+  - Android minimum touch-target principle through verified project scaling
+  - Xbox accessibility focus/navigation/context guidance to GRIMOIRE Windows+Android UI
+TEST:
+  - actual device/touch ergonomics
+  - full aspect/cutout/foldable/tablet matrix under Task9
+AVOID:
+  - touch-only semantic branch
+  - hidden auto-target
+  - preview mutation
+  - duplicated transaction authority
+  - fixed one-aspect layout assumptions
+  - unsupported tracked-v3.1.4 PASS claim
+REFERENCE_ONLY:
+  - competitor presentation/expression
+```
+
+## Execution gate
+
+Persistent Task 8 authoring may begin only after a fresh authorized HiGodot readback establishes a trustworthy v3.1.4 authoring state and the vendor/tool-state delta is reconciled or explicitly isolated.
+
+Then execute:
+
+```text
+HiGodot v3.1.4 alignment readback
+→ focused GUT RED
+→ minimum Task8 screen authoring via HiGodot
+→ focused GREEN
+→ Task5/6/7 + Spell Workflow regressions
+→ fresh HiGodot receipt exact-delta readback
+→ Hera live acceptance with HERA_SOURCE_DELTA: NONE
+→ exact-head CI
+→ adversarial review
+→ merge gate
+→ merged-main + same-ID Sheet synchronization
+```
+
+## Evidence boundary
+
+```yaml
+human_validation: NOT_RUN
+device_validation: NOT_RUN
+performance_validation: NOT_RUN
+full_vertical_slice_runtime: NOT_RUN
+export_validation: NOT_RUN
+hera_source_mutation: FORBIDDEN
+persistent_godot_source_mutation_via_github: FORBIDDEN
+```
+
+## Current disposition
+
+```yaml
+research_gate: PASS
+existing_solution_first: PASS
+product_plan: READY_REFRESHED_FOR_V3_1_4
+persistent_authoring: BLOCKED_IN_THIS_CHATGPT_SESSION_NO_HIGODOT_EXECUTOR
+next_authorized_external_action: HIGODOT_V3_1_4_ALIGNMENT_THEN_TASK8_TDD_RED
+```

--- a/docs/superpowers/plans/2026-08-11-task8-spell-use-screen.md
+++ b/docs/superpowers/plans/2026-08-11-task8-spell-use-screen.md
@@ -1,0 +1,228 @@
+# Task 8 Spell Use Screen Implementation Plan
+
+> Persistent Godot authoring MUST use the project-authorized HiGodot/Godot AI route. GitHub text writes are not an authoring fallback.
+
+**Decision:** `GM-SPELL-WORKFLOW-UI-V2-01`  
+**Resume sync:** `GR-SYNC-20260811-17-TASK8-RESUME-V314-PREFLIGHT`  
+**Current project main at preflight:** `8b3a82576bce2961fe104dc430c2d9c9e0831e06`  
+**Current Base main at preflight:** `315c66eea9614c284b9c11c4d522141065dfa4b0`
+
+**Goal:** Implement `TASK8_SPELL_USE_SCREEN` as the third screen of the approved spell workflow while consuming the existing Stage 3 preview/confirmation/atomic-use authority exactly as-is.
+
+**Architecture:**
+
+```text
+prepared spell UI
+→ explicit target choice
+→ SpellWorkflowCoordinator.prepare_target_preview(...)
+→ mutation-free expected result + final Mana display
+→ SpellWorkflowCoordinator.request_use_confirmation()
+→ explicit confirm
+→ SpellWorkflowCoordinator.confirm_use(transaction_id)
+→ existing AtomicSpellUseService
+```
+
+Task 8 owns presentation and user intent only. It does not own spell-use business rules, Mana spend, inventory consumption, result mutation, rollback, save semantics, or responsive root coordination.
+
+## 0. Preconditions and tool alignment
+
+Current tracked project evidence says HiGodot v3.1.3. The user reports the live Godot AI environment is now v3.1.4, and official upstream v3.1.4 has been verified. Before any new protected persistent Task 8 source mutation:
+
+- [ ] obtain fresh live readback that the authoring executor reports v3.1.4 and is ready for this project;
+- [ ] compare/reconcile the project-tracked `addons/godot_ai` state with the intended v3.1.4 tool state, or explicitly isolate a vendor-only delta before Task 8 product authoring;
+- [ ] do not label tracked vendor v3.1.4 `PASS` solely from the user report or upstream release existence;
+- [ ] preserve GUT 9.7.1 as deterministic GDScript test authority;
+- [ ] preserve Hera 1.0.0 as live QA/observability only with persistent source mutation forbidden;
+- [ ] create a fresh Task 8 HiGodot authoring receipt for the exact protected product delta.
+
+If v3.1.4 alignment cannot be evidenced, persistent Task 8 authoring is `BLOCKED_UNVERIFIED`; planning/tests/handoff may continue, but GitHub writes must not bypass HiGodot.
+
+## 1. Exact interfaces to consume
+
+Recovered from current main before authoring:
+
+### `SpellWorkflowCoordinator`
+
+Use these exact existing Stage 3 entry points:
+
+- `select_prepared_spell(spell_id: StringName) -> bool`
+- `prepare_target_preview(target_keyword: StringName, target: Dictionary, payload: Dictionary) -> Dictionary`
+- `request_use_confirmation() -> bool`
+- `confirm_use(use_transaction_id: StringName) -> Dictionary`
+
+`prepare_target_preview()` owns target validation + preview-plan construction but performs no use commit. `confirm_use()` creates the existing use request and delegates to the existing use service.
+
+### `AtomicSpellUseService`
+
+Existing authority owns:
+
+- validation of prepared spell / target / final Mana;
+- Mana spend;
+- `mark_used_once`;
+- result `commit_once`;
+- snapshots and rollback on partial failure;
+- prior-result/idempotency handling.
+
+Task 8 MUST NOT duplicate any of these behaviors locally.
+
+### Task 6/7 UI conventions
+
+Follow the existing `src/ui/spell_workflow/` family:
+
+- `Control` root;
+- explicit intent signals / Button semantics;
+- reusable component/panel binding;
+- supplied state rendered without domain recomputation;
+- focus/context restoration where overlays are involved;
+- existing test layout under `tests/integration/`.
+
+Task 7 explicitly has no `TargetSelectionPanel`/`TargetButton`, so target selection belongs first to Task 8.
+
+## 2. TDD RED through HiGodot
+
+Use the exact current Task 6/7 integration-test conventions. Expected new test surface should remain under the existing spell-workflow UI test family; do not create a replacement framework.
+
+RED behaviors:
+
+- [ ] opening the Spell Use screen causes zero Mana/inventory/result/world mutation;
+- [ ] no selected valid target => confirm unavailable/fail-closed and zero mutation;
+- [ ] selecting a valid target calls existing preview authority and updates expected result with zero mutation;
+- [ ] changing target deterministically refreshes preview and does not consume the prepared spell;
+- [ ] final Mana/cost shown to the player is the supplied Stage 3 final preview value, not locally recalculated;
+- [ ] explicit confirmation routes to existing `confirm_use()` exactly once;
+- [ ] repeated/double activation cannot spend Mana, consume the spell, or apply a result twice;
+- [ ] stale/invalid target at commit fails closed with no partial local transaction;
+- [ ] cancel/back before commit preserves current PreparedSpell/workflow semantics and defines no new restore policy;
+- [ ] keyboard/gamepad focus activation and touch activation resolve to the same semantic confirm action;
+- [ ] visible selected/focused/disabled states do not rely on color alone;
+- [ ] long Korean labels and minimum supported layout do not make confirm/cancel/target state ambiguous in the automated structural baseline.
+
+Run the smallest focused GUT command and verify the tests fail for the intended missing Task 8 screen behavior before GREEN implementation.
+
+## 3. Minimum Spell Use Screen through HiGodot
+
+Preferred path follows current family:
+
+```text
+src/ui/spell_workflow/spell_use_screen.gd
+src/ui/spell_workflow/spell_use_screen.tscn
+```
+
+Only use these names if fresh authoring readback confirms no current conflicting path or newer convention.
+
+Required information hierarchy:
+
+```text
+prepared spell summary
+→ explicit target choices
+→ clearly selected target
+→ final Mana / cost
+→ expected result / consequence preview
+→ explicit confirm
+→ cancel / back
+```
+
+Required boundaries:
+
+- no hidden final auto-targeting;
+- no mutation on open, hover, focus, target browsing, or preview;
+- confirm remains unavailable until the existing coordinator reports a confirmable selection;
+- target UI passes target keyword/data/payload to the coordinator rather than computing spell outcome itself;
+- final confirm delegates to `confirm_use()`; no duplicate use service or UI transaction state machine;
+- after successful commit, repeated UI activation is disabled/rejected while navigation/result handling proceeds;
+- failure displays the existing status/reason without a local rollback implementation;
+- no Task 9 root coordinator or full responsive system is pulled into Task 8.
+
+## 4. Input, focus, accessibility, and layout contract
+
+Fresh benchmark disposition:
+
+- **ADOPT — Godot Control/Button/InputMap:** use one semantic action path shared by mouse/touch/keyboard/gamepad instead of a touch-only branch.
+- **ADOPT — visible focus:** keyboard/gamepad focus must remain clearly visible and deterministic.
+- **ADAPT — Microsoft XAG 107/112/113/114:** predictable navigation/back path, input equivalence, clear focus, and enough context to understand an activation before committing.
+- **ADAPT — Android 48dp touch-target principle:** meet physical touch usability through verified project scaling. Do not treat `48dp == 48px` as a universal implementation constant.
+- **TEST — responsive/device evidence:** Task 8 must avoid blocking responsive adaptation, but Task 9 remains owner of the full aspect/cutout/foldable/tablet matrix and real device validation.
+
+Implementation rules:
+
+- use `Control` / `Container` ownership rather than fixed-position layout where practical;
+- important interactive controls remain inside safe layout regions;
+- disabled confirm visibly communicates why it is disabled when that reason is player-relevant;
+- selection/focus/disabled state has textual/shape/state support, not color-only meaning;
+- cancel/back remains reachable using each declared input family;
+- popup/overlay closure restores a meaningful prior focus when applicable.
+
+## 5. HiGodot receipt + deterministic GREEN
+
+- [ ] produce a fresh HiGodot authoring receipt for every protected persistent file changed by the Task 8 authoring session, including generated `.gd.uid` files if created;
+- [ ] keep vendor/tool-state delta separate from Task 8 product delta unless an explicitly scoped reconciliation proves both;
+- [ ] read back the exact protected delta against the receipt;
+- [ ] focused Task 8 GUT tests GREEN;
+- [ ] existing Task 5 atomic-use + workflow coordinator regressions GREEN;
+- [ ] existing Task 6/7 screen regressions GREEN;
+- [ ] applicable repository CI GREEN at exact PR head;
+- [ ] Hera acceptance reports `HERA_SOURCE_DELTA: NONE`;
+- [ ] human/device/performance/full-slice/export remain `NOT_RUN` unless real new evidence is produced.
+
+## 6. Adversarial merge review
+
+Attack at minimum:
+
+```text
+second target/use authority appeared in UI
+preview mutates Mana/inventory/result/world
+first/nearest target is silently selected or confirmed
+UI recalculates final Mana/result instead of displaying coordinator output
+confirm can double-fire
+stale target creates a partial transaction
+cancel/back invents competing restore semantics
+input paths diverge by device
+focus is absent/ambiguous
+layout is hardcoded to one aspect and blocks Task9
+v3.1.4 user report was promoted to tracked-vendor PASS without evidence
+receipt omits protected/generated files
+Hera/test tooling mutates persistent source
+human/device/performance claims are promoted without evidence
+```
+
+Merge evidence:
+
+```yaml
+exact_head_unchanged: true
+all_applicable_ci_success: true
+focused_task8_gut_green: true
+spell_workflow_regression_green: true
+higodot_v314_alignment: PASS_OR_EXPLICITLY_ISOLATED_VENDOR_DELTA
+higodot_task8_fresh_receipt_readback: PASS
+hera_source_delta: NONE
+unresolved_review_threads: 0
+P0: 0
+P1: 0
+product_decision_changed: false
+```
+
+## 7. Post-merge synchronization
+
+After product implementation is actually merged:
+
+- re-read merged `main`;
+- promote Task 8 to merged only from merged-main evidence;
+- set Task 9 next only after that readback;
+- synchronize GitHub canon + Google Sheet using `GM-SPELL-WORKFLOW-UI-V2-01` and the same Task 8 implementation sync/checkpoint ID;
+- preserve historical Task 8 hold and v3.1.3 audit evidence rather than rewriting history;
+- keep unsupported human/device/performance/export/full-slice statuses unchanged;
+- run stale-consumer and adversarial readback.
+
+## 8. Current execution boundary
+
+This ChatGPT session has completed fresh authority reads, current-interface recovery, and fresh benchmark/professional research. It does not expose the authorized HiGodot authoring executor, so it must stop before persistent Task 8 `.gd/.tscn/.tres/.res/project.godot` mutation.
+
+The next persistent action is:
+
+```text
+HiGodot v3.1.4 live/tracked alignment readback
+→ Task 8 focused GUT RED
+→ minimum Spell Use Screen GREEN
+→ receipt/readback
+→ regressions/Hera/CI/adversarial
+```


### PR DESCRIPTION
## Scope

Resume `GM-SPELL-WORKFLOW-UI-V2-01` Task 8 from current `main` after Frostbloom Graybox completion. This PR is a **docs-only execution preflight** and does not author persistent Godot product source.

Sync: `GR-SYNC-20260811-17-TASK8-RESUME-V314-PREFLIGHT`

## Fresh prework completed

- Base current main/structure re-read: `315c66eea9614c284b9c11c4d522141065dfa4b0`
- GRIMOIRE current main/open PR/latest re-read: `8b3a82576bce2961fe104dc430c2d9c9e0831e06`
- Google Sheet current/work-order/tool/history state re-read and Sync17 written/read back
- fresh Godot/Android/Xbox accessibility and input research
- Existing Solution First against current Task 5/6/7 code/tests
- adversarial preflight

## HiGodot v3.1.4 state

The user reports the live Godot AI environment is v3.1.4 and official upstream v3.1.4 is verified. Current tracked project evidence is still v3.1.3, so this PR deliberately does **not** claim tracked-v3.1.4 PASS.

Persistent Task 8 authoring gate:

`fresh authorized v3.1.4 live/tracked alignment readback OR explicitly isolated vendor delta → focused GUT RED → HiGodot Task8 authoring`

## Existing authority preserved

Task 8 remains a thin UI consumer of:

`SpellWorkflowCoordinator.select_prepared_spell → prepare_target_preview → request_use_confirmation → confirm_use → AtomicSpellUseService.use`

No new Mana/inventory/result/rollback/save/transaction authority is introduced.

## Changed files

- Task8 v3.1.4 research receipt
- refreshed Task8 execution plan
- Sync17 resume/preflight checkpoint

## Evidence boundaries

- persistent Godot product source mutation: `NONE`
- human/device/performance/full-slice/export: `NOT_RUN`
- Hera persistent mutation: `FORBIDDEN`
- GitHub Godot-source bypass: `FORBIDDEN`

This supersedes the operational purpose of historical Draft PR #116; #116 should not be merged as-is because it is based on older main/v3.1.3 assumptions.