### PR TITLE
fix: harden Godot 4.7.1 toolchain artifact download

### DIFF
--- a/docs/planning/research/2026-08-11-godot-toolchain-download-resilience-research-receipt.md
+++ b/docs/planning/research/2026-08-11-godot-toolchain-download-resilience-research-receipt.md
@@ -1,0 +1,151 @@
+# Godot 4.7.1 Toolchain Download Resilience — Research Receipt
+
+```yaml
+work_unit: GODOT_TOOLCHAIN_DOWNLOAD_RESILIENCE
+decision_id: GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01
+sync_id: GR-SYNC-20260811-18-GODOT-TOOLCHAIN-DOWNLOAD-RESILIENCE
+work_question: How should GRIMOIRE make its pinned Godot 4.7.1 export-template CI download deterministic and fail-closed after repeated BadZipFile failures, without changing product/Godot authoring authority?
+observed_at: 2026-08-11
+base_main: 069f0c9654a6cde7cea6f3343dd2fa81c6248d5d
+project_main: 821ad1255ebc620e1a9e14a1e27bc2af1844de4b
+triggering_pr: 128
+implementation_pr: 129
+persistent_godot_source_mutation: NONE
+product_decision_change: NONE
+```
+
+## Fresh authority read
+
+- Base `main` advanced from the prior Task 8 observation to `069f0c9654a6cde7cea6f3343dd2fa81c6248d5d`; the current Source Context policy still requires source role/freshness/applicability, Existing Solution First, explicit disposition, adversarial review, and exact-head/readback.
+- GRIMOIRE `main` at work-unit start was `821ad1255ebc620e1a9e14a1e27bc2af1844de4b`.
+- Open PR #128 contained one documentation-only HiGodot v3.1.4 alignment-input file. Its planning/Spell/authoring/Star gates were green, but the Godot 4.7.1 toolchain lane failed repeatedly after the offline contract tests passed.
+- The current Sheet still observed the earlier Base SHA, so this work unit treats that as stale observation metadata rather than a product-authority conflict.
+
+## Triggering failure evidence
+
+The failing workflow reached:
+
+```text
+python -m unittest tests.test_godot_toolchain_setup
+→ PASS (7 tests)
+→ download engine/templates
+→ export template extraction
+→ zipfile.BadZipFile: File is not a zip file
+```
+
+The failure repeated across multiple attempts on PR #128. The existing downloader accepted any non-empty HTTP response and immediately handed it to `zipfile.ZipFile`, so HTTP success was being treated as archive integrity proof.
+
+## Existing Solution First
+
+Keep the existing toolchain ownership:
+
+```text
+tools/setup_godot_toolchain.py
+→ build pinned URLs
+→ download_file(...)
+→ safe_extract_zip(...)
+→ install_engine / install_templates
+→ version + headless probe
+```
+
+Do not replace this with a second installer, shell-only curl path, third-party download action, or product-source workaround. Extend the existing downloader with the minimum missing artifact-integrity contract.
+
+## Fresh official / professional research
+
+| Source | role | freshness / applicability | use | disposition |
+|---|---|---|---|---|
+| Godot 4.7.1 official archive | AUTHORITY_TARGET | exact pinned engine release | confirms stable release and export-template distribution | ADOPT |
+| `godotengine/godot-builds` official 4.7.1 release asset metadata | AUTHORITY_TARGET | exact artifact | pin direct release URL, exact byte size, exact SHA256 | ADOPT |
+| Python `urllib.request` docs | AUTHORITY_TARGET | current stdlib behavior | timeout/HTTP completion is not integrity verification | ADOPT |
+| Python `zipfile` docs | AUTHORITY_TARGET | current stdlib behavior | extraction must happen only after trusted artifact verification | ADOPT |
+| GitHub REST release-asset metadata | AUTHORITY_TARGET | current GitHub behavior | release assets expose size/digest/browser download URL | ADOPT |
+| GitHub Actions dependency-cache guidance | REFERENCE_TARGET | current CI option | cache is possible but not the smallest first fix for a 1.28 GB artifact | TEST / DEFER |
+
+Primary references:
+
+- https://godotengine.org/download/archive/4.7.1-stable/
+- https://github.com/godotengine/godot-builds/releases/tag/4.7.1-stable
+- https://docs.python.org/3/library/urllib.request.html
+- https://docs.python.org/3/library/zipfile.html
+- https://docs.github.com/en/rest/releases/assets
+- https://docs.github.com/actions/using-workflows/caching-dependencies-to-speed-up-workflows
+
+## Exact official export-template artifact
+
+```yaml
+name: Godot_v4.7.1-stable_export_templates.tpz
+browser_download_url: https://github.com/godotengine/godot-builds/releases/download/4.7.1-stable/Godot_v4.7.1-stable_export_templates.tpz
+size_bytes: 1280486955
+sha256: 86409db6200b6f8fd3230989c2d2002851f3dd18acf11d7bdbafddf5a0dd0f72
+```
+
+## Disposition
+
+```yaml
+ADOPT:
+  - direct pinned official godot-builds release-asset URL for export templates
+  - exact official size verification
+  - exact official SHA256 verification
+  - delete corrupt/partial files before another attempt
+ADAPT:
+  - bounded retry inside existing Python downloader
+TEST:
+  - future Actions cache only if repeated 1.28 GB transfer cost becomes material
+AVOID:
+  - generic redirect endpoint as sole artifact identity
+  - HTTP success or non-empty file as integrity proof
+  - extracting the same known-corrupt file again
+  - unbounded retries
+  - adding a second installer path
+IGNORE:
+  - product/gameplay changes; unrelated to this failure
+REFERENCE_ONLY:
+  - caching as optimization rather than correctness authority
+```
+
+## TDD evidence
+
+The implementation followed small RED → GREEN cycles on PR #129:
+
+1. require pinned official export-template release URL;
+2. require explicit size/SHA256/retry download contract;
+3. reject and remove size-mismatched artifacts;
+4. reject and remove SHA256-mismatched artifacts;
+5. retry after an integrity failure and redownload from scratch;
+6. require `install_templates()` to pass the exact official size/SHA256 and bounded retry count.
+
+Observed RED failures matched the missing behavior each time, including:
+
+- generic URL mismatch;
+- missing integrity-contract parameters;
+- `RuntimeError not raised` for truncated content;
+- `RuntimeError not raised` for checksum mismatch;
+- no second attempt after first corrupt artifact;
+- `expected_size == None` at the `install_templates()` integration boundary.
+
+## Adversarial review
+
+Fail closed if any of these occurs:
+
+1. a corrupt file survives after a failed integrity check;
+2. a mismatch is retried without deleting the previous bytes;
+3. retries are unbounded;
+4. the template URL is not pinned to the exact 4.7.1 stable asset;
+5. the official size or SHA256 is not supplied by `install_templates()`;
+6. extraction happens before the size/SHA256 contract passes;
+7. the change mutates persistent Godot product source or changes HiGodot/GUT/Hera ownership;
+8. a cache is treated as artifact authenticity authority;
+9. engine/product validation is promoted beyond actual CI evidence.
+
+## Research conclusion
+
+```yaml
+root_cause_class: LARGE_ARTIFACT_DOWNLOAD_INTEGRITY_GAP
+implementation_direction: EXTEND_EXISTING_DOWNLOADER_WITH_PINNED_ASSET_SIZE_SHA256_AND_BOUNDED_RETRY
+product_scope: NONE
+godot_authoring_scope: NONE
+higodot_authority_change: NONE
+gut_authority_change: NONE
+hera_authority_change: NONE
+research_gate: PASS
+```

--- a/docs/planning/sync/GR-SYNC-20260811-18-GODOT-TOOLCHAIN-DOWNLOAD-RESILIENCE.md
+++ b/docs/planning/sync/GR-SYNC-20260811-18-GODOT-TOOLCHAIN-DOWNLOAD-RESILIENCE.md
@@ -1,0 +1,139 @@
+# GR-SYNC-20260811-18 — Godot 4.7.1 Toolchain Download Resilience
+
+```yaml
+sync_id: GR-SYNC-20260811-18-GODOT-TOOLCHAIN-DOWNLOAD-RESILIENCE
+decision_id: GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01
+status: IMPLEMENTED_PENDING_EXACT_HEAD_MERGE_GATE
+scope: CI_TOOLCHAIN_RESILIENCE_ONLY
+base_main_observed: 069f0c9654a6cde7cea6f3343dd2fa81c6248d5d
+project_main_observed: 821ad1255ebc620e1a9e14a1e27bc2af1844de4b
+triggering_pr: 128
+implementation_pr: 129
+persistent_godot_source_mutation: NONE
+product_decision_changed: false
+```
+
+## Why this work unit exists
+
+PR #128's documentation-only Task 8 alignment input repeatedly failed the Godot 4.7.1 toolchain lane after offline contract tests passed. The repeated exception was `zipfile.BadZipFile` while extracting the 4.7.1 export-template download.
+
+The existing downloader treated a non-empty response as sufficient and performed no expected-size or digest check before extraction.
+
+This is a CI/toolchain reliability defect, not a Task 8 product defect. The work was separated into its own work unit and PR instead of weakening #128's merge gate or mixing product logic with infrastructure repair.
+
+## Fresh prework gate
+
+Completed:
+
+```text
+fresh Base current main/structure
+→ fresh GRIMOIRE main/open PR/latest
+→ fresh Sheet current rows
+→ define toolchain integrity question
+→ official Godot/Python/GitHub research
+→ source role/freshness/applicability
+→ Existing Solution First
+→ disposition
+→ adversarial review
+→ TDD RED/GREEN implementation
+```
+
+Research receipt:
+
+`docs/planning/research/2026-08-11-godot-toolchain-download-resilience-research-receipt.md`
+
+## Implementation
+
+`tools/setup_godot_toolchain.py` now keeps the existing installer architecture and adds only the missing integrity behavior for the pinned export templates:
+
+```text
+direct official 4.7.1 release asset URL
+→ fresh download attempt
+→ exact byte-size check
+→ exact SHA256 check
+→ delete failed bytes
+→ bounded retry (max 3)
+→ extraction only after verification passes
+```
+
+Pinned artifact:
+
+```yaml
+asset: Godot_v4.7.1-stable_export_templates.tpz
+size_bytes: 1280486955
+sha256: 86409db6200b6f8fd3230989c2d2002851f3dd18acf11d7bdbafddf5a0dd0f72
+max_attempts: 3
+```
+
+The engine download path is unchanged because the observed defect was the export-template artifact and the smallest correction is preferred.
+
+## TDD proof
+
+PR #129 observed the intended RED state before each implementation increment:
+
+- pinned official URL missing;
+- integrity/retry parameters missing;
+- truncated artifact accepted;
+- checksum mismatch accepted;
+- integrity failure not retried;
+- `install_templates()` not passing official metadata.
+
+Each RED failed for the targeted missing behavior before its GREEN implementation was added.
+
+## Authority boundaries
+
+Unchanged:
+
+```yaml
+higodot: SOLE_PERSISTENT_GODOT_AUTHORING_AUTHORITY
+gut: DETERMINISTIC_GDSCRIPT_TEST_AUTHORITY
+hera: LIVE_QA_OBSERVABILITY_ONLY
+persistent_godot_source_mutation_via_github: FORBIDDEN
+product_source_mutation_this_sync: NONE
+```
+
+This work changes only Python CI/toolchain setup logic, its deterministic unit tests, and planning/audit documentation.
+
+## Adversarial merge gate
+
+Before merge require:
+
+```yaml
+exact_pr_head_unchanged: true
+toolchain_contract_tests: PASS
+real_godot_4_7_1_engine_download: PASS
+real_export_template_1280486955_byte_sha256_verification: PASS
+real_export_template_extraction: PASS
+headless_probe: PASS
+planning_base_gate: PASS
+spell_current_state_gate: PASS
+godot_authoring_authority_gate: PASS
+star_gates: PASS_OR_APPLICABLE_SKIP
+review_threads: 0
+persistent_godot_source_delta: NONE
+P0: 0
+P1: 0
+```
+
+## Interaction with Task 8
+
+PR #128 remains the Task 8 v3.1.4 alignment-input PR and must not be merged while its exact-head toolchain check is red. After this resilience fix merges to `main`, #128 must be refreshed onto the repaired base (or replaced by an equivalent fresh branch) and re-run at an exact head before merge.
+
+Task 8 protected product authoring still requires:
+
+```text
+HiGodot v3.1.4 exact alignment readback
+→ focused GUT RED
+→ minimum Spell Use Screen GREEN via HiGodot
+```
+
+## Current evidence boundary
+
+```yaml
+human_validation: NOT_RUN
+device_validation: NOT_RUN
+performance_validation: NOT_RUN
+export_product_validation: NOT_RUN
+full_vertical_slice_runtime: NOT_RUN
+task8_product_authoring: NOT_STARTED_IN_THIS_SYNC
+```

--- a/tests/test_godot_toolchain_setup.py
+++ b/tests/test_godot_toolchain_setup.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import tempfile
 import unittest
 import zipfile
@@ -9,6 +10,7 @@ from tools.setup_godot_toolchain import (
     GODOT_VERSION,
     build_engine_url,
     build_templates_url,
+    download_file,
     resolve_platform,
     safe_extract_zip,
     version_matches,
@@ -42,6 +44,12 @@ class GodotToolchainSetupTests(unittest.TestCase):
             "https://github.com/godotengine/godot-builds/releases/download/4.7.1-stable/Godot_v4.7.1-stable_export_templates.tpz",
             build_templates_url(),
         )
+
+    def test_download_file_accepts_integrity_and_retry_contract(self) -> None:
+        parameters = inspect.signature(download_file).parameters
+        self.assertIn("expected_size", parameters)
+        self.assertIn("expected_sha256", parameters)
+        self.assertIn("max_attempts", parameters)
 
     def test_unsupported_architecture_fails_clearly(self) -> None:
         with self.assertRaisesRegex(RuntimeError, "Unsupported Godot host"):

--- a/tests/test_godot_toolchain_setup.py
+++ b/tests/test_godot_toolchain_setup.py
@@ -36,10 +36,10 @@ class GodotToolchainSetupTests(unittest.TestCase):
             build_engine_url(spec),
         )
 
-    def test_templates_use_same_exact_version(self) -> None:
+    def test_templates_use_pinned_official_release_asset(self) -> None:
         self.assertEqual("4.7.1", GODOT_VERSION)
         self.assertEqual(
-            "https://downloads.godotengine.org/?flavor=stable&platform=templates&slug=export_templates.tpz&version=4.7.1",
+            "https://github.com/godotengine/godot-builds/releases/download/4.7.1-stable/Godot_v4.7.1-stable_export_templates.tpz",
             build_templates_url(),
         )
 

--- a/tests/test_godot_toolchain_setup.py
+++ b/tests/test_godot_toolchain_setup.py
@@ -68,6 +68,23 @@ class GodotToolchainSetupTests(unittest.TestCase):
                     )
             self.assertFalse(destination.exists())
 
+    def test_download_file_rejects_sha256_mismatch_and_removes_bad_file(self) -> None:
+        payload = b"same-size-corruption"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            destination = Path(temp_dir) / "artifact.tpz"
+            with patch(
+                "tools.setup_godot_toolchain.urllib.request.urlopen",
+                return_value=io.BytesIO(payload),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "sha256 mismatch"):
+                    download_file(
+                        "https://example.invalid/artifact.tpz",
+                        destination,
+                        expected_size=len(payload),
+                        expected_sha256="0" * 64,
+                    )
+            self.assertFalse(destination.exists())
+
     def test_unsupported_architecture_fails_clearly(self) -> None:
         with self.assertRaisesRegex(RuntimeError, "Unsupported Godot host"):
             resolve_platform("Windows", "ARM32")

--- a/tests/test_godot_toolchain_setup.py
+++ b/tests/test_godot_toolchain_setup.py
@@ -13,6 +13,7 @@ from tools.setup_godot_toolchain import (
     build_engine_url,
     build_templates_url,
     download_file,
+    install_templates,
     resolve_platform,
     safe_extract_zip,
     version_matches,
@@ -105,6 +106,38 @@ class GodotToolchainSetupTests(unittest.TestCase):
             if destination.exists():
                 self.assertEqual(b"good", destination.read_bytes())
             self.assertEqual(2, opener.call_count)
+
+    def test_install_templates_uses_official_size_sha256_and_bounded_retries(self) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_download(
+            url: str,
+            destination: Path,
+            timeout_seconds: int = 180,
+            **kwargs: object,
+        ) -> None:
+            captured["url"] = url
+            captured["timeout_seconds"] = timeout_seconds
+            captured.update(kwargs)
+            with zipfile.ZipFile(destination, "w") as bundle:
+                bundle.writestr("templates/dummy.txt", "ok")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            install_root = Path(temp_dir) / "godot"
+            with patch("tools.setup_godot_toolchain.download_file", side_effect=fake_download):
+                template_root = install_templates(install_root)
+
+            self.assertEqual(
+                "https://github.com/godotengine/godot-builds/releases/download/4.7.1-stable/Godot_v4.7.1-stable_export_templates.tpz",
+                captured.get("url"),
+            )
+            self.assertEqual(1280486955, captured.get("expected_size"))
+            self.assertEqual(
+                "86409db6200b6f8fd3230989c2d2002851f3dd18acf11d7bdbafddf5a0dd0f72",
+                captured.get("expected_sha256"),
+            )
+            self.assertEqual(3, captured.get("max_attempts"))
+            self.assertEqual("ok", (template_root / "dummy.txt").read_text(encoding="utf-8"))
 
     def test_unsupported_architecture_fails_clearly(self) -> None:
         with self.assertRaisesRegex(RuntimeError, "Unsupported Godot host"):

--- a/tests/test_godot_toolchain_setup.py
+++ b/tests/test_godot_toolchain_setup.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import inspect
+import io
 import tempfile
 import unittest
 import zipfile
 from pathlib import Path
+from unittest.mock import patch
 
 from tools.setup_godot_toolchain import (
     GODOT_VERSION,
@@ -50,6 +52,21 @@ class GodotToolchainSetupTests(unittest.TestCase):
         self.assertIn("expected_size", parameters)
         self.assertIn("expected_sha256", parameters)
         self.assertIn("max_attempts", parameters)
+
+    def test_download_file_rejects_size_mismatch_and_removes_bad_file(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            destination = Path(temp_dir) / "artifact.tpz"
+            with patch(
+                "tools.setup_godot_toolchain.urllib.request.urlopen",
+                return_value=io.BytesIO(b"bad"),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "size mismatch"):
+                    download_file(
+                        "https://example.invalid/artifact.tpz",
+                        destination,
+                        expected_size=4,
+                    )
+            self.assertFalse(destination.exists())
 
     def test_unsupported_architecture_fails_clearly(self) -> None:
         with self.assertRaisesRegex(RuntimeError, "Unsupported Godot host"):

--- a/tests/test_godot_toolchain_setup.py
+++ b/tests/test_godot_toolchain_setup.py
@@ -85,6 +85,27 @@ class GodotToolchainSetupTests(unittest.TestCase):
                     )
             self.assertFalse(destination.exists())
 
+    def test_download_file_retries_after_integrity_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            destination = Path(temp_dir) / "artifact.tpz"
+            with patch(
+                "tools.setup_godot_toolchain.urllib.request.urlopen",
+                side_effect=[io.BytesIO(b"bad"), io.BytesIO(b"good")],
+            ) as opener:
+                try:
+                    download_file(
+                        "https://example.invalid/artifact.tpz",
+                        destination,
+                        expected_size=4,
+                        max_attempts=2,
+                    )
+                except RuntimeError:
+                    pass
+            self.assertTrue(destination.exists())
+            if destination.exists():
+                self.assertEqual(b"good", destination.read_bytes())
+            self.assertEqual(2, opener.call_count)
+
     def test_unsupported_architecture_fails_clearly(self) -> None:
         with self.assertRaisesRegex(RuntimeError, "Unsupported Godot host"):
             resolve_platform("Windows", "ARM32")

--- a/tools/setup_godot_toolchain.py
+++ b/tools/setup_godot_toolchain.py
@@ -103,7 +103,15 @@ def safe_extract_zip(archive: Path, destination: Path) -> None:
         bundle.extractall(destination)
 
 
-def download_file(url: str, destination: Path, timeout_seconds: int = 180) -> None:
+def download_file(
+    url: str,
+    destination: Path,
+    timeout_seconds: int = 180,
+    *,
+    expected_size: int | None = None,
+    expected_sha256: str | None = None,
+    max_attempts: int = 1,
+) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
     request = urllib.request.Request(url, headers={"User-Agent": "GRIMOIRE-Godot-Toolchain/1"})
     with urllib.request.urlopen(request, timeout=timeout_seconds) as response:

--- a/tools/setup_godot_toolchain.py
+++ b/tools/setup_godot_toolchain.py
@@ -79,7 +79,11 @@ def build_engine_url(spec: PlatformSpec) -> str:
 
 
 def build_templates_url() -> str:
-    return _download_url("templates", "export_templates.tpz")
+    return (
+        f"https://github.com/godotengine/godot-builds/releases/download/"
+        f"{GODOT_VERSION}-{GODOT_STATUS}/"
+        f"Godot_v{GODOT_VERSION}-{GODOT_STATUS}_export_templates.tpz"
+    )
 
 
 def version_matches(output: str) -> bool:

--- a/tools/setup_godot_toolchain.py
+++ b/tools/setup_godot_toolchain.py
@@ -117,8 +117,15 @@ def download_file(
     with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
         with destination.open("wb") as output:
             shutil.copyfileobj(response, output)
-    if destination.stat().st_size == 0:
+    actual_size = destination.stat().st_size
+    if actual_size == 0:
+        destination.unlink(missing_ok=True)
         raise RuntimeError(f"downloaded empty file from {url}")
+    if expected_size is not None and actual_size != expected_size:
+        destination.unlink(missing_ok=True)
+        raise RuntimeError(
+            f"download size mismatch for {url}: expected {expected_size} bytes, got {actual_size}"
+        )
 
 
 def _find_executable(root: Path, executable_name: str) -> Path:

--- a/tools/setup_godot_toolchain.py
+++ b/tools/setup_godot_toolchain.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import platform
@@ -103,6 +104,14 @@ def safe_extract_zip(archive: Path, destination: Path) -> None:
         bundle.extractall(destination)
 
 
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
 def download_file(
     url: str,
     destination: Path,
@@ -126,6 +135,13 @@ def download_file(
         raise RuntimeError(
             f"download size mismatch for {url}: expected {expected_size} bytes, got {actual_size}"
         )
+    if expected_sha256 is not None:
+        actual_sha256 = _sha256_file(destination)
+        if actual_sha256.lower() != expected_sha256.lower():
+            destination.unlink(missing_ok=True)
+            raise RuntimeError(
+                f"download sha256 mismatch for {url}: expected {expected_sha256}, got {actual_sha256}"
+            )
 
 
 def _find_executable(root: Path, executable_name: str) -> Path:

--- a/tools/setup_godot_toolchain.py
+++ b/tools/setup_godot_toolchain.py
@@ -121,27 +121,39 @@ def download_file(
     expected_sha256: str | None = None,
     max_attempts: int = 1,
 ) -> None:
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be at least 1")
     destination.parent.mkdir(parents=True, exist_ok=True)
-    request = urllib.request.Request(url, headers={"User-Agent": "GRIMOIRE-Godot-Toolchain/1"})
-    with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
-        with destination.open("wb") as output:
-            shutil.copyfileobj(response, output)
-    actual_size = destination.stat().st_size
-    if actual_size == 0:
+
+    for attempt in range(1, max_attempts + 1):
         destination.unlink(missing_ok=True)
-        raise RuntimeError(f"downloaded empty file from {url}")
-    if expected_size is not None and actual_size != expected_size:
-        destination.unlink(missing_ok=True)
-        raise RuntimeError(
-            f"download size mismatch for {url}: expected {expected_size} bytes, got {actual_size}"
-        )
-    if expected_sha256 is not None:
-        actual_sha256 = _sha256_file(destination)
-        if actual_sha256.lower() != expected_sha256.lower():
-            destination.unlink(missing_ok=True)
-            raise RuntimeError(
-                f"download sha256 mismatch for {url}: expected {expected_sha256}, got {actual_sha256}"
+        try:
+            request = urllib.request.Request(
+                url,
+                headers={"User-Agent": "GRIMOIRE-Godot-Toolchain/1"},
             )
+            with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+                with destination.open("wb") as output:
+                    shutil.copyfileobj(response, output)
+
+            actual_size = destination.stat().st_size
+            if actual_size == 0:
+                raise RuntimeError(f"downloaded empty file from {url}")
+            if expected_size is not None and actual_size != expected_size:
+                raise RuntimeError(
+                    f"download size mismatch for {url}: expected {expected_size} bytes, got {actual_size}"
+                )
+            if expected_sha256 is not None:
+                actual_sha256 = _sha256_file(destination)
+                if actual_sha256.lower() != expected_sha256.lower():
+                    raise RuntimeError(
+                        f"download sha256 mismatch for {url}: expected {expected_sha256}, got {actual_sha256}"
+                    )
+            return
+        except (OSError, RuntimeError):
+            destination.unlink(missing_ok=True)
+            if attempt >= max_attempts:
+                raise
 
 
 def _find_executable(root: Path, executable_name: str) -> Path:

--- a/tools/setup_godot_toolchain.py
+++ b/tools/setup_godot_toolchain.py
@@ -20,6 +20,9 @@ from typing import Final
 GODOT_VERSION: Final = "4.7.1"
 GODOT_STATUS: Final = "stable"
 OFFICIAL_DOWNLOAD_ENDPOINT: Final = "https://downloads.godotengine.org/"
+GODOT_TEMPLATES_SIZE: Final = 1_280_486_955
+GODOT_TEMPLATES_SHA256: Final = "86409db6200b6f8fd3230989c2d2002851f3dd18acf11d7bdbafddf5a0dd0f72"
+GODOT_TEMPLATES_DOWNLOAD_ATTEMPTS: Final = 3
 VERSION_PATTERN: Final = re.compile(r"^4\.7\.1\.stable(?:\.|$)")
 
 
@@ -202,7 +205,13 @@ def install_templates(install_root: Path) -> Path:
         temp_root = Path(temp_dir)
         archive = temp_root / "export_templates.tpz"
         extract_root = temp_root / "templates-extracted"
-        download_file(build_templates_url(), archive)
+        download_file(
+            build_templates_url(),
+            archive,
+            expected_size=GODOT_TEMPLATES_SIZE,
+            expected_sha256=GODOT_TEMPLATES_SHA256,
+            max_attempts=GODOT_TEMPLATES_DOWNLOAD_ATTEMPTS,
+        )
         safe_extract_zip(archive, extract_root)
         source = extract_root / "templates"
         if not source.is_dir():


### PR DESCRIPTION
## Scope

New CI-resilience work unit discovered while validating Task8 PR #128. This PR is intentionally separate from Task8 product/alignment content.

Owner decision: `GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01`
Sync: `GR-SYNC-20260811-18-GODOT-TOOLCHAIN-DOWNLOAD-RESILIENCE`

## Fresh-start status

- Base current main re-read: `069f0c9654a6cde7cea6f3343dd2fa81c6248d5d`
- GRIMOIRE main re-read: `821ad1255ebc620e1a9e14a1e27bc2af1844de4b`
- open PR state re-read: #128 only before this PR
- Sheet current rows re-read; Sheet Base observation is stale at `315c66ee...`
- official Godot 4.7.1 release asset metadata re-verified
- Python/GitHub Actions official download/integrity behavior researched

## TDD

First commit is deliberately RED: it requires the export-template URL to resolve to the pinned official Godot build release asset instead of the generic redirect endpoint. Production code has not yet been changed.

The repeated PR #128 failure is `zipfile.BadZipFile` after the 7 offline toolchain contract tests pass, on a 1.280 GB official export-template asset. The implementation will remain bounded to download integrity/retry behavior and will not touch persistent Godot product source.
