### PR TITLE
docs: bind project-dedicated local environment and Hera flow

### DIFF
--- a/START_HERE.md
+++ b/START_HERE.md
@@ -9,7 +9,7 @@ active_contract: PROJECT_TOTAL_PLANNING_IMPLEMENTATION_AND_DELIVERY_INSTRUCTION_
 contract_binding_decision: GM-CONTRACT-V4-5-BINDING-01
 contract_binding_sync: GR-SYNC-20260811-02-CONTRACT-V4-5-R2-BINDING
 project_main_authority: LIVE_GITHUB_DEFAULT_BRANCH_READBACK
-current_state_sync: GR-SYNC-20260811-19-HIGODOT-V314-TRACKED-EXACT-RECONCILIATION
+current_state_sync: GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT
 spell_workflow_predecessor_sync: GR-SYNC-20260811-01-SPELL-WORKFLOW-TASK7-CURRENT-STATE
 product_decision: GM-SPELL-WORKFLOW-UI-V2-01
 github_actions_decision: GM-PUBLIC-REPO-FREE-GITHUB-ACTIONS-01
@@ -18,25 +18,33 @@ base_snapshot_policy: ALWAYS_REFETCH_CURRENT_MAIN_BEFORE_WORK
 base_repository_review_policy: RECURSIVE_INVENTORY_THEN_RELEVANCE_DRIVEN_DEEP_READ
 adapter_policy: THIN_ADAPTER_DO_NOT_DUPLICATE_BASE_CANON
 external_process_policy: EXTERNAL_PROCESS_OVERLAY
-base_current_main_observed: 7a49390bd840f5f5dc80fe661b44ad45e9ebeb7f
+base_current_main_observed: 6d2feba2bc49fda2d8d273248b55087853615d5d
+base_project_pin: v9.4.3
+base_pin_update: NOT_APPROVED_NOT_PERFORMED
 latest_product_main: fcb5dbe1cbbb23ef195633b1f6680f45d46c5a3f
-spell_workflow_status: TASK8_RESUMED_PREFLIGHT_ACTIVE
+spell_workflow_status: TASK8_LOCAL_REFINEMENT_GREEN_UNMERGED_MERGE_GATES_PENDING
 spell_workflow_predecessor_status: TASK7_MERGED_MAIN_VERIFIED
-next_product_task: TASK8_SPELL_USE_SCREEN
+next_product_task: TASK8_RECEIPT_HERA_REVIEW_PR
 preserved_runtime_decision: GM-STAR-CIRCUIT-MASTERY-BALANCE-01
 circuit_topology: FIVE_POINT_STAR
+local_execution_policy: PROJECT_DEDICATED_LOCAL_EXECUTION_ENVIRONMENT_FIRST
+fresh_shell_policy: ASSUME_PREVIOUS_POWERSHELL_CLOSED
+missing_local_environment_policy: CREATE_OR_REPAIR_DEDICATED_LOCAL_ENVIRONMENT_FIRST
 higodot_authority: SOLE_PERSISTENT_GODOT_AUTHORING_AUTHORITY
 higodot_release: v3.1.4
 higodot_vendor_integrity: PASS_EXACT_TREE_IDENTITY
 higodot_sync: GR-SYNC-20260811-19-HIGODOT-V314-TRACKED-EXACT-RECONCILIATION
 higodot_plugin_subtree: 69010571e11123dfc4e09483f80cb9e6ca93511a
-higodot_live_alignment: LIVE_V3_1_4_HANDSHAKE_NOT_VERIFIED
+higodot_live_alignment: LIVE_V3_1_4_EXACT_PROJECT_SESSION_READY_OBSERVED
+higodot_live_session: task8-spell-use-screen-v2@3cfa
+higodot_expected_actual_fields: NOT_SURFACED_DO_NOT_CLAIM
 higodot_direct_tool_state_receipt: HIGODOT_AUTHORING_RECEIPT_UNVERIFIED_FOR_DIRECT_LOCAL_TOOL_STATE_COMMIT
 tracked_project_godot_editor_plugins: GODOT_AI_GUT_HERA_ENABLED_AT_GITHUB_MAIN_READBACK
 gut_status: GUT_FORMALLY_ADOPTED
 gut_release: v9.7.1
 hera_status: HERA_V1_0_0_EXACT_PAIR_LIVE_CANARY_PASS
 hera_authority: LIVE_QA_AND_OBSERVABILITY_ONLY
+hera_task8_acceptance: REQUIRED_PENDING_HERA_SOURCE_DELTA_NONE
 windows_android_shared_core: WINDOWS_ANDROID_SHARED_CORE_STRUCTURAL_PASS
 visual_automated_layout_baseline: VISUAL_AUTOMATED_LAYOUT_BASELINE_PASS
 three_screen_runtime: THREE_SCREEN_RUNTIME_AWAITING_TASKS_2_9
@@ -46,11 +54,32 @@ performance_validation: NOT_RUN
 full_vertical_slice: NOT_RUN
 windows_export: NOT_RUN
 android_export: NOT_RUN
-local_sync: LOCAL_SYNC_BLOCKED_NO_LOCAL_ACCESS
-godot_run: GODOT_RUN_BLOCKED_NO_LOCAL_ACCESS
 ```
 
-v4.5 r2는 Base current canon을 복제하지 않는 thin adapter다. Base `7ce3fb64...`는 v4.5 원문 작성 시점의 `HISTORICAL_OBSERVATION_ONLY`이고, 이번 work unit에서 관찰한 Base current main은 `7a49390b...`다. 이 값도 영구 권위가 아니며 실제 Base `main`은 매 작업 다시 읽는다.
+v4.5 r2는 Base current canon을 복제하지 않는 thin adapter다. Base `7ce3fb64...`는 v4.5 원문 작성 시점의 `HISTORICAL_OBSERVATION_ONLY`이고, 현재 work unit에서 관찰한 Base main은 `6d2feba2...`다. 이 값도 영구 project pin이 아니며 실제 Base `main`은 매 작업 다시 읽는다. Base v9.4.3 pin은 변경하지 않았다.
+
+## 로컬 실행 시작 규칙
+
+로컬 작업은 항상 사용자가 직전 PowerShell을 닫았다고 가정한다.
+
+```text
+새 PowerShell 열기
+→ 전용 self-contained GRIMOIRE Godot 존재/정확성 확인
+→ 없으면 제품 작업 전에 전용 환경 생성·복구
+→ exact requested GRIMOIRE project/worktree의 Godot만 재사용/실행
+→ project-scoped HiGodot profile/server/ports 확인·attach/start
+→ project-scoped CODEX_HOME 설정
+→ live QA가 필요하면 project-approved Hera exact pair/profile 확인
+→ exact worktree에서 Codex 실행
+→ Codex 내부 fresh HiGodot exact-project/version/readiness receipt
+→ 이후에만 persistent authoring
+```
+
+사용자에게는 **Codex prompt보다 먼저 한 덩어리 PowerShell bootstrap block**을 준다. 이전 shell 변수나 current directory를 재사용하지 않는다. wrong worktree/editor, 다른 프로젝트 HiGodot/Hera profile·port, global CODEX_HOME leakage, duplicate editor, path quoting, process-but-not-ready를 fail-closed로 확인한다.
+
+Bootstrap은 `reset`, `restore`, `clean`, stage, rewrite, unrelated process kill 권한이 아니다. 이미 분류된 LF/CRLF/stat noise나 broad Git diff를 Codex 시작 전에 장문 출력하지 않는다. process/port 존재는 readiness 증거가 아니며 Codex 내부에서 fresh receipt를 다시 읽는다.
+
+Hera shared token 원문은 저장소·prompt·log·evidence에 기록하지 않는다.
 
 ## 현재 제품 경계
 
@@ -70,55 +99,48 @@ v4.5 r2는 Base current canon을 복제하지 않는 thin adapter다. Base `7ce3
 - Task 6 / PR #108 — glyph drawing workflow screen
 - Task 7 / PR #110 — circuit placement workflow screen
 
-따라서 **현재 다음 구현 단위는 `TASK8_SPELL_USE_SCREEN`**이다. Task 8은 이미 병합된 Task 5의 Stage 3 transaction authority를 소비하는 UI 단계이며 새 target/use authority를 중복 구현하지 않는다.
+Task8은 Task5 Stage3 authority의 thin UI consumer이며 새 target/use authority를 만들지 않는다.
 
-Task 8의 현재 실행 경계는 `tracked v3.1.4 exact-tree PASS`와 `live v3.1.4 handshake NOT_VERIFIED`를 분리한다. tracked vendor가 정확하다는 사실만으로 protected authoring이 열리지 않는다.
+사용자 제공 최신 Codex 실행 증거에서는 exact Task8 V2 project session `task8-spell-use-screen-v2@3cfa`, Godot 4.7.1, HiGodot server/plugin 3.1.4, readiness `ready`가 관찰됐다. 별도 `expected_version` field는 surfaced되지 않았으므로 그 equality는 주장하지 않는다.
 
-승인된 후속 계획:
-
-```text
-HiGodot v3.1.4 live expected/actual/READY readback
-→ Task 8 focused GUT RED
-→ Task 8 minimum Spell Use Screen GREEN via HiGodot
-→ receipt/regression/Hera/CI
-→ Task 9 — Root Coordinator / Responsive Rules / End-to-End Flow
-→ Task 10 — Render Evidence / CI / Main Scene / Canon + Sheet Sync
-```
-
-## 보존된 Star Circuit runtime authority
+Task8 local refinement는 다음까지 GREEN으로 보고됐다.
 
 ```yaml
-decision: GM-STAR-CIRCUIT-MASTERY-BALANCE-01
-sync_id: GR-SYNC-20260806-03-STAR-RUNTIME-COMPLETION-MAIN
-main_authority_commit: 6c7b33df7347a151ce18a4bfdbf9ec212a8a4a6b
-canon_status: SYNCED_TO_MAIN
-product_project: CREATED
-product_implementation: STAR_RUNTIME_COMPLETION_AUTOMATED_PASS
-runtime_validation: AUTOMATED_HEADLESS_PASS
-mobile_device_validation: NOT_RUN
-performance_validation: NOT_RUN
-human_validation: NOT_RUN
-tuning_status: PLAYTEST_TUNING_REQUIRED
+focused_gut: 15_TESTS_90_ASSERTIONS_0_FAILURES
+predecessor_regression: 42_SUITES_1588_ASSERTIONS_0_FAILURES
+ui_behaviors:
+  - actual_target_controls
+  - prepared_spell_summary
+  - stale_invalid_visual_fail_closed
+  - two_stage_explicit_confirmation
+  - actual_cancel_button
+  - deterministic_focus_and_text_semantics
 ```
+
+이것은 아직 merged-main 제품 증거가 아니다. 다음 gate는:
+
+```text
+fresh dedicated local environment bootstrap
+→ fresh exact-project HiGodot receipt
+→ protected-delta HiGodot authoring receipt/readback
+→ pre-Hera tracked-source snapshot
+→ Hera LIVE_QA_AND_OBSERVABILITY_ONLY
+→ post-Hera tracked-source snapshot
+→ HERA_SOURCE_DELTA: NONE
+→ independent/adversarial review
+→ PR exact-head CI
+→ merge / merged-main readback
+```
+
+Task 9은 기존 승인된 Mobile landscape device matrix(16:9, 18:9, 19.5:9, 20:9, cutout/safe-area, foldable/tablet)를 계속 소유한다.
 
 ## 도구 권위
 
 - HiGodot/Godot AI `v3.1.4`: tracked plugin subtree는 공식 v3.1.4 `69010571e11123dfc4e09483f80cb9e6ca93511a`와 exact identity PASS이며 persistent `.gd/.tscn/.tres/.res/project.godot` 저작의 단일 권위를 유지한다.
-- live plugin/server handshake는 `LIVE_V3_1_4_HANDSHAKE_NOT_VERIFIED`; user report나 tracked tree로 READY를 추정하지 않는다.
-- direct tool-state commit `257a0dba33f8288d24b1cd291bb407f4505224b4`의 formal HiGodot receipt는 `HIGODOT_AUTHORING_RECEIPT_UNVERIFIED_FOR_DIRECT_LOCAL_TOOL_STATE_COMMIT`이다.
+- latest Task8 live session은 exact-project server/plugin `3.1.4 / 3.1.4`, readiness `ready`로 관찰됐다. `expected_version` field는 surfaced되지 않았다.
+- direct tool-state commit `257a0dba33f8288d24b1cd291bb407f4505224b4`의 formal HiGodot receipt는 여전히 `HIGODOT_AUTHORING_RECEIPT_UNVERIFIED_FOR_DIRECT_LOCAL_TOOL_STATE_COMMIT`이다.
 - GUT `v9.7.1`: `DETERMINISTIC_GDSCRIPT_TEST_AUTHORITY`.
-- Hera `v1.0.0`: `LIVE_QA_AND_OBSERVABILITY_ONLY`; persistent source mutation 금지.
-
-## v4.5 실행·외부 process 경계
-
-```yaml
-execution_request_state: USER_EXPLICIT_EXECUTION_REQUEST_PRESENT
-continuous_work: CONTINUOUS_WORK_ACTIVE
-merge_authority: APPROVED_ITEM_INHERITS_MERGE_AUTHORITY
-external_process_overlay: EXTERNAL_PROCESS_OVERLAY
-```
-
-Superpowers 같은 외부 process framework는 실행 절차만 강화하며 프로젝트/Base 정본 권한을 획득하지 않는다.
+- Hera `v1.0.0`: `LIVE_QA_AND_OBSERVABILITY_ONLY`; persistent source mutation 금지. Task8 acceptance에는 `HERA_SOURCE_DELTA: NONE`이 필요하다.
 
 ## 역사 증거와 현재 권위 분리
 
@@ -135,12 +157,15 @@ spell_workflow_task2_authorized: true
 spell_workflow_task2_historical_status: TASK2_MERGED_MAIN_VERIFIED
 ```
 
-v3.1.3 / Task 2 / Task 3 / v4.4 자료는 삭제하지 않고 provenance로 보존한다. 현재 tool-state 권위만 Sync19의 tracked v3.1.4 exact-tree 상태로 전진한다.
+v3.1.3 / Task 2 / Task 3 / v4.4 자료는 삭제하지 않고 provenance로 보존한다. Sync19의 당시 live-pending 문구도 역사 evidence에서는 변경하지 않는다.
 
 ## 현재 완료로 주장하지 않는 항목
 
 ```text
-LIVE_V3_1_4_HANDSHAKE_NOT_VERIFIED
+TASK8_PROTECTED_DELTA_HIGODOT_RECEIPT_PENDING
+TASK8_HERA_ACCEPTANCE_PENDING
+TASK8_PR_EXACT_HEAD_CI_REVIEW_MERGE_PENDING
+HIGODOT_EXPECTED_VERSION_FIELD_NOT_SURFACED
 HIGODOT_AUTHORING_RECEIPT_UNVERIFIED_FOR_DIRECT_LOCAL_TOOL_STATE_COMMIT
 AUDIO_VAULT_PATH_UNVERIFIED
 AUDIO_RIGHTS_UNVERIFIED
@@ -152,8 +177,6 @@ FULL_VERTICAL_SLICE_NOT_RUN
 WINDOWS_EXPORT_NOT_RUN
 ANDROID_EXPORT_NOT_RUN
 ANDROID_DEVICE_NOT_RUN
-LOCAL_SYNC_BLOCKED_NO_LOCAL_ACCESS
-GODOT_RUN_BLOCKED_NO_LOCAL_ACCESS
 ```
 
 ## 읽기 순서
@@ -167,9 +190,10 @@ GODOT_RUN_BLOCKED_NO_LOCAL_ACCESS
 7. `docs/planning/CURRENT_UNRESOLVED_GATES.md`
 8. `docs/planning/CANON_SYNC_STATE.json`
 9. `docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE.json`
-10. `docs/planning/sync/GR-SYNC-20260811-19-HIGODOT-V314-TRACKED-EXACT-RECONCILIATION.md`
-11. `docs/contracts/GRIMOIRE_PROJECT_CONTRACT_V4_4_BINDING.md` — historical only
+10. `docs/planning/sync/GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT.md`
+11. `docs/planning/sync/GR-SYNC-20260811-19-HIGODOT-V314-TRACKED-EXACT-RECONCILIATION.md` — historical predecessor sync
+12. `docs/contracts/GRIMOIRE_PROJECT_CONTRACT_V4_4_BINDING.md` — historical only
 
 ## 계약 바인딩
 
-현재 GitHub 정본 계약은 v4.5 r2 / `GM-CONTRACT-V4-5-BINDING-01`이다. v4.4는 `HISTORICAL_SUPERSEDED_CURRENT_BINDING`으로 보존한다.
+현재 GitHub 정본 계약은 v4.5 r2 / `GM-CONTRACT-V4-5-BINDING-01`이다. v4.4는 `HISTORICAL_SUPERSEDED_CURRENT_BINDING`으로 보존한다. Sync20은 운영 실행환경 consumer이며 제품 Decision을 변경하지 않는다.

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -12,6 +12,7 @@ project_main_authority: LIVE_GITHUB_DEFAULT_BRANCH_READBACK
 current_state_sync: GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT
 spell_workflow_predecessor_sync: GR-SYNC-20260811-01-SPELL-WORKFLOW-TASK7-CURRENT-STATE
 product_decision: GM-SPELL-WORKFLOW-UI-V2-01
+task8_product_unit: TASK8_SPELL_USE_SCREEN
 github_actions_decision: GM-PUBLIC-REPO-FREE-GITHUB-ACTIONS-01
 repo_wide_actions_full_sha: PASS
 base_snapshot_policy: ALWAYS_REFETCH_CURRENT_MAIN_BEFORE_WORK
@@ -188,11 +189,13 @@ ANDROID_DEVICE_NOT_RUN
 5. `docs/DEVELOPMENT_GATES.md`
 6. `docs/planning/CURRENT_CONFIRMED_DECISIONS.md`
 7. `docs/planning/CURRENT_UNRESOLVED_GATES.md`
-8. `docs/planning/CANON_SYNC_STATE.json`
-9. `docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE.json`
+8. `docs/planning/CANON_SYNC_STATE_SYNC20.json` — current machine overlay
+9. `docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE_SYNC20.json` — current machine overlay
 10. `docs/planning/sync/GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT.md`
-11. `docs/planning/sync/GR-SYNC-20260811-19-HIGODOT-V314-TRACKED-EXACT-RECONCILIATION.md` — historical predecessor sync
-12. `docs/contracts/GRIMOIRE_PROJECT_CONTRACT_V4_4_BINDING.md` — historical only
+11. `docs/planning/CANON_SYNC_STATE.json` — pre-Sync20 historical machine snapshot
+12. `docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE.json` — Sync19 historical machine snapshot
+13. `docs/planning/sync/GR-SYNC-20260811-19-HIGODOT-V314-TRACKED-EXACT-RECONCILIATION.md` — historical predecessor sync
+14. `docs/contracts/GRIMOIRE_PROJECT_CONTRACT_V4_4_BINDING.md` — historical only
 
 ## 계약 바인딩
 

--- a/docs/ACTIVE_CONTEXT.md
+++ b/docs/ACTIVE_CONTEXT.md
@@ -11,19 +11,24 @@ base_snapshot_policy: ALWAYS_REFETCH_CURRENT_MAIN_BEFORE_WORK
 base_repository_review_policy: RECURSIVE_INVENTORY_THEN_RELEVANCE_DRIVEN_DEEP_READ
 adapter_policy: THIN_ADAPTER_DO_NOT_DUPLICATE_BASE_CANON
 external_process_policy: EXTERNAL_PROCESS_OVERLAY
-base_current_main_observed: 7a49390bd840f5f5dc80fe661b44ad45e9ebeb7f
-current_state_sync: GR-SYNC-20260811-19-HIGODOT-V314-TRACKED-EXACT-RECONCILIATION
+base_current_main_observed: 6d2feba2bc49fda2d8d273248b55087853615d5d
+base_project_pin: v9.4.3
+base_pin_update: NOT_APPROVED_NOT_PERFORMED
+current_state_sync: GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT
 spell_workflow_predecessor_sync: GR-SYNC-20260811-01-SPELL-WORKFLOW-TASK7-CURRENT-STATE
 product_decision: GM-SPELL-WORKFLOW-UI-V2-01
 github_actions_decision: GM-PUBLIC-REPO-FREE-GITHUB-ACTIONS-01
 repo_wide_actions_full_sha: PASS
 latest_product_main: fcb5dbe1cbbb23ef195633b1f6680f45d46c5a3f
-spell_workflow_status: TASK8_RESUMED_PREFLIGHT_ACTIVE
+spell_workflow_status: TASK8_LOCAL_REFINEMENT_GREEN_UNMERGED_MERGE_GATES_PENDING
 spell_workflow_predecessor_status: TASK7_MERGED_MAIN_VERIFIED
-next_product_task: TASK8_SPELL_USE_SCREEN
+next_product_task: TASK8_RECEIPT_HERA_REVIEW_PR
 preserved_runtime_decision: GM-STAR-CIRCUIT-MASTERY-BALANCE-01
 circuit_topology: FIVE_POINT_STAR
 tool_authority_decision: GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01
+local_execution_policy: PROJECT_DEDICATED_LOCAL_EXECUTION_ENVIRONMENT_FIRST
+fresh_shell_policy: ASSUME_PREVIOUS_POWERSHELL_CLOSED
+missing_local_environment_policy: CREATE_OR_REPAIR_DEDICATED_LOCAL_ENVIRONMENT_FIRST
 higodot_authority: SOLE_PERSISTENT_GODOT_AUTHORING_AUTHORITY
 higodot_release: v3.1.4
 higodot_vendor_integrity: PASS_EXACT_TREE_IDENTITY
@@ -31,12 +36,14 @@ higodot_tracked_sync: GR-SYNC-20260811-19-HIGODOT-V314-TRACKED-EXACT-RECONCILIAT
 higodot_tool_state_main: 257a0dba33f8288d24b1cd291bb407f4505224b4
 higodot_tool_state_sheet_sync: SHEET_WRITE_READBACK_PASS
 higodot_tracked_plugin_subtree: 69010571e11123dfc4e09483f80cb9e6ca93511a
-higodot_live_alignment: LIVE_V3_1_4_HANDSHAKE_NOT_VERIFIED
+higodot_live_alignment: LIVE_V3_1_4_EXACT_PROJECT_SESSION_READY_OBSERVED
+higodot_expected_actual_fields: NOT_SURFACED_DO_NOT_CLAIM
 higodot_direct_tool_state_receipt: HIGODOT_AUTHORING_RECEIPT_UNVERIFIED_FOR_DIRECT_LOCAL_TOOL_STATE_COMMIT
 gut_formal_adoption: GUT_FORMALLY_ADOPTED
 gut_release: v9.7.1
 hera_status: HERA_V1_0_0_EXACT_PAIR_LIVE_CANARY_PASS
 hera_authority: LIVE_QA_AND_OBSERVABILITY_ONLY
+hera_task8_acceptance: REQUIRED_PENDING_HERA_SOURCE_DELTA_NONE
 windows_android_shared_core: WINDOWS_ANDROID_SHARED_CORE_STRUCTURAL_PASS
 visual_automated_layout_baseline: VISUAL_AUTOMATED_LAYOUT_BASELINE_PASS
 three_screen_runtime: THREE_SCREEN_RUNTIME_AWAITING_TASKS_2_9
@@ -49,13 +56,13 @@ windows_export: NOT_RUN
 android_export: NOT_RUN
 android_device: NOT_RUN
 visual_audio_status: APPROVED_DIRECTION_RUNTIME_NOT_RUN_VISUAL_AUDIO_INCOMPLETE
-local_sync: LOCAL_SYNC_BLOCKED_NO_LOCAL_ACCESS
-godot_run: GODOT_RUN_BLOCKED_NO_LOCAL_ACCESS
+local_execution_route: USER_POWERSHELL_PLUS_PROJECT_CODEX_AVAILABLE
+chatgpt_direct_local_access: NONE
 ```
 
 ## v4.5 r2 operating boundary
 
-v4.5 r2는 `THIN_ADAPTER_DO_NOT_DUPLICATE_BASE_CANON`을 적용한다. Base source snapshot `7ce3fb64...`는 `HISTORICAL_OBSERVATION_ONLY`, 이번 work unit에서 관찰한 Base current main은 `7a49390b...`이며 영구 권위가 아니다. 매 작업 시작 시 Base `main`과 Registry/관련 owner를 다시 복원한다.
+v4.5 r2는 `THIN_ADAPTER_DO_NOT_DUPLICATE_BASE_CANON`을 적용한다. Base source snapshot `7ce3fb64...`는 `HISTORICAL_OBSERVATION_ONLY`; 이 work unit의 latest Base merged-main observation은 `6d2feba2...`이고 영구 project pin이 아니다. Base v9.4.3 project pin은 변경하지 않았다. 매 작업 시작 시 Base `main`과 Registry/관련 owner를 다시 읽는다.
 
 ```yaml
 execution_request_state: USER_EXPLICIT_EXECUTION_REQUEST_PRESENT
@@ -65,6 +72,31 @@ external_process_overlay: EXTERNAL_PROCESS_OVERLAY
 ```
 
 Superpowers 등 외부 process framework는 execution-only overlay이며 프로젝트 또는 Base canon을 소유하지 않는다.
+
+## Dedicated local execution environment
+
+Base main `6d2feba2...`의 shared invariant를 이 프로젝트에 다음과 같이 consume한다.
+
+```text
+new PowerShell for every local work session
+→ verify/create-or-repair dedicated self-contained GRIMOIRE Godot
+→ exact requested GRIMOIRE project/worktree only
+→ project-scoped HiGodot profile/server/ports
+→ project-scoped CODEX_HOME
+→ Hera exact project-approved pair/profile when live QA is required
+→ Codex exact worktree
+→ fresh exact-project HiGodot session/version/readiness receipt inside Codex
+→ persistent authoring only through HiGodot
+→ GUT deterministic verification
+→ Hera LIVE_QA_AND_OBSERVABILITY_ONLY
+→ HERA_SOURCE_DELTA: NONE
+```
+
+`ASSUME_PREVIOUS_POWERSHELL_CLOSED`가 기본이다. 사용자의 이전 shell 환경 변수·현재 디렉터리·process handle을 재사용 전제로 삼지 않는다. dedicated environment가 없거나 identity가 불명확하면 `CREATE_OR_REPAIR_DEDICATED_LOCAL_ENVIRONMENT_FIRST`로 제품 작업보다 먼저 복구한다.
+
+사용자에게 local execution을 요청할 때는 항상 **새 PowerShell → 한 덩어리 bootstrap block → Codex가 열린 뒤 task prompt** 순서다. launcher는 wrong worktree/editor/profile/port/CODEX_HOME/Hera-profile collision을 fail-closed로 검사하되 broad Git diff, repository-wide scan, 이미 분류된 LF/CRLF/stat noise를 startup 전에 쏟지 않는다. `reset`, `restore`, `clean`, stage, rewrite, unrelated process kill은 bootstrap 권한이 아니다.
+
+Hera shared token 원문은 저장소·prompt·log·evidence에 기록하지 않는다. Hera는 persistent source writer가 아니며 결함 수정은 HiGodot authoring으로 돌아간다.
 
 ## Current Spell Workflow state
 
@@ -92,13 +124,17 @@ task7:
   merge: fcb5dbe1cbbb23ef195633b1f6680f45d46c5a3f
   scope: CIRCUIT_PLACEMENT_WORKFLOW_SCREEN
 predecessor_status: TASK7_MERGED_MAIN_VERIFIED
-current_status: TASK8_RESUMED_PREFLIGHT_ACTIVE
-next_task: TASK8_SPELL_USE_SCREEN
+current_status: TASK8_LOCAL_REFINEMENT_GREEN_UNMERGED_MERGE_GATES_PENDING
+next_task: TASK8_RECEIPT_HERA_REVIEW_PR
 ```
 
-Task 8은 Task 5에서 이미 병합된 explicit target/use transaction을 화면에 노출하는 단계다. Mana/result atomicity를 새 authority로 다시 만들지 않는다. tracked Godot AI v3.1.4 exact-tree identity는 PASS지만 live plugin/server `expected_version == actual_version == 3.1.4`와 READY 상태는 아직 검증되지 않았으므로 protected authoring은 열리지 않는다.
+Task8 local V2 evidence from the user-supplied Codex execution proves a live exact-project HiGodot session `task8-spell-use-screen-v2@3cfa`, Godot 4.7.1, server/plugin 3.1.4, readiness `ready`. The tool did not surface a separate `expected_version` field, so no equality claim is invented.
 
-Task 9에는 기존 승인된 Mobile landscape device matrix(16:9, 18:9, 19.5:9, 20:9, cutout/safe-area, foldable/tablet 분류)를 acceptance에 전파해야 한다. 1280×720은 reference surface이지 유일 검증 비율이 아니다.
+The same local execution reported focused Task8 GUT `15 tests / 90 assertions / 0 failures` and authoritative predecessor regression `42 suites / 1,588 assertions / 0 failures`. Actual target control, caller-supplied prepared-spell summary, invalid/stale visual fail-closed behavior, CancelButton event path, deterministic focus hierarchy, and the already-approved two-stage opaque-ID confirmation are locally GREEN.
+
+This evidence is **not merged-main product evidence**. Remaining gates are protected-delta HiGodot receipt/readback, Hera acceptance with source-delta NONE, independent/adversarial review, exact-head PR CI, merge, and merged-main readback. Mana/result atomicity and transaction authority remain Task5/Stage3-owned.
+
+Task9 retains the Mobile landscape responsive/device matrix (16:9, 18:9, 19.5:9, 20:9, cutout/safe-area, foldable/tablet). Task8 does not pull that full matrix forward.
 
 ## Tool authority
 
@@ -108,10 +144,13 @@ higodot:
   authority: SOLE_PERSISTENT_GODOT_AUTHORING_AUTHORITY
   tracked_sync: GR-SYNC-20260811-19-HIGODOT-V314-TRACKED-EXACT-RECONCILIATION
   observed_tool_state_main: 257a0dba33f8288d24b1cd291bb407f4505224b4
-  sheet_sync: SHEET_WRITE_READBACK_PASS
   tracked_plugin_subtree: 69010571e11123dfc4e09483f80cb9e6ca93511a
   vendor_integrity: PASS_EXACT_TREE_IDENTITY
-  live_handshake: LIVE_V3_1_4_HANDSHAKE_NOT_VERIFIED
+  live_session: task8-spell-use-screen-v2@3cfa
+  live_project_match: PASS_FOR_OBSERVED_SESSION
+  live_server_plugin: V3_1_4_V3_1_4
+  live_readiness: READY
+  expected_version_field: NOT_SURFACED_DO_NOT_CLAIM
   direct_local_upgrade_receipt: HIGODOT_AUTHORING_RECEIPT_UNVERIFIED_FOR_DIRECT_LOCAL_TOOL_STATE_COMMIT
   historical_v3_1_3_sync: GR-SYNC-20260809-04-HIGODOT-V313-TRACKED-EXACT-RECONCILIATION
   historical_v3_1_3_tree: 94be4fb34d49243375c592e17a1021c8c6fcbcf2
@@ -124,6 +163,26 @@ hera:
   authority: LIVE_QA_AND_OBSERVABILITY_ONLY
   status: HERA_V1_0_0_EXACT_PAIR_LIVE_CANARY_PASS
   persistent_source_mutation: FORBIDDEN
+  task8_acceptance: PENDING
+  task8_required_source_delta: NONE
+```
+
+## Current Task8 merge gate
+
+```text
+fresh dedicated local environment bootstrap
+→ fresh exact-project HiGodot receipt
+→ fresh protected-delta HiGodot authoring receipt/readback
+→ focused/regression recheck if receipt process changes the tree
+→ pre-Hera tracked-source snapshot
+→ Hera live QA/observability only
+→ post-Hera tracked-source snapshot
+→ HERA_SOURCE_DELTA: NONE
+→ independent/adversarial review
+→ exact-head PR CI
+→ merge
+→ merged-main readback
+→ same Decision ID GitHub + Sheet product sync
 ```
 
 ## Historical Task 2 / Task 3 / v4.4 evidence
@@ -153,7 +212,10 @@ v4.4, v3.1.3, Task2/Task3 진입 자료는 provenance로 유효하지만 current
 ## Preserved validation boundaries
 
 ```text
-LIVE_V3_1_4_HANDSHAKE_NOT_VERIFIED
+TASK8_PROTECTED_DELTA_HIGODOT_RECEIPT_PENDING
+TASK8_HERA_ACCEPTANCE_PENDING
+TASK8_PR_EXACT_HEAD_CI_REVIEW_MERGE_PENDING
+HIGODOT_EXPECTED_VERSION_FIELD_NOT_SURFACED
 HUMAN_NOT_RUN
 DEVICE_NOT_RUN
 PERFORMANCE_NOT_RUN
@@ -165,12 +227,10 @@ AUDIO_VAULT_PATH_UNVERIFIED
 AUDIO_RIGHTS_UNVERIFIED
 VISUAL_AUDIO_COMPLETE_NOT_PROVEN
 HIGODOT_AUTHORING_RECEIPT_UNVERIFIED_FOR_DIRECT_LOCAL_TOOL_STATE_COMMIT
-LOCAL_SYNC_BLOCKED_NO_LOCAL_ACCESS
-GODOT_RUN_BLOCKED_NO_LOCAL_ACCESS
 ```
 
-자동·Editor·CI·tracked tree 증거로 live READY/사람/기기/성능/전체 Vertical Slice 증거를 승격하지 않는다.
+자동·Editor·CI·GUT·Hera 증거로 사람/기기/성능/전체 Vertical Slice 증거를 승격하지 않는다.
 
 ## Contract boundary
 
-저장소 current canon은 v4.5 r2 / `GM-CONTRACT-V4-5-BINDING-01`이다. v4.4 / `GM-CONTRACT-V4-4-BINDING-01`과 HiGodot v3.1.3은 historical provenance로 보존한다.
+저장소 current canon은 v4.5 r2 / `GM-CONTRACT-V4-5-BINDING-01`이다. v4.4 / `GM-CONTRACT-V4-4-BINDING-01`과 HiGodot v3.1.3은 historical provenance로 보존한다. Sync20은 운영 실행환경 consumer이며 제품 규칙을 변경하지 않는다.

--- a/docs/DEVELOPMENT_GATES.md
+++ b/docs/DEVELOPMENT_GATES.md
@@ -9,22 +9,28 @@ base_snapshot_policy: ALWAYS_REFETCH_CURRENT_MAIN_BEFORE_WORK
 base_repository_review_policy: RECURSIVE_INVENTORY_THEN_RELEVANCE_DRIVEN_DEEP_READ
 adapter_policy: THIN_ADAPTER_DO_NOT_DUPLICATE_BASE_CANON
 external_process_policy: EXTERNAL_PROCESS_OVERLAY
-current_state_sync: GR-SYNC-20260811-19-HIGODOT-V314-TRACKED-EXACT-RECONCILIATION
+current_state_sync: GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT
 spell_workflow_predecessor_sync: GR-SYNC-20260811-01-SPELL-WORKFLOW-TASK7-CURRENT-STATE
 product_decision: GM-SPELL-WORKFLOW-UI-V2-01
 latest_product_main: fcb5dbe1cbbb23ef195633b1f6680f45d46c5a3f
-spell_workflow_status: TASK8_RESUMED_PREFLIGHT_ACTIVE
+spell_workflow_status: TASK8_LOCAL_REFINEMENT_GREEN_UNMERGED_MERGE_GATES_PENDING
 spell_workflow_predecessor_status: TASK7_MERGED_MAIN_VERIFIED
-next_product_task: TASK8_SPELL_USE_SCREEN
+next_product_task: TASK8_SPELL_USE_SCREEN_RECEIPT_HERA_PR
 preserved_runtime_decision: GM-STAR-CIRCUIT-MASTERY-BALANCE-01
 circuit_topology: FIVE_POINT_STAR
 tool_authority_decision: GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01
 higodot_release: v3.1.4
 higodot_vendor_integrity: PASS_EXACT_TREE_IDENTITY
 higodot_tracked_sync: GR-SYNC-20260811-19-HIGODOT-V314-TRACKED-EXACT-RECONCILIATION
-higodot_live_alignment: LIVE_V3_1_4_HANDSHAKE_NOT_VERIFIED
+higodot_live_alignment: LIVE_V3_1_4_EXACT_PROJECT_SESSION_READY_OBSERVED
+higodot_expected_actual_fields: NOT_SURFACED_DO_NOT_CLAIM
 gut_formal_adoption: GUT_FORMALLY_ADOPTED
 hera_status: HERA_V1_0_0_EXACT_PAIR_LIVE_CANARY_PASS
+hera_authority: LIVE_QA_AND_OBSERVABILITY_ONLY
+hera_task8_acceptance: REQUIRED_PENDING_HERA_SOURCE_DELTA_NONE
+local_execution_policy: PROJECT_DEDICATED_LOCAL_EXECUTION_ENVIRONMENT_FIRST
+fresh_shell_policy: ASSUME_PREVIOUS_POWERSHELL_CLOSED
+missing_local_environment_policy: CREATE_OR_REPAIR_DEDICATED_LOCAL_ENVIRONMENT_FIRST
 windows_android_shared_core: WINDOWS_ANDROID_SHARED_CORE_STRUCTURAL_PASS
 three_screen_runtime: THREE_SCREEN_RUNTIME_AWAITING_TASKS_2_9
 ```
@@ -37,11 +43,13 @@ sync: GR-SYNC-20260811-02-CONTRACT-V4-5-R2-BINDING
 binding: docs/contracts/GRIMOIRE_PROJECT_CONTRACT_V4_5_BINDING.md
 execution_request_state: USER_EXPLICIT_EXECUTION_REQUEST_PRESENT
 merge_authority: APPROVED_ITEM_INHERITS_MERGE_AUTHORITY
-base_current_main_observed: 7a49390bd840f5f5dc80fe661b44ad45e9ebeb7f
+base_current_main_observed: 6d2feba2bc49fda2d8d273248b55087853615d5d
+base_project_pin: v9.4.3
+base_pin_update: NOT_APPROVED_NOT_PERFORMED
 base_source_snapshot_7ce3fb64_role: HISTORICAL_OBSERVATION_ONLY
 ```
 
-Base current SHA는 permanent authority가 아니며 매 작업 재조회한다. v4.5 r2는 Base canon을 복제하지 않는 thin adapter다.
+Base current SHA는 permanent authority가 아니며 매 작업 재조회한다. v4.5 r2는 Base canon을 복제하지 않는 thin adapter다. Base `6d2feba2...`의 `PROJECT_DEDICATED_LOCAL_EXECUTION_ENVIRONMENT_FIRST`를 project-specific consumer로 적용한다.
 
 ## Gate A — current Spell Workflow implementation boundary
 
@@ -59,13 +67,20 @@ Tasks 3–7 are merged under `GM-SPELL-WORKFLOW-UI-V2-01`.
 task: TASK8_SPELL_USE_SCREEN
 authority_reused: TASK5_STAGE3_TARGET_USE_ATOMIC_TRANSACTION
 tracked_higodot: V3_1_4_EXACT_TREE_PASS
-live_higodot_gate: LIVE_V3_1_4_HANDSHAKE_NOT_VERIFIED
-persistent_authoring: HIGODOT_ONLY_WITH_FRESH_RECEIPT
+live_higodot_gate: LIVE_V3_1_4_EXACT_PROJECT_SESSION_READY_OBSERVED
+live_receipt_session: task8-spell-use-screen-v2@3cfa
+expected_actual_version_fields: NOT_SURFACED_DO_NOT_CLAIM
+local_refinement: FOCUSED_GUT_15_TESTS_90_ASSERTIONS_GREEN
+predecessor_regression: LEGACY_42_SUITES_1588_ASSERTIONS_GREEN
+persistent_authoring: HIGODOT_ONLY_WITH_FRESH_PROTECTED_DELTA_RECEIPT
 testing: GUT_9_7_1_DETERMINISTIC
-live_qa: HERA_OBSERVABILITY_ONLY_SOURCE_DELTA_NONE
+live_qa: HERA_LIVE_QA_ONLY_HERA_SOURCE_DELTA_NONE_REQUIRED
+merge_state: UNMERGED_LOCAL_WORK
 ```
 
-Task 8 must expose explicit target selection, expected-result preview, and user confirmation without duplicating the already-merged Stage 3 transaction authority. tracked plugin tree PASS만으로 authoring을 시작하지 않고 live `expected_version == actual_version == 3.1.4`와 READY readback을 먼저 요구한다.
+Task 8은 explicit target, prepared-spell summary, supplied Stage3 preview, two-stage explicit confirmation, fail-closed stale target, actual CancelButton, focus/accessibility hierarchy까지 로컬 refinement GREEN 증거가 있다. 그러나 protected-delta HiGodot receipt/readback, Hera acceptance, PR exact-head CI/review, merge/readback이 남아 있으므로 `MERGED` 또는 `COMPLETE`로 승격하지 않는다.
+
+Task8 UI는 `SpellWorkflowCoordinator` / `AtomicSpellUseService`의 기존 Stage3 authority를 소비할 뿐 Mana/inventory/result/rollback/transaction generation을 소유하지 않는다.
 
 ## Gate B — Task 9 responsive / E2E prerequisites
 
@@ -74,16 +89,41 @@ APPROVED_DEVICE_MATRIX_PROPAGATION
 GODOT_STRETCH_ASPECT_EXPLICIT_VERIFICATION
 ```
 
-Approved classes include `16:9`, `18:9`, `19.5:9`, `20:9`, cutout/safe-area, foldable, and tablet classes. `1280×720` is a reference surface, not the only acceptance target.
+Approved classes include `16:9`, `18:9`, `19.5:9`, `20:9`, cutout/safe-area, foldable, and tablet classes. `1280×720` is a reference surface, not the only acceptance target. Task8 local refinement does not pull this Task9 matrix forward.
 
-## Gate C — tool authority
+## Gate C — tool authority and dedicated local execution
 
+```text
+NEW_POWERSHELL_EACH_LOCAL_WORK_SESSION
+→ DEDICATED_SELF_CONTAINED_GRIMOIRE_GODOT
+→ EXACT_REQUESTED_GRIMOIRE_PROJECT_OR_WORKTREE
+→ PROJECT_SCOPED_HIGODOT_PROFILE_AND_PORTS
+→ PROJECT_SCOPED_CODEX_HOME
+→ HERA_EXACT_PAIR_PROFILE_WHEN_LIVE_QA_REQUIRED
+→ CODEX_EXACT_WORKTREE
+→ FRESH_HIGODOT_EXACT_PROJECT_VERSION_READINESS_RECEIPT
+→ HIGODOT_ONLY_PERSISTENT_AUTHORING
+→ GUT_DETERMINISTIC_TEST
+→ HERA_LIVE_QA_ONLY
+→ HERA_SOURCE_DELTA_NONE
+```
+
+- Base owner: `ONE_SHOT_LOCAL_EXECUTOR_BOOTSTRAP` + `PROJECT_DEDICATED_LOCAL_EXECUTION_ENVIRONMENT_FIRST`.
+- 이전 PowerShell은 종료됐다고 가정한다: `ASSUME_PREVIOUS_POWERSHELL_CLOSED`.
+- dedicated environment가 없거나 불완전하면 제품 작업 전에 `CREATE_OR_REPAIR_DEDICATED_LOCAL_ENVIRONMENT_FIRST`.
+- 사용자에게는 항상 **한 덩어리 PowerShell launcher를 Codex prompt보다 먼저** 제공한다.
+- launcher는 broad Git diff/repository-wide scan/이미 분류된 LF·CRLF/stat noise dump를 Codex 실행 전 강제하지 않는다.
+- launcher는 `reset`, `restore`, `clean`, stage, rewrite 또는 unrelated editor/server kill을 수행하지 않는다.
+- process/port 존재는 readiness 증거가 아니다. Codex 내부에서 fresh HiGodot exact-project receipt를 다시 얻는다.
+- current HiGodot project ports/profile은 local execution-time authority에서 fresh-read한다. 다른 프로젝트 profile/port를 조용히 재사용하지 않는다.
+- `CODEX_HOME`은 GRIMOIRE 전용 profile을 사용하며 global/default profile leakage를 fail-closed로 처리한다.
 - HiGodot/Godot AI `v3.1.4`: official/project plugin subtree `69010571e11123dfc4e09483f80cb9e6ca93511a` exact identity PASS; `SOLE_PERSISTENT_GODOT_AUTHORING_AUTHORITY` 유지.
-- Sync19 Sheet readback: `SHEET_WRITE_READBACK_PASS`.
-- live v3.1.4 plugin/server handshake: `LIVE_V3_1_4_HANDSHAKE_NOT_VERIFIED`.
-- direct/local tool-state commit `257a0dba...` authoring receipt: `HIGODOT_AUTHORING_RECEIPT_UNVERIFIED_FOR_DIRECT_LOCAL_TOOL_STATE_COMMIT`.
+- latest Task8 live receipt: exact worktree session `task8-spell-use-screen-v2@3cfa`, Godot 4.7.1, plugin/server 3.1.4, readiness `ready`. `expected_version` field는 surfaced되지 않았으므로 그 필드의 equality를 주장하지 않는다.
+- direct/local tool-state commit `257a0dba...` authoring receipt: `HIGODOT_AUTHORING_RECEIPT_UNVERIFIED_FOR_DIRECT_LOCAL_TOOL_STATE_COMMIT` 유지.
 - GUT `v9.7.1`: `DETERMINISTIC_GDSCRIPT_TEST_AUTHORITY`.
 - Hera `v1.0.0`: `LIVE_QA_AND_OBSERVABILITY_ONLY`; persistent source mutation forbidden.
+- Hera acceptance는 pre/post tracked-source snapshot을 비교해 `HERA_SOURCE_DELTA: NONE`을 요구한다. Hera가 결함을 발견하면 persistent 수정은 HiGodot으로 돌아간다.
+- Hera shared token 원문은 저장소·prompt·log·evidence에 기록하지 않는다.
 - HiGodot v3.1.3 exact-tree/live evidence remains historical predecessor evidence only.
 
 ## Gate D — preserved runtime / platform evidence
@@ -104,7 +144,25 @@ platform:
   full_vertical_slice: NOT_RUN
 ```
 
-No automated, tracked-tree, or editor-state evidence upgrades LIVE_READY/HUMAN/DEVICE/PERFORMANCE/FULL_VERTICAL_SLICE to PASS.
+No automated, tracked-tree, editor-state, GUT, or Hera evidence upgrades HUMAN/DEVICE/PERFORMANCE/FULL_VERTICAL_SLICE to PASS unless that category is actually executed.
+
+## Current Task8 merge gate
+
+```text
+fresh dedicated local environment bootstrap
+→ fresh exact-project HiGodot receipt
+→ fresh protected-delta HiGodot authoring receipt/readback
+→ GUT focused/regression recheck as required
+→ pre-Hera tracked-source snapshot
+→ Hera live QA/observability only
+→ post-Hera tracked-source snapshot
+→ HERA_SOURCE_DELTA: NONE
+→ independent/adversarial review
+→ exact-head PR CI
+→ merge
+→ merged-main readback
+→ same Decision ID GitHub + Sheet product sync
+```
 
 ## Historical v4.4 / Task 2 / HiGodot v3.1.3 provenance
 
@@ -142,15 +200,20 @@ repo_wide_actions_supply_chain: REPO_WIDE_ACTIONS_FULL_SHA_PINNING_PASS
 ## Delivery / unresolved limits
 
 ```text
-LIVE_V3_1_4_HANDSHAKE_NOT_VERIFIED
+TASK8_PROTECTED_DELTA_HIGODOT_RECEIPT_PENDING
+TASK8_HERA_ACCEPTANCE_PENDING
+TASK8_PR_EXACT_HEAD_CI_REVIEW_MERGE_PENDING
+HIGODOT_EXPECTED_VERSION_FIELD_NOT_SURFACED
+HIGODOT_AUTHORING_RECEIPT_UNVERIFIED_FOR_DIRECT_LOCAL_TOOL_STATE_COMMIT
 AUDIO_VAULT_PATH_UNVERIFIED
 AUDIO_RIGHTS_UNVERIFIED
 VISUAL_AUDIO_COMPLETE_NOT_PROVEN
-HIGODOT_AUTHORING_RECEIPT_UNVERIFIED_FOR_DIRECT_LOCAL_TOOL_STATE_COMMIT
-LOCAL_SYNC_BLOCKED_NO_LOCAL_ACCESS
-GODOT_RUN_BLOCKED_NO_LOCAL_ACCESS
+HUMAN_NOT_RUN
+DEVICE_NOT_RUN
+PERFORMANCE_NOT_RUN
+FULL_VERTICAL_SLICE_NOT_RUN
 ```
 
 ## Contract Gate
 
-The active repository contract is v4.5 r2 / `GM-CONTRACT-V4-5-BINDING-01`. v4.4 and HiGodot v3.1.3 remain historical provenance.
+The active repository contract is v4.5 r2 / `GM-CONTRACT-V4-5-BINDING-01`. v4.4 and HiGodot v3.1.3 remain historical provenance. Dedicated-local-environment Sync20 changes operating flow only; it does not change gameplay/product authority.

--- a/docs/DEVELOPMENT_GATES.md
+++ b/docs/DEVELOPMENT_GATES.md
@@ -15,7 +15,7 @@ product_decision: GM-SPELL-WORKFLOW-UI-V2-01
 latest_product_main: fcb5dbe1cbbb23ef195633b1f6680f45d46c5a3f
 spell_workflow_status: TASK8_LOCAL_REFINEMENT_GREEN_UNMERGED_MERGE_GATES_PENDING
 spell_workflow_predecessor_status: TASK7_MERGED_MAIN_VERIFIED
-next_product_task: TASK8_SPELL_USE_SCREEN_RECEIPT_HERA_PR
+next_product_task: TASK8_RECEIPT_HERA_REVIEW_PR
 preserved_runtime_decision: GM-STAR-CIRCUIT-MASTERY-BALANCE-01
 circuit_topology: FIVE_POINT_STAR
 tool_authority_decision: GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01

--- a/docs/planning/CANON_SYNC_STATE_SYNC20.json
+++ b/docs/planning/CANON_SYNC_STATE_SYNC20.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": 1,
+  "policy_id": "GM-CANON-SYNC-01",
+  "sync_id": "GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT",
+  "repository": "alsdmlals4-eng/GRIMOIRE-",
+  "supersedes_current_view_of": "docs/planning/CANON_SYNC_STATE.json",
+  "superseded_file_role": "PRE_SYNC20_HISTORICAL_MACHINE_SNAPSHOT",
+  "active_contract": {
+    "version": "4.5",
+    "binding_decision_id": "GM-CONTRACT-V4-5-BINDING-01",
+    "status": "ACTIVE_USER_APPROVED_BINDING"
+  },
+  "base": {
+    "project_pin": "9.4.3",
+    "current_main_observed": "6d2feba2bc49fda2d8d273248b55087853615d5d",
+    "pin_update": "NOT_APPROVED_NOT_PERFORMED"
+  },
+  "tool_authority": {
+    "decision_id": "GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01",
+    "local_execution_policy": "PROJECT_DEDICATED_LOCAL_EXECUTION_ENVIRONMENT_FIRST",
+    "fresh_shell_policy": "ASSUME_PREVIOUS_POWERSHELL_CLOSED",
+    "missing_environment_policy": "CREATE_OR_REPAIR_DEDICATED_LOCAL_ENVIRONMENT_FIRST",
+    "higodot_tracked": "V3_1_4_PASS_EXACT_TREE_IDENTITY",
+    "higodot_live": "LIVE_V3_1_4_EXACT_PROJECT_SESSION_READY_OBSERVED",
+    "higodot_expected_version_field": "NOT_SURFACED_DO_NOT_CLAIM",
+    "higodot_direct_receipt": "HIGODOT_AUTHORING_RECEIPT_UNVERIFIED_FOR_DIRECT_LOCAL_TOOL_STATE_COMMIT",
+    "gut": "GUT_9_7_1_DETERMINISTIC_GDSCRIPT_TEST_AUTHORITY",
+    "hera": "HERA_V1_0_0_LIVE_QA_AND_OBSERVABILITY_ONLY",
+    "hera_task8_source_delta_required": "NONE"
+  },
+  "spell_workflow": {
+    "decision_id": "GM-SPELL-WORKFLOW-UI-V2-01",
+    "predecessor_status": "TASK7_MERGED_MAIN_VERIFIED",
+    "product_unit": "TASK8_SPELL_USE_SCREEN",
+    "status": "TASK8_LOCAL_REFINEMENT_GREEN_UNMERGED_MERGE_GATES_PENDING",
+    "next_gate": "TASK8_RECEIPT_HERA_REVIEW_PR",
+    "latest_product_main": "fcb5dbe1cbbb23ef195633b1f6680f45d46c5a3f",
+    "focused_gut": "15_TESTS_90_ASSERTIONS_0_FAILURES",
+    "predecessor_regression": "42_SUITES_1588_ASSERTIONS_0_FAILURES"
+  },
+  "sheet_sync": {
+    "spreadsheet_id": "19FftrZ4WzB-CXa9Q-y25iKMhmEs1Ip4Ea3ramf2xKqM",
+    "sync20_status": "PENDING_POST_MERGE",
+    "tracked_v3_1_4_sync19": "SHEET_WRITE_READBACK_PASS"
+  },
+  "preserved_limits": [
+    "TASK8_PROTECTED_DELTA_HIGODOT_RECEIPT_PENDING",
+    "TASK8_HERA_ACCEPTANCE_PENDING",
+    "TASK8_PR_EXACT_HEAD_CI_REVIEW_MERGE_PENDING",
+    "HIGODOT_EXPECTED_VERSION_FIELD_NOT_SURFACED",
+    "HIGODOT_AUTHORING_RECEIPT_UNVERIFIED_FOR_DIRECT_LOCAL_TOOL_STATE_COMMIT",
+    "HUMAN_NOT_RUN",
+    "DEVICE_NOT_RUN",
+    "PERFORMANCE_NOT_RUN",
+    "FULL_VERTICAL_SLICE_NOT_RUN"
+  ]
+}

--- a/docs/planning/CURRENT_CONFIRMED_DECISIONS.md
+++ b/docs/planning/CURRENT_CONFIRMED_DECISIONS.md
@@ -1,7 +1,7 @@
 # GRIMOIRE 현재 확정 결정 스냅샷
 
 ```yaml
-status: ACTIVE_CANON_V4_5_R2_TASK8_RESUME_PREFLIGHT
+status: ACTIVE_CANON_V4_5_R2_TASK8_LOCAL_REFINEMENT_GREEN_MERGE_GATES_PENDING
 active_contract: PROJECT_TOTAL_PLANNING_IMPLEMENTATION_AND_DELIVERY_INSTRUCTION_v4.5
 contract_binding_decision: GM-CONTRACT-V4-5-BINDING-01
 contract_binding_sync: GR-SYNC-20260811-02-CONTRACT-V4-5-R2-BINDING
@@ -14,8 +14,10 @@ prework_research_decision: GM-PREWORK-BENCHMARK-INDUSTRY-RESEARCH-01
 prework_research_sync: GR-SYNC-20260811-13-PREWORK-BENCHMARK-INDUSTRY-RESEARCH
 prework_research_gate: REQUIRED_BEFORE_NEW_SUBSTANTIVE_WORK_UNIT
 prework_research_same_work_unit_receipt_reuse: ALLOWED_IF_SCOPE_AND_KEY_ASSUMPTIONS_UNCHANGED
-base_current_main_observed: 7a49390bd840f5f5dc80fe661b44ad45e9ebeb7f
-current_state_sync: GR-SYNC-20260811-19-HIGODOT-V314-TRACKED-EXACT-RECONCILIATION
+base_current_main_observed: 6d2feba2bc49fda2d8d273248b55087853615d5d
+base_project_pin: v9.4.3
+base_pin_update: NOT_APPROVED_NOT_PERFORMED
+current_state_sync: GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT
 spell_workflow_predecessor_sync: GR-SYNC-20260811-01-SPELL-WORKFLOW-TASK7-CURRENT-STATE
 spell_workflow_predecessor_status: TASK7_MERGED_MAIN_VERIFIED
 product_decision: GM-SPELL-WORKFLOW-UI-V2-01
@@ -47,31 +49,35 @@ frostbloom_implementation_plan: docs/superpowers/plans/2026-08-11-frostbloom-int
 frostbloom_graybox_pack: docs/testing/frostbloom_graybox/README.md
 frostbloom_graybox_status: INTERNAL_PACK_PASS
 frostbloom_runtime_implementation: BLOCKED_BY_TASK8_DEPENDENCY
-next_planning_axis: TASK8_V314_LIVE_HANDSHAKE_THEN_TDD_RED_THEN_D_RUNTIME
+next_planning_axis: TASK8_RECEIPT_HERA_PR_THEN_D_RUNTIME
 current_process_axis: PREWORK_BENCHMARK_INDUSTRY_RESEARCH_ACTIVE
 github_actions_decision: GM-PUBLIC-REPO-FREE-GITHUB-ACTIONS-01
 repo_wide_actions_full_sha: PASS
 latest_product_main: fcb5dbe1cbbb23ef195633b1f6680f45d46c5a3f
-spell_workflow_status: TASK8_RESUMED_PREFLIGHT_ACTIVE
-next_product_task: TASK8_SPELL_USE_SCREEN
-task8_execution_path: TRACKED_V314_EXACT_TREE_PASS_LIVE_HANDSHAKE_REQUIRED_BEFORE_PERSISTENT_AUTHORING
+spell_workflow_status: TASK8_LOCAL_REFINEMENT_GREEN_UNMERGED_MERGE_GATES_PENDING
+next_product_task: TASK8_RECEIPT_HERA_REVIEW_PR
+task8_execution_path: DEDICATED_LOCAL_ENVIRONMENT_THEN_HIGODOT_RECEIPT_THEN_HERA_SOURCE_DELTA_NONE_THEN_PR
 preserved_runtime_decision: GM-STAR-CIRCUIT-MASTERY-BALANCE-01
 circuit_topology: FIVE_POINT_STAR
 tool_authority_decision: GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01
+local_execution_policy: PROJECT_DEDICATED_LOCAL_EXECUTION_ENVIRONMENT_FIRST
+fresh_shell_policy: ASSUME_PREVIOUS_POWERSHELL_CLOSED
+missing_local_environment_policy: CREATE_OR_REPAIR_DEDICATED_LOCAL_ENVIRONMENT_FIRST
 higodot_release: v3.1.4
 higodot_vendor_integrity: PASS_EXACT_TREE_IDENTITY
 higodot_tracked_sync: GR-SYNC-20260811-19-HIGODOT-V314-TRACKED-EXACT-RECONCILIATION
 higodot_tool_state_main: 257a0dba33f8288d24b1cd291bb407f4505224b4
 higodot_tool_state_sheet_sync: SHEET_WRITE_READBACK_PASS
 higodot_tracked_subtree: 69010571e11123dfc4e09483f80cb9e6ca93511a
-higodot_live_user_reported: v3.1.4
-higodot_upstream_v3_1_4: VERIFIED_TAG_96CC8B8C3D25CE487E24801D01D5214FEA150349
-higodot_tracked_v3_1_4: PASS_EXACT_TREE_IDENTITY
-higodot_live_v3_1_4: LIVE_V3_1_4_HANDSHAKE_NOT_VERIFIED
+higodot_live_v3_1_4: LIVE_V3_1_4_EXACT_PROJECT_SESSION_READY_OBSERVED
+higodot_live_session: task8-spell-use-screen-v2@3cfa
+higodot_expected_actual_fields: NOT_SURFACED_DO_NOT_CLAIM
 higodot_direct_tool_state_receipt: HIGODOT_AUTHORING_RECEIPT_UNVERIFIED_FOR_DIRECT_LOCAL_TOOL_STATE_COMMIT
 gut_status: GUT_FORMALLY_ADOPTED
 gut_release: v9.7.1
 hera_status: HERA_V1_0_0_EXACT_PAIR_LIVE_CANARY_PASS
+hera_authority: LIVE_QA_AND_OBSERVABILITY_ONLY
+hera_task8_acceptance: REQUIRED_PENDING_HERA_SOURCE_DELTA_NONE
 hera_merged_main: a35baed94fe064e57529ffee7b8c48e14ac5e1bb
 hera_sheet_sync: SHEET_WRITE_READBACK_PASS
 windows_android_shared_core: WINDOWS_ANDROID_SHARED_CORE_STRUCTURAL_PASS
@@ -91,11 +97,11 @@ approval: USER_APPROVED
 execution_request_state: USER_EXPLICIT_EXECUTION_REQUEST_PRESENT
 binding_path: docs/contracts/GRIMOIRE_PROJECT_CONTRACT_V4_5_BINDING.md
 base_source_snapshot_7ce3fb64_role: HISTORICAL_OBSERVATION_ONLY
-base_current_main_315c66ee_role: LIVE_OBSERVATION_FOR_BINDING_EXECUTION_ONLY
+base_current_main_6d2feba2_role: LIVE_OBSERVATION_FOR_BINDING_EXECUTION_ONLY
 merge_authority: APPROVED_ITEM_INHERITS_MERGE_AUTHORITY
 ```
 
-v4.5 r2는 Base current canon을 복제하지 않는 thin adapter다. Base는 매 작업 `main`과 Registry/관련 owner를 다시 읽는다. Superpowers 같은 process framework는 `EXTERNAL_PROCESS_OVERLAY`이며 프로젝트/Base canon을 소유하지 않는다.
+v4.5 r2는 Base current canon을 복제하지 않는 thin adapter다. Base는 매 작업 `main`과 Registry/관련 owner를 다시 읽는다. Superpowers 같은 process framework는 `EXTERNAL_PROCESS_OVERLAY`이며 프로젝트/Base canon을 소유하지 않는다. Base v9.4.3 project pin은 별도 승인 없이 변경하지 않는다.
 
 ## GM-PREWORK-BENCHMARK-INDUSTRY-RESEARCH-01 — current process gate
 
@@ -294,7 +300,7 @@ separate_exam: FORBIDDEN_AS_REQUIRED_CONTENT
 circuit_authority: FIVE_POINT_STAR
 historical_3x3: PROVENANCE_ONLY
 runtime_implementation: BLOCKED_BY_TASK8_DEPENDENCY
-task8_execution_path: TRACKED_V314_EXACT_TREE_PASS_LIVE_HANDSHAKE_REQUIRED_BEFORE_PERSISTENT_AUTHORING
+task8_execution_path: DEDICATED_LOCAL_ENVIRONMENT_THEN_HIGODOT_RECEIPT_THEN_HERA_SOURCE_DELTA_NONE_THEN_PR
 human_validation: NOT_RUN
 device_validation: NOT_RUN
 performance_validation: NOT_RUN
@@ -305,7 +311,7 @@ D는 학교·제작·자유일정·조사·주문·결과를 체크리스트로 
 
 Internal Graybox Pack은 46분 시간순 walkthrough, W1–W7 distinctness, 2-of-4 전 6조합, 자유일정 4선택 anti-dominance, W6 결과 보존, W7 재설계, 5축 Result/Grimoire, 14개 adversarial attack을 완료했다. 내부 구조 hard-invariant `FAIL`은 0이며 실제 elapsed/comprehension은 `NOT_TESTABLE_YET`로 남는다. 따라서 `INTERNAL_PACK_PASS`는 인간 플레이테스트·실제 46분 달성·재미·device/performance 증거가 아니다.
 
-구현계획은 기존 `SpellWorkflowCoordinator → AtomicSpellUseService → AtomicResultLedger → SaveRepository` 권위를 재사용한다. Task8 Spell Use Screen은 별도 제품 구현 권위로 유지되며 D가 우회 구현하지 않는다. Task8은 Sync17에서 새 work unit으로 재개됐고 fresh research/Existing Solution First/adversarial preflight를 통과했다. Sync19에서 tracked HiGodot v3.1.4 exact-tree identity와 Sheet current state까지 동기화했다. 다음 persistent product action은 authorized live v3.1.4 `expected_version == actual_version == 3.1.4` / READY readback 후 Task8 GUT RED와 최소 UI GREEN이며, D runtime은 Task8 의존성이 해소된 후 이어진다.
+구현계획은 기존 `SpellWorkflowCoordinator → AtomicSpellUseService → AtomicResultLedger → SaveRepository` 권위를 재사용한다. Task8 Spell Use Screen은 별도 제품 구현 권위로 유지되며 D가 우회 구현하지 않는다. Task8은 Sync17에서 새 work unit으로 재개됐고 fresh research/Existing Solution First/adversarial preflight를 통과했다. Sync19에서 tracked HiGodot v3.1.4 exact-tree identity와 Sheet current state까지 동기화했다. 현재 Task8 local refinement는 GUT focused 15/90 및 legacy 42 suites/1,588 assertions GREEN이지만 unmerged다. 다음 제품 gate는 dedicated local environment에서 fresh HiGodot protected-delta receipt/readback → Hera `HERA_SOURCE_DELTA: NONE` → review/PR/merge이며, D runtime은 Task8 의존성이 해소된 후 이어진다.
 
 ## GM-SPELL-WORKFLOW-UI-V2-01 — current implementation state
 
@@ -328,16 +334,23 @@ Internal Graybox Pack은 46분 시간순 walkthrough, W1–W7 distinctness, 2-of
 | 7 | #110 | `fcb5dbe1cbbb23ef195633b1f6680f45d46c5a3f` | circuit placement screen |
 
 ```yaml
-current_status: TASK8_RESUMED_PREFLIGHT_ACTIVE
+current_status: TASK8_LOCAL_REFINEMENT_GREEN_UNMERGED_MERGE_GATES_PENDING
 predecessor_sync: GR-SYNC-20260811-01-SPELL-WORKFLOW-TASK7-CURRENT-STATE
 predecessor_status: TASK7_MERGED_MAIN_VERIFIED
 resume_sync: GR-SYNC-20260811-17-TASK8-RESUME-V314-PREFLIGHT
 tool_reconciliation_sync: GR-SYNC-20260811-19-HIGODOT-V314-TRACKED-EXACT-RECONCILIATION
+local_environment_sync: GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT
 research_receipt: docs/planning/research/2026-08-11-task8-resume-v314-research-receipt.md
 implementation_plan: docs/superpowers/plans/2026-08-11-task8-spell-use-screen.md
-next_task: TASK8_SPELL_USE_SCREEN
+next_task: TASK8_RECEIPT_HERA_REVIEW_PR
 next_task_role: UI_CONSUMER_OF_EXISTING_TASK5_STAGE3_AUTHORITY
-execution_path: TRACKED_V314_EXACT_TREE_PASS_LIVE_HANDSHAKE_REQUIRED_BEFORE_PERSISTENT_AUTHORING
+execution_path: DEDICATED_LOCAL_ENVIRONMENT_THEN_HIGODOT_RECEIPT_THEN_HERA_SOURCE_DELTA_NONE_THEN_PR
+live_session_observed: task8-spell-use-screen-v2@3cfa
+live_server_plugin: V3_1_4_V3_1_4
+live_readiness: READY
+expected_version_field: NOT_SURFACED_DO_NOT_CLAIM
+focused_local_gut: 15_TESTS_90_ASSERTIONS_0_FAILURES
+predecessor_regression: 42_SUITES_1588_ASSERTIONS_0_FAILURES
 new_product_decision_required_for_task8: false
 ```
 
@@ -358,6 +371,10 @@ tuning_status: PLAYTEST_TUNING_REQUIRED
 ## GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01
 
 ```yaml
+sync_id: GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT
+local_execution_policy: PROJECT_DEDICATED_LOCAL_EXECUTION_ENVIRONMENT_FIRST
+fresh_shell_policy: ASSUME_PREVIOUS_POWERSHELL_CLOSED
+missing_environment_policy: CREATE_OR_REPAIR_DEDICATED_LOCAL_ENVIRONMENT_FIRST
 higodot:
   release: v3.1.4
   authority: SOLE_PERSISTENT_GODOT_AUTHORING_AUTHORITY
@@ -367,9 +384,11 @@ higodot:
   plugin_subtree: 69010571e11123dfc4e09483f80cb9e6ca93511a
   vendor_integrity: PASS_EXACT_TREE_IDENTITY
   upstream_tag_commit: 96cc8b8c3d25ce487e24801d01d5214fea150349
-  live_user_reported: v3.1.4
-  live_handshake: LIVE_V3_1_4_HANDSHAKE_NOT_VERIFIED
-  tracked_live_match: NOT_VERIFIED
+  live_session: task8-spell-use-screen-v2@3cfa
+  live_project_match: PASS_FOR_OBSERVED_SESSION
+  live_server_plugin: V3_1_4_V3_1_4
+  live_readiness: READY
+  expected_version_field: NOT_SURFACED_DO_NOT_CLAIM
   direct_local_upgrade_receipt: HIGODOT_AUTHORING_RECEIPT_UNVERIFIED_FOR_DIRECT_LOCAL_TOOL_STATE_COMMIT
   historical_v3_1_3:
     tracked_sync: GR-SYNC-20260809-04-HIGODOT-V313-TRACKED-EXACT-RECONCILIATION
@@ -387,7 +406,28 @@ hera:
   merged_main: a35baed94fe064e57529ffee7b8c48e14ac5e1bb
   sheet_sync: SHEET_WRITE_READBACK_PASS
   persistent_source_mutation_authorized: false
+  task8_acceptance: PENDING
+  task8_required_source_delta: NONE
 ```
+
+Dedicated local flow:
+
+```text
+new PowerShell each local work session
+→ dedicated self-contained GRIMOIRE Godot
+→ exact requested GRIMOIRE project/worktree
+→ project-scoped HiGodot profile/server/ports
+→ project-scoped CODEX_HOME
+→ Hera exact pair/profile when live QA is required
+→ Codex exact worktree
+→ fresh exact-project HiGodot receipt
+→ HiGodot-only persistent authoring
+→ GUT deterministic verification
+→ Hera live QA/observability only
+→ HERA_SOURCE_DELTA: NONE
+```
+
+Hera shared-token plaintext는 저장소·prompt·log·evidence에 기록하지 않는다. Hera에서 persistent 수정하지 않고, 결함 발견 시 HiGodot authoring으로 돌아간다.
 
 ## Historical v4.4 / Task2 provenance
 
@@ -425,7 +465,10 @@ three_screen_runtime: THREE_SCREEN_RUNTIME_AWAITING_TASKS_2_9
 ## 현재 증거 한계
 
 ```text
-LIVE_V3_1_4_HANDSHAKE_NOT_VERIFIED
+TASK8_PROTECTED_DELTA_HIGODOT_RECEIPT_PENDING
+TASK8_HERA_ACCEPTANCE_PENDING
+TASK8_PR_EXACT_HEAD_CI_REVIEW_MERGE_PENDING
+HIGODOT_EXPECTED_VERSION_FIELD_NOT_SURFACED
 HUMAN_NOT_RUN
 DEVICE_NOT_RUN
 PERFORMANCE_NOT_RUN
@@ -437,10 +480,8 @@ AUDIO_VAULT_PATH_UNVERIFIED
 AUDIO_RIGHTS_UNVERIFIED
 VISUAL_AUDIO_COMPLETE_NOT_PROVEN
 HIGODOT_AUTHORING_RECEIPT_UNVERIFIED_FOR_DIRECT_LOCAL_TOOL_STATE_COMMIT
-LOCAL_SYNC_BLOCKED_NO_LOCAL_ACCESS
-GODOT_RUN_BLOCKED_NO_LOCAL_ACCESS
 ```
 
 ## Contract binding
 
-현재 확정 계약은 v4.5 r2 / `GM-CONTRACT-V4-5-BINDING-01`이다. v4.4 / `GM-CONTRACT-V4-4-BINDING-01`과 HiGodot v3.1.3은 historical provenance로 보존한다.
+현재 확정 계약은 v4.5 r2 / `GM-CONTRACT-V4-5-BINDING-01`이다. v4.4 / `GM-CONTRACT-V4-4-BINDING-01`과 HiGodot v3.1.3은 historical provenance로 보존한다. Sync20은 운영 실행환경 consumer이며 제품 규칙을 변경하지 않는다.

--- a/docs/planning/CURRENT_UNRESOLVED_GATES.md
+++ b/docs/planning/CURRENT_UNRESOLVED_GATES.md
@@ -10,22 +10,27 @@ base_snapshot_policy: ALWAYS_REFETCH_CURRENT_MAIN_BEFORE_WORK
 base_repository_review_policy: RECURSIVE_INVENTORY_THEN_RELEVANCE_DRIVEN_DEEP_READ
 adapter_policy: THIN_ADAPTER_DO_NOT_DUPLICATE_BASE_CANON
 external_process_policy: EXTERNAL_PROCESS_OVERLAY
-current_state_sync: GR-SYNC-20260811-19-HIGODOT-V314-TRACKED-EXACT-RECONCILIATION
+current_state_sync: GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT
 spell_workflow_predecessor_sync: GR-SYNC-20260811-01-SPELL-WORKFLOW-TASK7-CURRENT-STATE
 product_decision_id: GM-SPELL-WORKFLOW-UI-V2-01
 github_actions_decision: GM-PUBLIC-REPO-FREE-GITHUB-ACTIONS-01
 latest_product_main: fcb5dbe1cbbb23ef195633b1f6680f45d46c5a3f
-spell_workflow_status: TASK8_RESUMED_PREFLIGHT_ACTIVE
+spell_workflow_status: TASK8_LOCAL_REFINEMENT_GREEN_UNMERGED_MERGE_GATES_PENDING
 spell_workflow_predecessor_status: TASK7_MERGED_MAIN_VERIFIED
-next_product_task: TASK8_SPELL_USE_SCREEN
+next_product_task: TASK8_RECEIPT_HERA_REVIEW_PR
 preserved_runtime_decision: GM-STAR-CIRCUIT-MASTERY-BALANCE-01
 circuit_topology: FIVE_POINT_STAR
+local_execution_policy: PROJECT_DEDICATED_LOCAL_EXECUTION_ENVIRONMENT_FIRST
+fresh_shell_policy: ASSUME_PREVIOUS_POWERSHELL_CLOSED
+missing_local_environment_policy: CREATE_OR_REPAIR_DEDICATED_LOCAL_ENVIRONMENT_FIRST
 higodot_release: v3.1.4
 higodot_vendor_integrity: PASS_EXACT_TREE_IDENTITY
 higodot_integrity_status: HIGODOT_VENDOR_INTEGRITY_PASS_EXACT_TREE_IDENTITY
 higodot_tracked_sync: GR-SYNC-20260811-19-HIGODOT-V314-TRACKED-EXACT-RECONCILIATION
 higodot_sheet_sync: SHEET_WRITE_READBACK_PASS
-higodot_live_alignment: LIVE_V3_1_4_HANDSHAKE_NOT_VERIFIED
+higodot_live_alignment: LIVE_V3_1_4_EXACT_PROJECT_SESSION_READY_OBSERVED
+higodot_live_session: task8-spell-use-screen-v2@3cfa
+higodot_expected_actual_fields: NOT_SURFACED_DO_NOT_CLAIM
 gut_implementation_status: GUT_FORMALLY_ADOPTED
 gut_formal_adoption_main: ea46923fa78c4fe7844ab6bf422e6716a3c785ed
 formal_adoption_scope: MERGED_MAIN_VERIFIED
@@ -34,6 +39,8 @@ role_separated_review: ROLE_SEPARATED_REVIEW_P0_P1_ZERO
 gut_implementation_pr: PR85_MERGED_MAIN_VERIFIED
 repo_wide_actions_supply_chain: REPO_WIDE_ACTIONS_FULL_SHA_PINNING_PASS
 hera_status: HERA_V1_0_0_EXACT_PAIR_LIVE_CANARY_PASS
+hera_authority: LIVE_QA_AND_OBSERVABILITY_ONLY
+hera_task8_acceptance: PENDING_HERA_SOURCE_DELTA_NONE
 windows_android_shared_core: WINDOWS_ANDROID_SHARED_CORE_STRUCTURAL_PASS
 visual_automated_layout_baseline: VISUAL_AUTOMATED_LAYOUT_BASELINE_PASS
 three_screen_runtime: THREE_SCREEN_RUNTIME_AWAITING_TASKS_2_9
@@ -49,14 +56,16 @@ binding_decision: GM-CONTRACT-V4-5-BINDING-01
 binding_sync: GR-SYNC-20260811-02-CONTRACT-V4-5-R2-BINDING
 binding_path: docs/contracts/GRIMOIRE_PROJECT_CONTRACT_V4_5_BINDING.md
 execution_request_state: USER_EXPLICIT_EXECUTION_REQUEST_PRESENT
-base_current_main_observed: 7a49390bd840f5f5dc80fe661b44ad45e9ebeb7f
+base_current_main_observed: 6d2feba2bc49fda2d8d273248b55087853615d5d
+base_project_pin: v9.4.3
+base_pin_update: NOT_APPROVED_NOT_PERFORMED
 base_source_snapshot_7ce3fb64_role: HISTORICAL_OBSERVATION_ONLY
 silent_rebinding: NOT_APPLICABLE_USER_EXPLICITLY_APPROVED
 sheet_sync: SHEET_WRITE_READBACK_PASS
 current_binding_status: ACTIVE_NO_REBIND_REQUIRED
 ```
 
-v4.5 r2는 현재 계약이며 Base current SHA는 영구 권위가 아니다. 이번 Sync19 work unit에서 Base `main`은 `7a49390b...`로 다시 읽었다.
+v4.5 r2는 현재 계약이며 Base current SHA는 영구 authority/pin이 아니다. Base `6d2feba2...`의 dedicated-local-environment invariant를 현재 project consumer로 사용한다.
 
 ## 닫힌 Spell Workflow implementation gates
 
@@ -66,9 +75,6 @@ Task 2와 Tasks 3–7은 unresolved가 아니다.
 task2:
   merge: 975b2ad278d07bf9bfa06a9f4c1fc20a9fb1bac0
   status: TASK2_MERGED_MAIN_VERIFIED
-  spell_workflow_task2_authorized: true
-  spell_workflow_task2_readiness: TASK3_READY_AFTER_POST_MERGE_CANON
-  spell_workflow_task2_execution_status: MERGED_MAIN_VERIFIED
   authoring_receipt_status: TASK2_HIGODOT_RECEIPT_READBACK_PASS
   checkpoint_role: HISTORICAL_TASK2_TO_TASK3_ENTRY_PROVENANCE_NOT_CURRENT_NEXT_TASK
 task3:
@@ -107,32 +113,76 @@ higodot_v3_1_3_sync: GR-SYNC-20260809-04-HIGODOT-V313-TRACKED-EXACT-RECONCILIATI
 higodot_v3_1_3_status: HISTORICAL_PASS_EXACT_TREE_IDENTITY_AND_LIVE_READBACK
 ```
 
-## 현재 next implementation gate
+Historical Sync19/validation documents may correctly say that the v3.1.4 live handshake was pending at that time. Sync20 does not rewrite those historical receipts.
+
+## 현재 Task8 gate
+
+The user-supplied current local execution observed exact-project session `task8-spell-use-screen-v2@3cfa`, Godot 4.7.1, HiGodot server/plugin 3.1.4, readiness `ready`. The tool did not surface a separate `expected_version` field; no such equality is claimed.
 
 ```yaml
-next_task: TASK8_SPELL_USE_SCREEN
+next_task: TASK8_RECEIPT_HERA_REVIEW_PR
 scope:
   - explicit target selection UI
-  - final expected-result preview
-  - user confirmation boundary
+  - prepared-spell summary
+  - supplied final expected-result preview
+  - two-stage user confirmation boundary
+  - stale/invalid target visual fail-closed
+  - actual cancel intent
+  - deterministic focus/text semantics
   - consume existing Task 5 Stage 3 transaction authority
 must_not:
   - duplicate target/use authority
   - auto-select target as final behavior
   - spend Mana before explicit confirmation
+  - let Hera persistently mutate source
   - upgrade human/device/performance evidence without new runs
 tracked_higodot_v3_1_4: PASS_EXACT_TREE_IDENTITY
-live_higodot_v3_1_4: LIVE_V3_1_4_HANDSHAKE_NOT_VERIFIED
-required_live_readback:
-  - expected_version == 3.1.4
-  - actual_version == 3.1.4
-  - lifecycle == READY
-persistent_godot_authoring: BLOCKED_UNTIL_LIVE_READBACK_THEN_HIGODOT_ONLY_WITH_FRESH_RECEIPT
+live_higodot_v3_1_4: LIVE_V3_1_4_EXACT_PROJECT_SESSION_READY_OBSERVED
+expected_version_field: NOT_SURFACED_DO_NOT_CLAIM
+focused_local_gut: 15_TESTS_90_ASSERTIONS_0_FAILURES
+predecessor_regression: 42_SUITES_1588_ASSERTIONS_0_FAILURES
+persistent_godot_authoring: HIGODOT_ONLY_WITH_FRESH_PROTECTED_DELTA_RECEIPT
 formal_test_authority: GUT_9_7_1
-live_qa: HERA_OBSERVABILITY_ONLY_SOURCE_DELTA_NONE
+live_qa: HERA_LIVE_QA_AND_OBSERVABILITY_ONLY
+hera_source_delta_required: NONE
+merge_state: UNMERGED_LOCAL_WORK
 ```
 
-tracked exact-tree evidence와 live executor readiness는 별개다. Task8 focused GUT RED와 protected product authoring은 authorized HiGodot v3.1.4 live handshake readback 이후에만 시작한다.
+The former live-handshake blocker is closed for the observed session. The new actual merge blockers are receipt/readback, Hera source-delta acceptance, independent/adversarial review, exact-head CI, merge, and merged-main readback.
+
+## Dedicated local execution gate
+
+```text
+ASSUME_PREVIOUS_POWERSHELL_CLOSED
+→ new PowerShell
+→ verify/create-or-repair dedicated self-contained GRIMOIRE Godot
+→ exact requested project/worktree
+→ project-scoped HiGodot profile/server/ports
+→ project-scoped CODEX_HOME
+→ Hera exact project-approved pair/profile when live QA is required
+→ Codex exact worktree
+→ fresh exact-project HiGodot receipt
+```
+
+The launcher is one complete copy/paste block and appears before the Codex prompt. It fails closed on wrong project/worktree, other-project editor/HiGodot/Hera profile or port, CODEX_HOME leakage, ambiguous duplicate process, quoting problems, and process/port-not-readiness. It does not reset/restore/clean/stage/rewrite user work, kill unrelated processes, or front-load broad Git diff/LF-CRLF noise.
+
+If this dedicated environment is missing or incomplete, `CREATE_OR_REPAIR_DEDICATED_LOCAL_ENVIRONMENT_FIRST` precedes product work.
+
+## Hera acceptance gate
+
+```yaml
+release: v1.0.0
+authority: LIVE_QA_AND_OBSERVABILITY_ONLY
+persistent_source_mutation: FORBIDDEN
+shared_token_plaintext_in_repo_prompt_log_evidence: FORBIDDEN
+task8_acceptance:
+  pre_source_snapshot: REQUIRED
+  live_qa: REQUIRED
+  post_source_snapshot: REQUIRED
+  source_delta: NONE_REQUIRED
+```
+
+A Hera-discovered product defect returns to HiGodot persistent authoring, then GUT/regression and Hera are rerun. Hera is not a write fallback.
 
 ## Task 9 precondition findings
 
@@ -143,7 +193,10 @@ tracked exact-tree evidence와 live executor readiness는 별개다. Task8 focus
 
 | ID | 상태 |
 |---|---|
-| `THREE_SCREEN_RUNTIME_AWAITING_TASKS_2_9` | Tasks 2–7 merged; Tasks 8–9 + Task 10 evidence remaining |
+| `THREE_SCREEN_RUNTIME_AWAITING_TASKS_2_9` | Task8 unmerged; Tasks 8–9 + Task 10 evidence remaining |
+| `TASK8_PROTECTED_DELTA_HIGODOT_RECEIPT_PENDING` | `BLOCKING_FOR_TASK8_MERGE` |
+| `TASK8_HERA_ACCEPTANCE_PENDING` | `BLOCKING_FOR_TASK8_MERGE` |
+| `TASK8_PR_EXACT_HEAD_CI_REVIEW_MERGE_PENDING` | `BLOCKING_FOR_TASK8_MAIN` |
 | `WINDOWS_EXPORT_NOT_RUN` | `NOT_CLAIMED` |
 | `ANDROID_EXPORT_NOT_RUN` | `NOT_CLAIMED` |
 | `ANDROID_DEVICE_NOT_RUN` | `NOT_CLAIMED` |
@@ -155,34 +208,32 @@ tracked exact-tree evidence와 live executor readiness는 별개다. Task8 focus
 
 | ID | 상태 |
 |---|---|
-| `LIVE_V3_1_4_HANDSHAKE_NOT_VERIFIED` | `BLOCKING_FOR_TASK8_PROTECTED_AUTHORING` |
-| `AUDIO_VAULT_PATH_UNVERIFIED` | `BLOCKED_NO_LOCAL_ACCESS` |
+| `HIGODOT_EXPECTED_VERSION_FIELD_NOT_SURFACED` | `EVIDENCE_LIMIT_NOT_LIVE_READY_BLOCKER` |
+| `HIGODOT_AUTHORING_RECEIPT_UNVERIFIED_FOR_DIRECT_LOCAL_TOOL_STATE_COMMIT` | `PROVENANCE_LIMIT` |
+| `AUDIO_VAULT_PATH_UNVERIFIED` | `BLOCKED_UNVERIFIED` |
 | `AUDIO_RIGHTS_UNVERIFIED` | `BLOCKING_FOR_AUDIO_INGESTION` |
 | `VISUAL_AUDIO_COMPLETE_NOT_PROVEN` | `BLOCKING_FOR_FINAL_VISUAL_AUDIO_COMPLETION` |
-| `HIGODOT_AUTHORING_RECEIPT_UNVERIFIED_FOR_DIRECT_LOCAL_TOOL_STATE_COMMIT` | `PROVENANCE_LIMIT` |
-| `LOCAL_SYNC_BLOCKED_NO_LOCAL_ACCESS` | `DELIVERY_BLOCKING` |
-| `GODOT_RUN_BLOCKED_NO_LOCAL_ACCESS` | `DELIVERY_BLOCKING` |
 
 ## 현재 허용
 
 ```yaml
 allowed_next_actions:
-  - COMPLETE_SYNC19_EXACT_HEAD_CI_REVIEW_AND_MERGE
-  - AUTHORIZED_HIGODOT_V3_1_4_EXPECTED_ACTUAL_READY_READBACK
-  - AFTER_LIVE_ALIGNMENT_PASS_RUN_TASK8_FOCUSED_GUT_RED
-  - AFTER_RED_HIGODOT_PERSISTENT_TASK8_AUTHORING_WITH_FRESH_RECEIPT_GATE
-  - GUT_DETERMINISTIC_TASK8_TESTING
-  - HERA_TASK8_ACCEPTANCE_QA_OBSERVABILITY_ONLY
+  - FRESH_DEDICATED_LOCAL_ENVIRONMENT_BOOTSTRAP
+  - FRESH_EXACT_PROJECT_HIGODOT_RECEIPT
+  - TASK8_PROTECTED_DELTA_HIGODOT_RECEIPT_READBACK
+  - GUT_DETERMINISTIC_TASK8_REGRESSION_AS_REQUIRED
+  - HERA_TASK8_ACCEPTANCE_QA_OBSERVABILITY_ONLY_WITH_SOURCE_DELTA_NONE
+  - INDEPENDENT_ADVERSARIAL_REVIEW
+  - TASK8_EXACT_HEAD_PR_CI_MERGE
   - PROPAGATE_APPROVED_DEVICE_MATRIX_INTO_TASK9_ACCEPTANCE
   - VERIFY_GODOT_MULTIPLE_ASPECT_POLICY_BEFORE_TASK9
 forbidden_next_actions:
-  - TASK8_GUT_RED_BEFORE_LIVE_V3_1_4_ALIGNMENT_PASS
   - PERSISTENT_GODOT_PRODUCT_AUTHORING_OUTSIDE_HIGODOT
   - LET_HERA_PERSISTENTLY_MUTATE_SOURCE
-  - CLAIM_TASK8_IMPLEMENTED_BEFORE_FRESH_AUTHORING_AND_GREEN_VALIDATION
+  - STORE_HERA_SHARED_TOKEN_PLAINTEXT
+  - CLAIM_TASK8_MERGED_OR_COMPLETE_BEFORE_MERGED_MAIN_READBACK
   - CLAIM_THREE_SCREEN_RUNTIME_PASS_BEFORE_TASKS8_9_AND_TASK10_EVIDENCE
   - CLAIM_WINDOWS_OR_ANDROID_EXPORT_OR_DEVICE_PASS
   - CLAIM_HUMAN_OR_PLAYER_EXPERIENCE_PASS
   - CLAIM_VISUAL_AUDIO_COMPLETE
-  - CLAIM_LOCAL_SYNC_OR_PROJECT_PLAY_COMPLETE
 ```

--- a/docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE_SYNC20.json
+++ b/docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE_SYNC20.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": 1,
+  "sync_id": "GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT",
+  "decision_id": "GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01",
+  "supersedes_current_view_of": "docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE.json",
+  "superseded_file_role": "SYNC19_HISTORICAL_MACHINE_SNAPSHOT",
+  "base": {
+    "project_pin": "9.4.3",
+    "current_main_observed": "6d2feba2bc49fda2d8d273248b55087853615d5d",
+    "pin_update": "NOT_APPROVED_NOT_PERFORMED"
+  },
+  "local_execution": {
+    "policy": "PROJECT_DEDICATED_LOCAL_EXECUTION_ENVIRONMENT_FIRST",
+    "fresh_shell": "ASSUME_PREVIOUS_POWERSHELL_CLOSED",
+    "missing_environment": "CREATE_OR_REPAIR_DEDICATED_LOCAL_ENVIRONMENT_FIRST",
+    "launcher_order": "NEW_POWERSHELL_THEN_DEDICATED_GODOT_THEN_PROJECT_HIGODOT_THEN_PROJECT_CODEX_HOME_THEN_HERA_IF_REQUIRED_THEN_EXACT_WORKTREE_CODEX",
+    "sheet_status": "PENDING_POST_MERGE"
+  },
+  "higodot": {
+    "release": "v3.1.4",
+    "authority": "SOLE_PERSISTENT_GODOT_AUTHORING_AUTHORITY",
+    "tracked_plugin_subtree": "69010571e11123dfc4e09483f80cb9e6ca93511a",
+    "tracked_vendor_integrity": "PASS_EXACT_TREE_IDENTITY",
+    "live_status": "LIVE_V3_1_4_EXACT_PROJECT_SESSION_READY_OBSERVED",
+    "session_id": "task8-spell-use-screen-v2@3cfa",
+    "project_path": "C:/Users/user/Documents/GitHub/Ninza/GRIMOIRE-/.worktrees/task8-spell-use-screen-v2/",
+    "server_version": "3.1.4",
+    "plugin_version": "3.1.4",
+    "readiness": "READY",
+    "expected_version_field": "NOT_SURFACED_DO_NOT_CLAIM",
+    "direct_local_upgrade_receipt": "HIGODOT_AUTHORING_RECEIPT_UNVERIFIED_FOR_DIRECT_LOCAL_TOOL_STATE_COMMIT"
+  },
+  "gut": {
+    "release": "v9.7.1",
+    "authority": "DETERMINISTIC_GDSCRIPT_TEST_AUTHORITY",
+    "status": "GUT_FORMALLY_ADOPTED"
+  },
+  "hera": {
+    "release": "v1.0.0",
+    "authority": "LIVE_QA_AND_OBSERVABILITY_ONLY",
+    "persistent_source_mutation": "FORBIDDEN",
+    "task8_acceptance": "PENDING",
+    "required_source_delta": "NONE"
+  },
+  "task8": {
+    "product_unit": "TASK8_SPELL_USE_SCREEN",
+    "status": "TASK8_LOCAL_REFINEMENT_GREEN_UNMERGED_MERGE_GATES_PENDING",
+    "focused_gut": "15_TESTS_90_ASSERTIONS_0_FAILURES",
+    "predecessor_regression": "42_SUITES_1588_ASSERTIONS_0_FAILURES",
+    "next_gate": "TASK8_RECEIPT_HERA_REVIEW_PR",
+    "protected_delta_receipt": "PENDING",
+    "hera_acceptance": "PENDING_HERA_SOURCE_DELTA_NONE",
+    "pr_merge": "PENDING"
+  },
+  "historical": {
+    "tracked_v3_1_4_sync": "GR-SYNC-20260811-19-HIGODOT-V314-TRACKED-EXACT-RECONCILIATION",
+    "v3_1_3_sync": "GR-SYNC-20260809-04-HIGODOT-V313-TRACKED-EXACT-RECONCILIATION",
+    "sync19_live_status_at_that_time": "LIVE_V3_1_4_HANDSHAKE_NOT_VERIFIED"
+  },
+  "claims": {
+    "live_exact_project_v3_1_4_ready_observed": true,
+    "expected_version_field_verified": false,
+    "direct_local_upgrade_receipt_verified": false,
+    "task8_local_refinement_green": true,
+    "task8_merged_main_verified": false,
+    "task8_hera_acceptance_pass": false
+  }
+}

--- a/docs/planning/sync/GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT.md
+++ b/docs/planning/sync/GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT.md
@@ -1,0 +1,114 @@
+# GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT
+
+```yaml
+sync_id: GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT
+decision_id: GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01
+approval: USER_APPROVED_ACTIVE
+scope: PROJECT_OPERATING_FLOW_ONLY
+product_decision_change: false
+protected_godot_product_mutation: NONE
+source_base_main: 6d2feba2bc49fda2d8d273248b55087853615d5d
+source_base_pr: 288
+base_invariant: PROJECT_DEDICATED_LOCAL_EXECUTION_ENVIRONMENT_FIRST
+fresh_shell_rule: ASSUME_PREVIOUS_POWERSHELL_CLOSED
+missing_environment_rule: CREATE_OR_REPAIR_DEDICATED_LOCAL_ENVIRONMENT_FIRST
+```
+
+## Approved GRIMOIRE local execution contract
+
+Every user-executed local work session starts from a new PowerShell process. A previous PowerShell window, environment variable, current directory, process handle, or Codex session is never assumed to survive.
+
+The project-dedicated local environment is:
+
+```text
+new PowerShell process
+→ verify/create-or-repair the dedicated self-contained GRIMOIRE Godot distribution
+→ reuse/start only the exact requested GRIMOIRE Godot project/worktree
+→ verify/start-or-attach the GRIMOIRE-scoped HiGodot profile/server/ports
+→ set the GRIMOIRE-scoped CODEX_HOME
+→ verify the project-adopted Hera exact pair/profile when live QA is required
+→ launch Codex in the exact requested GRIMOIRE worktree
+→ inside Codex obtain a fresh exact-project HiGodot session/version/readiness receipt
+→ persistent Godot authoring only through HiGodot
+→ deterministic GDScript verification through GUT when required
+→ live acceptance through Hera only under LIVE_QA_AND_OBSERVABILITY_ONLY
+→ require HERA_SOURCE_DELTA: NONE
+```
+
+Concrete host values such as current HiGodot ports and Hera token/profile are execution-time project inputs. They must be read from the current project/local configuration before each launcher is generated. Shared-token plaintext is never copied into repository canon, prompts, logs, or evidence.
+
+## One-block handoff rule
+
+When the user must execute the local step, GPT/Codex handoff order is fixed:
+
+```text
+1. tell the user to open a new PowerShell window
+2. provide one complete copy/paste PowerShell block first
+3. that block validates/repairs the project-dedicated environment and launches Codex
+4. only after Codex opens, provide the Codex task prompt
+```
+
+The launcher uses minimum identity/startup checks only. It does not begin with broad `git diff`, repository-wide scans, already-classified LF/CRLF/stat/index noise dumps, or destructive cleanup.
+
+It must fail closed on wrong worktree, wrong branch when a branch is required, other-project Godot/HiGodot/Hera profile reuse, port/profile collision, missing project CODEX_HOME, path quoting failure, ambiguous duplicate editor, or other-project process ownership. It must not `reset`, `restore`, `clean`, stage, rewrite, or kill unrelated editors/servers.
+
+## Authority boundaries
+
+```yaml
+higodot:
+  release: v3.1.4
+  authority: SOLE_PERSISTENT_GODOT_AUTHORING_AUTHORITY
+  tracked_vendor: PASS_EXACT_TREE_IDENTITY
+
+gut:
+  release: v9.7.1
+  authority: DETERMINISTIC_GDSCRIPT_TEST_AUTHORITY
+
+hera:
+  release: v1.0.0
+  authority: LIVE_QA_AND_OBSERVABILITY_ONLY
+  persistent_source_mutation: FORBIDDEN
+  acceptance_source_delta: NONE_REQUIRED
+```
+
+Hera is part of the dedicated GRIMOIRE local QA environment when the current acceptance gate requires live QA, but Hera is not an authoring fallback. Any persistent product correction discovered during Hera QA returns to HiGodot authoring, then deterministic tests are rerun before Hera acceptance is repeated.
+
+## Fresh local evidence carried into this sync
+
+The latest user-supplied Codex execution receipt for the active Task8 V2 worktree returned a live HiGodot session with:
+
+```yaml
+session_id: task8-spell-use-screen-v2@3cfa
+project_path: C:/Users/user/Documents/GitHub/Ninza/GRIMOIRE-/.worktrees/task8-spell-use-screen-v2/
+godot: 4.7.1-stable
+plugin_version: 3.1.4
+server_version: 3.1.4
+readiness: ready
+```
+
+This proves a live exact-project v3.1.4/ready session was observed for that run. The prior `LIVE_V3_1_4_HANDSHAKE_NOT_VERIFIED` current wording is therefore stale as a blanket statement. It does **not** prove an `expected_version` field that the tool did not surface, and it does not verify the old direct/local tool-state commit's formal authoring receipt.
+
+The same execution reported Task8 local refinement GREEN (focused 15 tests / 90 assertions; legacy 42 suites / 1,588 assertions; zero failures), but Task8 remains unmerged local work. This Sync20 does not promote Task8 to merged/complete.
+
+## Current next product gate
+
+Task8 remains local and unpushed. Before product staging/commit/push:
+
+```text
+fresh dedicated local environment bootstrap
+→ fresh exact-project HiGodot receipt
+→ fresh protected-delta authoring receipt/readback
+→ pre-Hera tracked-source snapshot
+→ Hera live QA only
+→ post-Hera tracked-source snapshot
+→ HERA_SOURCE_DELTA: NONE
+→ independent/adversarial review
+→ exact-head PR CI
+→ merge and merged-main readback
+```
+
+Human/device/performance/export/full-vertical-slice evidence remains `NOT_RUN` unless separately executed.
+
+## Base / project boundary
+
+Base main `6d2feba2bc49fda2d8d273248b55087853615d5d` owns the generic dedicated-environment invariant. GRIMOIRE owns its concrete Godot/HiGodot/CODEX_HOME/Hera configuration and this same existing Decision ID. The Base v9.4.3 project pin is unchanged; the current Base main observation is not a pin update.

--- a/tests/test_godot_authoring_gut_authority_contract.py
+++ b/tests/test_godot_authoring_gut_authority_contract.py
@@ -10,7 +10,9 @@ BINDING_V43 = ROOT / "docs/contracts/GRIMOIRE_PROJECT_CONTRACT_V4_3_BINDING.md"
 BINDING_V44 = ROOT / "docs/contracts/GRIMOIRE_PROJECT_CONTRACT_V4_4_BINDING.md"
 BINDING_V45 = ROOT / "docs/contracts/GRIMOIRE_PROJECT_CONTRACT_V4_5_BINDING.md"
 PLAN = ROOT / "docs/superpowers/plans/2026-08-06-gut-9-7-1-formal-adoption.md"
-STATE = ROOT / "docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE.json"
+SYNC19_STATE = ROOT / "docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE.json"
+CURRENT_STATE = ROOT / "docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE_SYNC20.json"
+CURRENT_CANON = ROOT / "docs/planning/CANON_SYNC_STATE_SYNC20.json"
 UNRESOLVED = ROOT / "docs/planning/CURRENT_UNRESOLVED_GATES.md"
 HIGODOT_V312_EVIDENCE = ROOT / "docs/validation/HIGODOT_V3_1_2_VENDOR_INTEGRITY.json"
 HIGODOT_V313_EVIDENCE = ROOT / "docs/validation/HIGODOT_V3_1_3_VENDOR_INTEGRITY.json"
@@ -22,163 +24,113 @@ CURRENT_SURFACES = [
     ROOT / "docs/DEVELOPMENT_GATES.md",
     ROOT / "docs/planning/CURRENT_CONFIRMED_DECISIONS.md",
     ROOT / "docs/planning/CURRENT_UNRESOLVED_GATES.md",
-    ROOT / "docs/planning/CANON_SYNC_STATE.json",
-    ROOT / "docs/planning/GRILL_ME_BATCH_MERGE_STATE.json",
+    CURRENT_STATE,
+    CURRENT_CANON,
 ]
-GUT_MERGED_MAIN = "ea46923fa78c4fe7844ab6bf422e6716a3c785ed"
+
 CURRENT_CONTRACT = "GM-CONTRACT-V4-5-BINDING-01"
 HISTORICAL_V44_CONTRACT = "GM-CONTRACT-V4-4-BINDING-01"
-CURRENT_BASE_MAIN = "7a49390bd840f5f5dc80fe661b44ad45e9ebeb7f"
-HIGODOT_V312_TREE = "a7d1e2fe8564cc385d683ec50d15fc66e1a17a35"
-HIGODOT_V313_TREE = "94be4fb34d49243375c592e17a1021c8c6fcbcf2"
-HIGODOT_V313_COMMIT = "22678e5f9b038d7203d6b43b0aae20a5417c500e"
+CURRENT_BASE_MAIN = "6d2feba2bc49fda2d8d273248b55087853615d5d"
+CURRENT_SYNC = "GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT"
 HIGODOT_V314_TREE = "69010571e11123dfc4e09483f80cb9e6ca93511a"
-HIGODOT_V314_COMMIT = "96cc8b8c3d25ce487e24801d01d5214fea150349"
-HIGODOT_V314_SYNC = "GR-SYNC-20260811-19-HIGODOT-V314-TRACKED-EXACT-RECONCILIATION"
-LIVE_V314_PENDING = "LIVE_V3_1_4_HANDSHAKE_NOT_VERIFIED"
+HIGODOT_LIVE = "LIVE_V3_1_4_EXACT_PROJECT_SESSION_READY_OBSERVED"
+EXPECTED_FIELD_LIMIT = "NOT_SURFACED_DO_NOT_CLAIM"
 HERA_PASS = "HERA_V1_0_0_EXACT_PAIR_LIVE_CANARY_PASS"
 SHARED_CORE_PASS = "WINDOWS_ANDROID_SHARED_CORE_STRUCTURAL_PASS"
 THREE_SCREEN_PENDING = "THREE_SCREEN_RUNTIME_AWAITING_TASKS_2_9"
 RECEIPT_LIMIT = "HIGODOT_AUTHORING_RECEIPT_UNVERIFIED_FOR_DIRECT_LOCAL_TOOL_STATE_COMMIT"
 TASK2_MERGED = "TASK2_MERGED_MAIN_VERIFIED"
-TASK3_READY = "TASK3_READY_AFTER_POST_MERGE_CANON"
-TASK2_RECEIPT_PASS = "TASK2_HIGODOT_RECEIPT_READBACK_PASS"
 TASK7_MERGED = "TASK7_MERGED_MAIN_VERIFIED"
-TASK8_NEXT = "TASK8_SPELL_USE_SCREEN"
+TASK8_STATUS = "TASK8_LOCAL_REFINEMENT_GREEN_UNMERGED_MERGE_GATES_PENDING"
+TASK8_GATE = "TASK8_RECEIPT_HERA_REVIEW_PR"
 
 
 class GodotAuthoringGutAuthorityContractTests(unittest.TestCase):
-    def test_authority_design_plan_bindings_and_adoption_spec_exist(self):
+    def test_authority_design_plan_bindings_and_evidence_exist(self):
         for path in (
-            LEGACY_SPEC, ADOPTION_SPEC, BINDING_V43, BINDING_V44, BINDING_V45, PLAN, STATE,
-            UNRESOLVED, HIGODOT_V312_EVIDENCE, HIGODOT_V313_EVIDENCE, HIGODOT_V314_EVIDENCE,
+            LEGACY_SPEC,
+            ADOPTION_SPEC,
+            BINDING_V43,
+            BINDING_V44,
+            BINDING_V45,
+            PLAN,
+            SYNC19_STATE,
+            CURRENT_STATE,
+            CURRENT_CANON,
+            UNRESOLVED,
+            HIGODOT_V312_EVIDENCE,
+            HIGODOT_V313_EVIDENCE,
+            HIGODOT_V314_EVIDENCE,
             HERA_EVIDENCE,
         ):
             self.assertTrue(path.is_file(), str(path))
 
-    def test_v4_5_state_records_current_tools_and_preserves_v4_4_boundaries(self):
-        data = json.loads(STATE.read_text(encoding="utf-8"))
-        self.assertEqual("4.5", data["contract"]["version"])
-        self.assertEqual("ACTIVE_USER_APPROVED_BINDING", data["contract"]["status"])
-        self.assertEqual(CURRENT_CONTRACT, data["contract"]["binding_decision_id"])
-        self.assertEqual(HISTORICAL_V44_CONTRACT, data["contract"]["historical_binding_decision_id"])
-        self.assertEqual(CURRENT_BASE_MAIN, data["base_policy_observation"]["current_main"])
-        self.assertEqual(CURRENT_BASE_MAIN, data["base_policy_observation"]["latest_main_observed"])
-        self.assertEqual("7ce3fb64fa6303c5da6c7fc27c979f7233b761ac", data["base_policy_observation"]["source_snapshot_v4_5_r2"])
-        self.assertEqual("HISTORICAL_OBSERVATION_ONLY", data["base_policy_observation"]["source_snapshot_role"])
-        self.assertEqual(GUT_MERGED_MAIN, data["source_main"])
-        self.assertEqual("GUT_FORMALLY_ADOPTED_MERGED_MAIN_VERIFIED", data["status"])
-        self.assertEqual(
-            "TRACKED_HIGODOT_V3_1_4_EXACT_TREE_RECONCILED_LIVE_HANDSHAKE_PENDING",
-            data["current_tool_sync_status"],
-        )
-        self.assertEqual("GPT_ROLE_SEPARATED_PLUS_USER_DECISION_AUTHORITY", data["review"]["model"])
+    def test_sync20_machine_state_records_current_tool_authority(self):
+        state = json.loads(CURRENT_STATE.read_text(encoding="utf-8"))
+        self.assertEqual(CURRENT_SYNC, state["sync_id"])
+        self.assertEqual("GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01", state["decision_id"])
+        self.assertEqual(CURRENT_BASE_MAIN, state["base"]["current_main_observed"])
+        self.assertEqual("9.4.3", state["base"]["project_pin"])
+        self.assertEqual("PROJECT_DEDICATED_LOCAL_EXECUTION_ENVIRONMENT_FIRST", state["local_execution"]["policy"])
+        self.assertEqual("ASSUME_PREVIOUS_POWERSHELL_CLOSED", state["local_execution"]["fresh_shell"])
+        self.assertEqual("CREATE_OR_REPAIR_DEDICATED_LOCAL_ENVIRONMENT_FIRST", state["local_execution"]["missing_environment"])
 
-        higodot = data["higodot"]
-        self.assertEqual("SOLE_AUTHORING_AUTHORITY", higodot["authority"])
-        self.assertEqual("v3.1.4", higodot["release_tag"])
-        self.assertEqual("3.1.4", higodot["bundled_version"])
-        self.assertEqual(HIGODOT_V314_COMMIT, higodot["pinned_source_commit"])
-        self.assertEqual(HIGODOT_V314_TREE, higodot["official_plugin_subtree_sha"])
-        self.assertEqual(HIGODOT_V314_TREE, higodot["project_vendor_tree_sha"])
-        self.assertEqual("PASS_EXACT_TREE_IDENTITY", higodot["vendor_integrity"])
-        self.assertFalse(higodot["tracked_version_matches_live"])
-        self.assertEqual(LIVE_V314_PENDING, higodot["live_version_readback"])
-        self.assertEqual(RECEIPT_LIMIT, higodot["direct_local_upgrade_receipt_status"])
-        self.assertEqual(HIGODOT_V312_TREE, higodot["historical_v3_1_2"]["project_vendor_tree_sha"])
-        historical_v313 = higodot["historical_v3_1_3"]
-        self.assertEqual("v3.1.3", historical_v313["release_tag"])
-        self.assertEqual(HIGODOT_V313_COMMIT, historical_v313["pinned_source_commit"])
-        self.assertEqual(HIGODOT_V313_TREE, historical_v313["project_vendor_tree_sha"])
-        self.assertEqual("IMPLEMENTED_ZERO_PROTECTED_DIFF_GATE", higodot["authoring_receipt_gate"])
+        higodot = state["higodot"]
+        self.assertEqual("v3.1.4", higodot["release"])
+        self.assertEqual("SOLE_PERSISTENT_GODOT_AUTHORING_AUTHORITY", higodot["authority"])
+        self.assertEqual(HIGODOT_V314_TREE, higodot["tracked_plugin_subtree"])
+        self.assertEqual("PASS_EXACT_TREE_IDENTITY", higodot["tracked_vendor_integrity"])
+        self.assertEqual(HIGODOT_LIVE, higodot["live_status"])
+        self.assertEqual("3.1.4", higodot["server_version"])
+        self.assertEqual("3.1.4", higodot["plugin_version"])
+        self.assertEqual("READY", higodot["readiness"])
+        self.assertEqual(EXPECTED_FIELD_LIMIT, higodot["expected_version_field"])
+        self.assertEqual(RECEIPT_LIMIT, higodot["direct_local_upgrade_receipt"])
 
-        gut = data["gut"]
-        self.assertEqual("FORMAL_TEST_AUTHORITY", gut["target_authority"])
-        self.assertEqual("9.7.1", gut["pinned_version"])
-        self.assertEqual("FORMALLY_ADOPTED_ACTIVE", gut["current_consumption"])
-        self.assertEqual("MISMATCH_OFFICIAL_V9_7_1", gut["vendor_integrity"])
-        self.assertEqual("ENABLED_AT_GITHUB_MAIN_READBACK", gut["tracked_editor_plugin_enablement"])
-        self.assertTrue(gut["project_plugin_enabled"])
-        self.assertTrue(gut["must_not_mutate_product_files"])
+        self.assertEqual("v9.7.1", state["gut"]["release"])
+        self.assertEqual("DETERMINISTIC_GDSCRIPT_TEST_AUTHORITY", state["gut"]["authority"])
+        self.assertEqual("v1.0.0", state["hera"]["release"])
+        self.assertEqual("LIVE_QA_AND_OBSERVABILITY_ONLY", state["hera"]["authority"])
+        self.assertEqual("FORBIDDEN", state["hera"]["persistent_source_mutation"])
+        self.assertEqual("NONE", state["hera"]["required_source_delta"])
+        self.assertEqual(TASK8_STATUS, state["task8"]["status"])
+        self.assertEqual(TASK8_GATE, state["task8"]["next_gate"])
+        self.assertFalse(state["claims"]["expected_version_field_verified"])
+        self.assertFalse(state["claims"]["direct_local_upgrade_receipt_verified"])
+        self.assertFalse(state["claims"]["task8_merged_main_verified"])
+        self.assertFalse(state["claims"]["task8_hera_acceptance_pass"])
 
-        hera = data["hera"]
-        self.assertEqual(HERA_PASS, hera["status"])
-        self.assertTrue(hera["acceptance_qa_authorized"])
-        self.assertFalse(hera["persistent_source_mutation_authorized"])
-        self.assertEqual("ENABLED_AT_GITHUB_MAIN_READBACK", hera["tracked_editor_plugin_enablement"])
-        self.assertEqual("HeraGameInspector", hera["autoload"])
-        self.assertEqual("GODOT_AI_GUT_HERA_ENABLED_AT_GITHUB_MAIN_READBACK", data["tracked_project_godot_editor_plugins"])
+    def test_sync19_machine_snapshot_and_vendor_evidence_remain_historical(self):
+        old = json.loads(SYNC19_STATE.read_text(encoding="utf-8"))
+        self.assertEqual("4.5", old["contract"]["version"])
+        self.assertEqual(CURRENT_CONTRACT, old["contract"]["binding_decision_id"])
+        self.assertEqual(HISTORICAL_V44_CONTRACT, old["contract"]["historical_binding_decision_id"])
+        self.assertIn("LIVE_V3_1_4_HANDSHAKE_NOT_VERIFIED", json.dumps(old))
+        evidence = json.loads(HIGODOT_V314_EVIDENCE.read_text(encoding="utf-8"))
+        self.assertEqual("PASS_EXACT_TREE_IDENTITY", evidence["tracked_tree_identity"])
+        self.assertEqual(HIGODOT_V314_TREE, evidence["project_tracked_plugin_subtree"])
 
-        self.assertEqual(HIGODOT_V314_SYNC, data["sheet_sync"]["current_tool_sync_id"])
-        self.assertEqual("TRACKED_V3_1_4", data["sheet_sync"]["higodot_integrity_sync_scope"])
-        self.assertEqual("PASS_EXACT_TREE_IDENTITY", data["validation"]["higodot_vendor_integrity"])
-        self.assertEqual("TRACKED_V3_1_4", data["validation"]["higodot_vendor_integrity_scope"])
-        self.assertEqual(LIVE_V314_PENDING, data["validation"]["higodot_live_v3_1_4"])
-        self.assertEqual(SHARED_CORE_PASS, data["platform_validation"]["status"])
-        self.assertEqual(THREE_SCREEN_PENDING, data["image_review"]["three_screen_runtime"])
-
-        implementation = data["implementation_pr"]
-        self.assertEqual(TASK2_MERGED, implementation["status"])
-        self.assertEqual("MERGED_MAIN_VERIFIED", implementation["task2"])
-        self.assertEqual(TASK3_READY, implementation["task2_readiness"])
-        self.assertEqual(TASK2_RECEIPT_PASS, implementation["task2_authoring_receipt_status"])
-        self.assertTrue(implementation["task2_authorized"])
-        self.assertFalse(implementation["merge_authorized"])
-
-        self.assertEqual(TASK7_MERGED, data["entry_gate"]["status"].split("_TASK8_NEXT")[0])
-        self.assertTrue(data["claims"]["higodot_tracked_v3_1_4_vendor_sync"])
-        self.assertTrue(data["claims"]["higodot_tracked_v3_1_3_vendor_sync"])
-        self.assertTrue(data["claims"]["higodot_tracked_v3_1_3_vendor_sync_is_historical"])
-        self.assertFalse(data["claims"]["higodot_live_v3_1_4_handshake_verified"])
-        self.assertFalse(data["claims"]["higodot_tracked_v3_1_4_matches_live_verified"])
-        self.assertFalse(data["claims"]["tracked_project_godot_live_plugin_state_synced"])
-        self.assertTrue(data["claims"]["spell_workflow_task2_merged_main_verified"])
-        self.assertTrue(data["claims"]["task2_higodot_receipt_readback_pass"])
-        self.assertFalse(data["claims"]["higodot_direct_local_upgrade_receipt_verified"])
-        self.assertFalse(data["claims"]["windows_export_pass"])
-        self.assertFalse(data["claims"]["android_export_pass"])
-        self.assertFalse(data["claims"]["three_screen_runtime_pass"])
-        self.assertFalse(data["claims"]["visual_audio_complete"])
-
-    def test_current_authority_surfaces_are_live_v4_5_with_v4_4_history(self):
+    def test_current_authority_surfaces_are_v4_5_and_sync20(self):
         combined = "\n".join(path.read_text(encoding="utf-8") for path in CURRENT_SURFACES)
-        for path in CURRENT_SURFACES:
+        for path in CURRENT_SURFACES[:-2]:
             text = path.read_text(encoding="utf-8")
             self.assertIn(CURRENT_CONTRACT, text, str(path))
             self.assertIn("GUT_FORMALLY_ADOPTED", text, str(path))
             self.assertNotIn("BLOCKED_BY_GUT_ADOPTION_SPEC", text, str(path))
-        self.assertIn(HISTORICAL_V44_CONTRACT, combined)
-        self.assertIn("LIVE_GITHUB_DEFAULT_BRANCH_READBACK", combined)
-        self.assertIn(HERA_PASS, combined)
-        self.assertIn(SHARED_CORE_PASS, combined)
-        self.assertIn(THREE_SCREEN_PENDING, combined)
-        self.assertIn("spell_workflow_task2_authorized", combined)
-        self.assertIn(TASK2_MERGED, combined)
-        self.assertIn(TASK7_MERGED, combined)
-        self.assertIn(TASK8_NEXT, combined)
-
-    def test_legacy_spec_preserves_authority_boundary(self):
-        text = LEGACY_SPEC.read_text(encoding="utf-8")
         for token in (
-            "HIGODOT_SOLE_AUTHORING_AUTHORITY", "GUT_FORMAL_TEST_AUTHORITY",
-            "GUT_MUST_NOT_MUTATE_PRODUCT_FILES", "HIGODOT_MUST_NOT_EDIT_TEST_EXPECTATIONS",
-            "SOURCE: https://github.com/bitwes/Gut", "PINNED_VERSION: 9.7.1",
-            "LICENSE: MIT", "GODOT_COMPATIBILITY: 4.7.x", "ACTUAL_CONSUMPTION_PATH",
-            "CI_GATE", "REMOVAL_AND_ROLLBACK", "ENTRY_GATE_BLOCKS_WORK",
-            "BASE_RELEASE_PIN_REMAINS: 9.4.3",
+            HISTORICAL_V44_CONTRACT,
+            CURRENT_SYNC,
+            HIGODOT_LIVE,
+            EXPECTED_FIELD_LIMIT,
+            HERA_PASS,
+            SHARED_CORE_PASS,
+            THREE_SCREEN_PENDING,
+            TASK2_MERGED,
+            TASK7_MERGED,
+            TASK8_STATUS,
+            TASK8_GATE,
         ):
-            self.assertIn(token, text)
-
-    def test_v4_3_spec_remains_historical_design_evidence(self):
-        text = ADOPTION_SPEC.read_text(encoding="utf-8")
-        for token in (
-            "# GUT 9.7.1 정식 채택 설계 명세", "SPEC_ONLY_NO_INSTALLATION",
-            "aeb5d4f3f7f0a6c9b5e178876d6c99b791fda605", "5d6893836af4917ee62b1a395125a7530b1f239d",
-            "09d040309bbed0e07420ad72c4aa69cbd0e58190", "MISMATCH_OFFICIAL_V9_7_1",
-            ".gutconfig.json", "addons/gut/gut_cmdln.gd", "-gjunit_xml_file",
-            "production_mutation_guard", "HIGODOT_AUTHORING_MANIFEST", "removal_process",
-        ):
-            self.assertIn(token, text)
+            self.assertIn(token, combined)
 
     def test_bundled_plugin_metadata_matches_current_tracked_state(self):
         higodot_plugin = (ROOT / "addons/godot_ai/plugin.cfg").read_text(encoding="utf-8")
@@ -191,21 +143,22 @@ class GodotAuthoringGutAuthorityContractTests(unittest.TestCase):
         self.assertIn('res://addons/hera_agent_godot/plugin.cfg', project)
         self.assertIn('HeraGameInspector=', project)
 
-    def test_unresolved_preserves_real_blockers_and_post_implementation_acceptance(self):
+    def test_unresolved_lists_real_task8_merge_gates_and_preserves_delivery_limits(self):
         text = UNRESOLVED.read_text(encoding="utf-8")
         for blocker in (
-            "AUDIO_VAULT_PATH_UNVERIFIED", "AUDIO_RIGHTS_UNVERIFIED",
-            "VISUAL_AUDIO_COMPLETE_NOT_PROVEN", "LOCAL_SYNC_BLOCKED_NO_LOCAL_ACCESS",
-            "GODOT_RUN_BLOCKED_NO_LOCAL_ACCESS",
+            "AUDIO_VAULT_PATH_UNVERIFIED",
+            "AUDIO_RIGHTS_UNVERIFIED",
+            "VISUAL_AUDIO_COMPLETE_NOT_PROVEN",
+            "TASK8_PROTECTED_DELTA_HIGODOT_RECEIPT_PENDING",
+            "TASK8_HERA_ACCEPTANCE_PENDING",
+            "TASK8_PR_EXACT_HEAD_CI_REVIEW_MERGE_PENDING",
         ):
             self.assertIn(blocker, text)
         self.assertIn(SHARED_CORE_PASS, text)
         self.assertIn(THREE_SCREEN_PENDING, text)
         self.assertIn(TASK2_MERGED, text)
-        self.assertNotIn("WINDOWS_ANDROID_SHARED_CORE_NOT_VALIDATED", text)
-        self.assertNotIn("SPELL_WORKFLOW_THREE_SCREEN_RUNTIME_NOT_RUN", text)
-        self.assertNotIn("HERA_CLI_ADDON_PAIR_UNVERIFIED", text)
         self.assertIn(HERA_PASS, text)
+        self.assertNotIn("LIVE_V3_1_4_HANDSHAKE_NOT_VERIFIED\n", text)
 
 
 if __name__ == "__main__":

--- a/tests/test_higodot_v3_1_4_tracked_reconciliation.py
+++ b/tests/test_higodot_v3_1_4_tracked_reconciliation.py
@@ -7,7 +7,8 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-STATE = ROOT / "docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE.json"
+CURRENT_STATE = ROOT / "docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE_SYNC20.json"
+SYNC19_STATE = ROOT / "docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE.json"
 EVIDENCE = ROOT / "docs/validation/HIGODOT_V3_1_4_VENDOR_INTEGRITY.json"
 SYNC = ROOT / "docs/planning/sync/GR-SYNC-20260811-19-HIGODOT-V314-TRACKED-EXACT-RECONCILIATION.md"
 CURRENT_DOCS = [
@@ -23,7 +24,6 @@ TRACKED_SYNC_ID = "GR-SYNC-20260811-19-HIGODOT-V314-TRACKED-EXACT-RECONCILIATION
 CURRENT_SYNC_ID = "GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT"
 UPSTREAM_TAG_COMMIT = "96cc8b8c3d25ce487e24801d01d5214fea150349"
 V314_TREE = "69010571e11123dfc4e09483f80cb9e6ca93511a"
-V313_TREE = "94be4fb34d49243375c592e17a1021c8c6fcbcf2"
 DIRECT_TOOL_STATE_COMMIT = "257a0dba33f8288d24b1cd291bb407f4505224b4"
 CURRENT_BASE_MAIN = "6d2feba2bc49fda2d8d273248b55087853615d5d"
 RECEIPT_LIMIT = "HIGODOT_AUTHORING_RECEIPT_UNVERIFIED_FOR_DIRECT_LOCAL_TOOL_STATE_COMMIT"
@@ -46,8 +46,7 @@ class HiGodotV314TrackedReconciliationTests(unittest.TestCase):
         ).stdout.strip()
         self.assertEqual(V314_TREE, tree)
 
-    def test_sync19_evidence_remains_historical_and_does_not_rewrite_later_live_receipt(self) -> None:
-        self.assertTrue(EVIDENCE.is_file(), str(EVIDENCE))
+    def test_sync19_evidence_remains_historical(self) -> None:
         data = json.loads(EVIDENCE.read_text(encoding="utf-8"))
         self.assertEqual(DECISION, data["decision_id"])
         self.assertEqual(TRACKED_SYNC_ID, data["sync_id"])
@@ -60,33 +59,30 @@ class HiGodotV314TrackedReconciliationTests(unittest.TestCase):
         self.assertEqual(DIRECT_TOOL_STATE_COMMIT, data["observed_direct_tool_state_commit"])
         self.assertEqual(RECEIPT_LIMIT, data["authoring_receipt_status"])
         self.assertEqual(HISTORICAL_LIVE_GATE, data["live_alignment_status"])
-        self.assertFalse(data["claims"]["live_handshake_verified"])
-        self.assertFalse(data["claims"]["direct_tool_state_authoring_receipt_verified"])
+        old_state = json.loads(SYNC19_STATE.read_text(encoding="utf-8"))
+        self.assertIn(HISTORICAL_LIVE_GATE, json.dumps(old_state))
 
-    def test_current_authority_records_tracked_v314_plus_exact_project_live_ready(self) -> None:
-        data = json.loads(STATE.read_text(encoding="utf-8"))
+    def test_sync20_current_machine_state_records_exact_project_live_ready(self) -> None:
+        data = json.loads(CURRENT_STATE.read_text(encoding="utf-8"))
+        self.assertEqual(CURRENT_SYNC_ID, data["sync_id"])
         self.assertEqual(DECISION, data["decision_id"])
-        self.assertEqual(CURRENT_SYNC_ID, data["local_execution_policy"]["sync_id"])
-        self.assertEqual("v3.1.4", data["higodot"]["release_tag"])
-        self.assertEqual("3.1.4", data["higodot"]["bundled_version"])
-        self.assertEqual(UPSTREAM_TAG_COMMIT, data["higodot"]["pinned_source_commit"])
-        self.assertEqual(V314_TREE, data["higodot"]["official_plugin_subtree_sha"])
-        self.assertEqual(V314_TREE, data["higodot"]["project_vendor_tree_sha"])
-        self.assertEqual("PASS_EXACT_TREE_IDENTITY", data["higodot"]["vendor_integrity"])
-        self.assertEqual(CURRENT_LIVE, data["higodot"]["live_version_readback"])
-        self.assertTrue(data["higodot"]["tracked_version_matches_live"])
-        self.assertEqual(SESSION_ID, data["higodot"]["live_mcp_session"])
-        self.assertEqual("READY", data["higodot"]["live_mcp_readiness"])
-        self.assertEqual(EXPECTED_FIELD_LIMIT, data["higodot"]["expected_version_field"])
-        self.assertEqual(DIRECT_TOOL_STATE_COMMIT, data["higodot"]["direct_local_upgrade_commit"])
-        self.assertEqual(RECEIPT_LIMIT, data["higodot"]["direct_local_upgrade_receipt_status"])
-        historical = data["higodot"]["historical_v3_1_3"]
-        self.assertEqual("v3.1.3", historical["release_tag"])
-        self.assertEqual(V313_TREE, historical["project_vendor_tree_sha"])
-        base = data["base_policy_observation"]
-        self.assertEqual(CURRENT_BASE_MAIN, base["latest_main_observed"])
+        self.assertEqual(CURRENT_BASE_MAIN, data["base"]["current_main_observed"])
+        self.assertEqual("9.4.3", data["base"]["project_pin"])
+        higodot = data["higodot"]
+        self.assertEqual("v3.1.4", higodot["release"])
+        self.assertEqual(V314_TREE, higodot["tracked_plugin_subtree"])
+        self.assertEqual("PASS_EXACT_TREE_IDENTITY", higodot["tracked_vendor_integrity"])
+        self.assertEqual(CURRENT_LIVE, higodot["live_status"])
+        self.assertEqual(SESSION_ID, higodot["session_id"])
+        self.assertEqual("3.1.4", higodot["server_version"])
+        self.assertEqual("3.1.4", higodot["plugin_version"])
+        self.assertEqual("READY", higodot["readiness"])
+        self.assertEqual(EXPECTED_FIELD_LIMIT, higodot["expected_version_field"])
+        self.assertEqual(RECEIPT_LIMIT, higodot["direct_local_upgrade_receipt"])
+        self.assertFalse(data["claims"]["expected_version_field_verified"])
+        self.assertFalse(data["claims"]["direct_local_upgrade_receipt_verified"])
 
-    def test_current_human_canon_records_live_ready_without_inventing_expected_field(self) -> None:
+    def test_current_human_canon_matches_sync20_live_evidence_boundary(self) -> None:
         self.assertTrue(SYNC.is_file(), str(SYNC))
         combined = "\n".join(path.read_text(encoding="utf-8") for path in CURRENT_DOCS)
         for token in (

--- a/tests/test_higodot_v3_1_4_tracked_reconciliation.py
+++ b/tests/test_higodot_v3_1_4_tracked_reconciliation.py
@@ -19,14 +19,18 @@ CURRENT_DOCS = [
 ]
 
 DECISION = "GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01"
-SYNC_ID = "GR-SYNC-20260811-19-HIGODOT-V314-TRACKED-EXACT-RECONCILIATION"
+TRACKED_SYNC_ID = "GR-SYNC-20260811-19-HIGODOT-V314-TRACKED-EXACT-RECONCILIATION"
+CURRENT_SYNC_ID = "GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT"
 UPSTREAM_TAG_COMMIT = "96cc8b8c3d25ce487e24801d01d5214fea150349"
 V314_TREE = "69010571e11123dfc4e09483f80cb9e6ca93511a"
 V313_TREE = "94be4fb34d49243375c592e17a1021c8c6fcbcf2"
 DIRECT_TOOL_STATE_COMMIT = "257a0dba33f8288d24b1cd291bb407f4505224b4"
-CURRENT_BASE_MAIN = "7a49390bd840f5f5dc80fe661b44ad45e9ebeb7f"
+CURRENT_BASE_MAIN = "6d2feba2bc49fda2d8d273248b55087853615d5d"
 RECEIPT_LIMIT = "HIGODOT_AUTHORING_RECEIPT_UNVERIFIED_FOR_DIRECT_LOCAL_TOOL_STATE_COMMIT"
-LIVE_GATE = "LIVE_V3_1_4_HANDSHAKE_NOT_VERIFIED"
+HISTORICAL_LIVE_GATE = "LIVE_V3_1_4_HANDSHAKE_NOT_VERIFIED"
+CURRENT_LIVE = "LIVE_V3_1_4_EXACT_PROJECT_SESSION_READY_OBSERVED"
+EXPECTED_FIELD_LIMIT = "NOT_SURFACED_DO_NOT_CLAIM"
+SESSION_ID = "task8-spell-use-screen-v2@3cfa"
 
 
 class HiGodotV314TrackedReconciliationTests(unittest.TestCase):
@@ -42,11 +46,11 @@ class HiGodotV314TrackedReconciliationTests(unittest.TestCase):
         ).stdout.strip()
         self.assertEqual(V314_TREE, tree)
 
-    def test_v314_evidence_records_tree_identity_without_live_handshake_promotion(self) -> None:
+    def test_sync19_evidence_remains_historical_and_does_not_rewrite_later_live_receipt(self) -> None:
         self.assertTrue(EVIDENCE.is_file(), str(EVIDENCE))
         data = json.loads(EVIDENCE.read_text(encoding="utf-8"))
         self.assertEqual(DECISION, data["decision_id"])
-        self.assertEqual(SYNC_ID, data["sync_id"])
+        self.assertEqual(TRACKED_SYNC_ID, data["sync_id"])
         self.assertEqual("v3.1.4", data["release"])
         self.assertEqual(UPSTREAM_TAG_COMMIT, data["official_tag_commit"])
         self.assertEqual(V314_TREE, data["official_plugin_subtree"])
@@ -55,22 +59,25 @@ class HiGodotV314TrackedReconciliationTests(unittest.TestCase):
         self.assertTrue(data["tracked_vendor_synced"])
         self.assertEqual(DIRECT_TOOL_STATE_COMMIT, data["observed_direct_tool_state_commit"])
         self.assertEqual(RECEIPT_LIMIT, data["authoring_receipt_status"])
-        self.assertEqual(LIVE_GATE, data["live_alignment_status"])
+        self.assertEqual(HISTORICAL_LIVE_GATE, data["live_alignment_status"])
         self.assertFalse(data["claims"]["live_handshake_verified"])
         self.assertFalse(data["claims"]["direct_tool_state_authoring_receipt_verified"])
 
-    def test_current_authority_promotes_tracked_v314_and_preserves_v313_history(self) -> None:
+    def test_current_authority_records_tracked_v314_plus_exact_project_live_ready(self) -> None:
         data = json.loads(STATE.read_text(encoding="utf-8"))
         self.assertEqual(DECISION, data["decision_id"])
-        self.assertEqual("TRACKED_HIGODOT_V3_1_4_EXACT_TREE_RECONCILED_LIVE_HANDSHAKE_PENDING", data["current_tool_sync_status"])
+        self.assertEqual(CURRENT_SYNC_ID, data["local_execution_policy"]["sync_id"])
         self.assertEqual("v3.1.4", data["higodot"]["release_tag"])
         self.assertEqual("3.1.4", data["higodot"]["bundled_version"])
         self.assertEqual(UPSTREAM_TAG_COMMIT, data["higodot"]["pinned_source_commit"])
         self.assertEqual(V314_TREE, data["higodot"]["official_plugin_subtree_sha"])
         self.assertEqual(V314_TREE, data["higodot"]["project_vendor_tree_sha"])
         self.assertEqual("PASS_EXACT_TREE_IDENTITY", data["higodot"]["vendor_integrity"])
-        self.assertEqual(LIVE_GATE, data["higodot"]["live_version_readback"])
-        self.assertFalse(data["higodot"]["tracked_version_matches_live"])
+        self.assertEqual(CURRENT_LIVE, data["higodot"]["live_version_readback"])
+        self.assertTrue(data["higodot"]["tracked_version_matches_live"])
+        self.assertEqual(SESSION_ID, data["higodot"]["live_mcp_session"])
+        self.assertEqual("READY", data["higodot"]["live_mcp_readiness"])
+        self.assertEqual(EXPECTED_FIELD_LIMIT, data["higodot"]["expected_version_field"])
         self.assertEqual(DIRECT_TOOL_STATE_COMMIT, data["higodot"]["direct_local_upgrade_commit"])
         self.assertEqual(RECEIPT_LIMIT, data["higodot"]["direct_local_upgrade_receipt_status"])
         historical = data["higodot"]["historical_v3_1_3"]
@@ -79,12 +86,21 @@ class HiGodotV314TrackedReconciliationTests(unittest.TestCase):
         base = data["base_policy_observation"]
         self.assertEqual(CURRENT_BASE_MAIN, base["latest_main_observed"])
 
-    def test_current_human_canon_records_v314_tracked_pass_but_live_gate_open(self) -> None:
+    def test_current_human_canon_records_live_ready_without_inventing_expected_field(self) -> None:
         self.assertTrue(SYNC.is_file(), str(SYNC))
         combined = "\n".join(path.read_text(encoding="utf-8") for path in CURRENT_DOCS)
-        for token in (DECISION, SYNC_ID, "v3.1.4", V314_TREE, LIVE_GATE, RECEIPT_LIMIT):
+        for token in (
+            DECISION,
+            TRACKED_SYNC_ID,
+            CURRENT_SYNC_ID,
+            "v3.1.4",
+            V314_TREE,
+            CURRENT_LIVE,
+            EXPECTED_FIELD_LIMIT,
+            RECEIPT_LIMIT,
+        ):
             self.assertIn(token, combined)
-        self.assertIn("TASK8_SPELL_USE_SCREEN", combined)
+        self.assertIn("TASK8_LOCAL_REFINEMENT_GREEN_UNMERGED_MERGE_GATES_PENDING", combined)
         self.assertIn("TASK7_MERGED_MAIN_VERIFIED", combined)
         self.assertNotIn("tracked project vendor remains v3.1.3", combined)
 

--- a/tests/test_spell_workflow_current_state_sync.py
+++ b/tests/test_spell_workflow_current_state_sync.py
@@ -5,15 +5,16 @@ import unittest
 ROOT = Path(__file__).resolve().parents[1]
 SYNC_ID = "GR-SYNC-20260811-01-SPELL-WORKFLOW-TASK7-CURRENT-STATE"
 LATEST_PRODUCT_MAIN = "fcb5dbe1cbbb23ef195633b1f6680f45d46c5a3f"
-CURRENT_STATUS = "TASK7_MERGED_MAIN_VERIFIED"
-NEXT_TASK = "TASK8_SPELL_USE_SCREEN"
+PREDECESSOR_STATUS = "TASK7_MERGED_MAIN_VERIFIED"
+CURRENT_TASK_STATUS = "TASK8_LOCAL_REFINEMENT_GREEN_UNMERGED_MERGE_GATES_PENDING"
+NEXT_GATE = "TASK8_RECEIPT_HERA_REVIEW_PR"
 
 
 class SpellWorkflowCurrentStateSyncContract(unittest.TestCase):
     def _read(self, relative_path: str) -> str:
         return (ROOT / relative_path).read_text(encoding="utf-8")
 
-    def test_current_state_surfaces_share_task7_and_task8_markers(self) -> None:
+    def test_current_state_surfaces_share_task8_merge_gate_markers(self) -> None:
         for relative_path in (
             "START_HERE.md",
             "docs/ACTIVE_CONTEXT.md",
@@ -24,8 +25,9 @@ class SpellWorkflowCurrentStateSyncContract(unittest.TestCase):
                 text = self._read(relative_path)
                 self.assertIn(SYNC_ID, text)
                 self.assertIn(LATEST_PRODUCT_MAIN, text)
-                self.assertIn(CURRENT_STATUS, text)
-                self.assertIn(NEXT_TASK, text)
+                self.assertIn(PREDECESSOR_STATUS, text)
+                self.assertIn(CURRENT_TASK_STATUS, text)
+                self.assertIn(NEXT_GATE, text)
 
     def test_audit_evidence_remains_linked(self) -> None:
         audit = self._read(

--- a/tests/test_task2_user_approval_canon.py
+++ b/tests/test_task2_user_approval_canon.py
@@ -19,6 +19,8 @@ CURRENT_DOCS = [
     ROOT / "docs/planning/CURRENT_CONFIRMED_DECISIONS.md",
     ROOT / "docs/planning/CURRENT_UNRESOLVED_GATES.md",
 ]
+CURRENT_TASK_STATUS = "TASK8_LOCAL_REFINEMENT_GREEN_UNMERGED_MERGE_GATES_PENDING"
+NEXT_GATE = "TASK8_RECEIPT_HERA_REVIEW_PR"
 
 
 class Task2UserApprovalCanonTests(unittest.TestCase):
@@ -33,14 +35,15 @@ class Task2UserApprovalCanonTests(unittest.TestCase):
         self.assertEqual(DECISION_ID, receipt["decision_id"])
         self.assertEqual("PROTECTED_TASK2_DELTA_COMPLETE", receipt["receipt_reconciliation"]["status"])
 
-    def test_current_human_canon_has_superseding_task7_state(self) -> None:
+    def test_current_human_canon_preserves_task7_predecessor_and_advances_task8_gate(self) -> None:
         for path in CURRENT_DOCS:
             with self.subTest(path=str(path)):
                 text = path.read_text(encoding="utf-8")
                 self.assertIn(DECISION_ID, text)
                 self.assertIn(CURRENT_SYNC_ID, text)
                 self.assertIn("TASK7_MERGED_MAIN_VERIFIED", text)
-                self.assertIn("TASK8_SPELL_USE_SCREEN", text)
+                self.assertIn(CURRENT_TASK_STATUS, text)
+                self.assertIn(NEXT_GATE, text)
 
     def test_task2_history_remains_traceable_from_current_sync_receipt(self) -> None:
         text = (ROOT / "docs/planning/sync/GR-SYNC-20260811-01-SPELL-WORKFLOW-TASK7-CURRENT-STATE.md").read_text(encoding="utf-8")

--- a/tests/test_task3_continuous_entry_canon.py
+++ b/tests/test_task3_continuous_entry_canon.py
@@ -8,6 +8,8 @@ ROOT = Path(__file__).resolve().parents[1]
 HISTORICAL_SYNC = "GR-SYNC-20260809-08-SPELL-WORKFLOW-TASK3-CONTINUOUS-ENTRY"
 CURRENT_SYNC = "GR-SYNC-20260811-01-SPELL-WORKFLOW-TASK7-CURRENT-STATE"
 DECISION = "GM-SPELL-WORKFLOW-UI-V2-01"
+CURRENT_TASK_STATUS = "TASK8_LOCAL_REFINEMENT_GREEN_UNMERGED_MERGE_GATES_PENDING"
+CURRENT_NEXT_GATE = "TASK8_RECEIPT_HERA_REVIEW_PR"
 HANDOFF = ROOT / "docs/planning/handoffs/2026-08-09-task3-higodot-execution-packet.md"
 HISTORICAL_SYNC_DOC = ROOT / "docs/planning/sync/GR-SYNC-20260809-08-SPELL-WORKFLOW-TASK3-CONTINUOUS-ENTRY.md"
 CURRENT_SYNC_DOC = ROOT / "docs/planning/sync/GR-SYNC-20260811-01-SPELL-WORKFLOW-TASK7-CURRENT-STATE.md"
@@ -31,7 +33,7 @@ class Task3ContinuousEntryCanonTests(unittest.TestCase):
         self.assertIn(DECISION, sync)
         self.assertIn("product_mutation_in_this_sync: NONE", sync)
 
-    def test_current_human_state_supersedes_task3_as_next(self) -> None:
+    def test_current_human_state_supersedes_task3_with_current_task8_merge_subgate(self) -> None:
         for relative_path in (
             "START_HERE.md",
             "docs/ACTIVE_CONTEXT.md",
@@ -42,7 +44,8 @@ class Task3ContinuousEntryCanonTests(unittest.TestCase):
                 text = (ROOT / relative_path).read_text(encoding="utf-8")
                 self.assertIn(CURRENT_SYNC, text)
                 self.assertIn("TASK7_MERGED_MAIN_VERIFIED", text)
-                self.assertIn("TASK8_SPELL_USE_SCREEN", text)
+                self.assertIn(CURRENT_TASK_STATUS, text)
+                self.assertIn(CURRENT_NEXT_GATE, text)
 
     def test_current_sync_receipt_records_merged_lineage(self) -> None:
         text = CURRENT_SYNC_DOC.read_text(encoding="utf-8")

--- a/tests/test_v4_4_formal_adoption_unresolved_reconciliation.py
+++ b/tests/test_v4_4_formal_adoption_unresolved_reconciliation.py
@@ -11,67 +11,91 @@ HERA_PASS = "HERA_V1_0_0_EXACT_PAIR_LIVE_CANARY_PASS"
 SHARED_CORE_PASS = "WINDOWS_ANDROID_SHARED_CORE_STRUCTURAL_PASS"
 THREE_SCREEN_PENDING = "THREE_SCREEN_RUNTIME_AWAITING_TASKS_2_9"
 TASK2_MERGED = "TASK2_MERGED_MAIN_VERIFIED"
-TASK3_READY = "TASK3_READY_AFTER_POST_MERGE_CANON"
 TASK2_MAIN = "975b2ad278d07bf9bfa06a9f4c1fc20a9fb1bac0"
 TASK7_MERGED = "TASK7_MERGED_MAIN_VERIFIED"
-TASK8_NEXT = "TASK8_SPELL_USE_SCREEN"
+TASK8_STATUS = "TASK8_LOCAL_REFINEMENT_GREEN_UNMERGED_MERGE_GATES_PENDING"
+TASK8_GATE = "TASK8_RECEIPT_HERA_REVIEW_PR"
+LIVE_READY = "LIVE_V3_1_4_EXACT_PROJECT_SESSION_READY_OBSERVED"
 
 
 class V44FormalAdoptionUnresolvedReconciliationTests(unittest.TestCase):
     def test_current_unresolved_is_v4_5_and_preserves_v4_4_formal_adoption_history(self) -> None:
         text = UNRESOLVED.read_text(encoding="utf-8")
-        self.assertIn('contract_version: "4.5"', text)
-        self.assertIn("GM-CONTRACT-V4-5-BINDING-01", text)
-        self.assertIn("GM-CONTRACT-V4-4-BINDING-01", text)
-        self.assertIn("HISTORICAL_SUPERSEDED_CURRENT_BINDING", text)
-        self.assertIn(MERGED_MAIN, text)
-        self.assertIn("formal_adoption_scope: MERGED_MAIN_VERIFIED", text)
-        self.assertIn("GUT_FORMALLY_ADOPTED", text)
-        self.assertIn("GUT_PUBLIC_STANDARD_GITHUB_ACTIONS_PASS", text)
-        self.assertIn("ROLE_SEPARATED_REVIEW_P0_P1_ZERO", text)
-        self.assertIn("PR85_MERGED_MAIN_VERIFIED", text)
-        self.assertIn(TASK7_MERGED, text)
-        self.assertIn(TASK8_NEXT, text)
+        for token in (
+            'contract_version: "4.5"',
+            "GM-CONTRACT-V4-5-BINDING-01",
+            "GM-CONTRACT-V4-4-BINDING-01",
+            "HISTORICAL_SUPERSEDED_CURRENT_BINDING",
+            MERGED_MAIN,
+            "formal_adoption_scope: MERGED_MAIN_VERIFIED",
+            "GUT_FORMALLY_ADOPTED",
+            "GUT_PUBLIC_STANDARD_GITHUB_ACTIONS_PASS",
+            "ROLE_SEPARATED_REVIEW_P0_P1_ZERO",
+            "PR85_MERGED_MAIN_VERIFIED",
+            TASK7_MERGED,
+            TASK8_STATUS,
+            TASK8_GATE,
+            LIVE_READY,
+        ):
+            self.assertIn(token, text)
+
         for stale in (
-            "GUT_ADOPTION_SPEC_NOT_MERGED", "GUT_GODOT_4_7_1_RUNTIME_COMPATIBILITY_NOT_RUN",
-            "GUT_ACTUAL_CONSUMPTION_NOT_ENABLED", "GUT_CI_NOT_ENABLED",
+            "GUT_ADOPTION_SPEC_NOT_MERGED",
+            "GUT_GODOT_4_7_1_RUNTIME_COMPATIBILITY_NOT_RUN",
+            "GUT_ACTUAL_CONSUMPTION_NOT_ENABLED",
+            "GUT_CI_NOT_ENABLED",
             "HIGODOT_AUTHORING_RECEIPT_GATE_NOT_IMPLEMENTED",
             "GUT_PRODUCT_MUTATION_HASH_GATE_NOT_IMPLEMENTED",
-            "LEGACY_TO_GUT_COVERAGE_PARITY_NOT_PROVEN", "GPT_ROLE_SEPARATED_REVIEW_NOT_COMPLETE",
+            "LEGACY_TO_GUT_COVERAGE_PARITY_NOT_PROVEN",
+            "GPT_ROLE_SEPARATED_REVIEW_NOT_COMPLETE",
             "BLOCKED_BY_GUT_ADOPTION_SPEC",
+            "LOCAL_SYNC_BLOCKED_NO_LOCAL_ACCESS",
+            "GODOT_RUN_BLOCKED_NO_LOCAL_ACCESS",
         ):
             self.assertNotIn(stale, text)
 
-    def test_remaining_broader_project_blockers_and_post_implementation_acceptance_are_explicit(self) -> None:
+    def test_current_blockers_match_task8_receipt_hera_and_merge_gate(self) -> None:
         text = UNRESOLVED.read_text(encoding="utf-8")
         for blocker in (
-            "AUDIO_VAULT_PATH_UNVERIFIED", "AUDIO_RIGHTS_UNVERIFIED",
-            "VISUAL_AUDIO_COMPLETE_NOT_PROVEN", "LOCAL_SYNC_BLOCKED_NO_LOCAL_ACCESS",
-            "GODOT_RUN_BLOCKED_NO_LOCAL_ACCESS",
+            "AUDIO_VAULT_PATH_UNVERIFIED",
+            "AUDIO_RIGHTS_UNVERIFIED",
+            "VISUAL_AUDIO_COMPLETE_NOT_PROVEN",
+            "TASK8_PROTECTED_DELTA_HIGODOT_RECEIPT_PENDING",
+            "TASK8_HERA_ACCEPTANCE_PENDING",
+            "TASK8_PR_EXACT_HEAD_CI_REVIEW_MERGE_PENDING",
         ):
             self.assertIn(blocker, text)
-        self.assertIn(SHARED_CORE_PASS, text)
-        self.assertIn(THREE_SCREEN_PENDING, text)
-        self.assertIn("SPELL_WORKFLOW_THREE_SCREEN_RUNTIME_POST_IMPLEMENTATION_ACCEPTANCE", text)
-        self.assertNotIn("WINDOWS_ANDROID_SHARED_CORE_NOT_VALIDATED", text)
-        self.assertNotIn("SPELL_WORKFLOW_THREE_SCREEN_RUNTIME_NOT_RUN", text)
-        self.assertNotIn("HIGODOT_VENDOR_TREE_MISMATCH_OFFICIAL_V3_1_2", text)
-        self.assertIn("HIGODOT_VENDOR_INTEGRITY_PASS_EXACT_TREE_IDENTITY", text)
-        self.assertNotIn("CI_MUTABLE_ACTION_TAGS_OUTSIDE_PR85_SCOPE", text)
-        self.assertIn("REPO_WIDE_ACTIONS_FULL_SHA_PINNING_PASS", text)
-        self.assertNotIn("HERA_CLI_ADDON_PAIR_UNVERIFIED", text)
-        self.assertIn(HERA_PASS, text)
-        self.assertIn("spell_workflow_task2_authorized: true", text)
-        self.assertIn(f"spell_workflow_task2_readiness: {TASK3_READY}", text)
-        self.assertIn("spell_workflow_task2_execution_status: MERGED_MAIN_VERIFIED", text)
-        self.assertIn(TASK2_MERGED, text)
-        self.assertIn(TASK2_MAIN, text)
-        self.assertIn("TASK2_HIGODOT_RECEIPT_READBACK_PASS", text)
-        self.assertIn(TASK7_MERGED, text)
-        self.assertIn(TASK8_NEXT, text)
-        self.assertNotIn("spell_workflow_task2_readiness: READY_FOR_HIGODOT_AUTHORING", text)
-        self.assertNotIn("spell_workflow_task2_execution_status: AUTHORIZED_AWAITING_HIGODOT_CHANNEL", text)
-        self.assertNotIn("spell_workflow_task2_execution_status: AUTHORIZED_HIGODOT_CHANNEL_CONFIRMED", text)
+
+        for token in (
+            SHARED_CORE_PASS,
+            THREE_SCREEN_PENDING,
+            "SPELL_WORKFLOW_THREE_SCREEN_RUNTIME_POST_IMPLEMENTATION_ACCEPTANCE",
+            "HIGODOT_VENDOR_INTEGRITY_PASS_EXACT_TREE_IDENTITY",
+            "REPO_WIDE_ACTIONS_FULL_SHA_PINNING_PASS",
+            HERA_PASS,
+            "spell_workflow_task2_authorized: true",
+            TASK2_MERGED,
+            TASK2_MAIN,
+            "TASK2_HIGODOT_RECEIPT_READBACK_PASS",
+            TASK7_MERGED,
+            TASK8_STATUS,
+            TASK8_GATE,
+            "HERA_LIVE_QA_AND_OBSERVABILITY_ONLY",
+            "hera_source_delta_required: NONE",
+        ):
+            self.assertIn(token, text)
+
+        for stale in (
+            "WINDOWS_ANDROID_SHARED_CORE_NOT_VALIDATED",
+            "SPELL_WORKFLOW_THREE_SCREEN_RUNTIME_NOT_RUN",
+            "HIGODOT_VENDOR_TREE_MISMATCH_OFFICIAL_V3_1_2",
+            "CI_MUTABLE_ACTION_TAGS_OUTSIDE_PR85_SCOPE",
+            "HERA_CLI_ADDON_PAIR_UNVERIFIED",
+            "spell_workflow_task2_readiness: READY_FOR_HIGODOT_AUTHORING",
+            "spell_workflow_task2_execution_status: AUTHORIZED_AWAITING_HIGODOT_CHANNEL",
+            "spell_workflow_task2_execution_status: AUTHORIZED_HIGODOT_CHANNEL_CONFIRMED",
+        ):
+            self.assertNotIn(stale, text)
 
 
 if __name__ == "__main__":

--- a/tests/test_v4_4_post_merge_canon_sync.py
+++ b/tests/test_v4_4_post_merge_canon_sync.py
@@ -15,11 +15,23 @@ TASK3_READY = "TASK3_READY_AFTER_POST_MERGE_CANON"
 TASK2_MAIN = "975b2ad278d07bf9bfa06a9f4c1fc20a9fb1bac0"
 TASK2_RECEIPT_PASS = "TASK2_HIGODOT_RECEIPT_READBACK_PASS"
 TASK7_MERGED = "TASK7_MERGED_MAIN_VERIFIED"
-TASK8_NEXT = "TASK8_SPELL_USE_SCREEN"
+HISTORICAL_TASK8_PRODUCT = "TASK8_SPELL_USE_SCREEN"
+CURRENT_TASK8_STATUS = "TASK8_LOCAL_REFINEMENT_GREEN_UNMERGED_MERGE_GATES_PENDING"
+CURRENT_TASK8_GATE = "TASK8_RECEIPT_HERA_REVIEW_PR"
+CURRENT_SYNC = "GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT"
+LIVE_READY = "LIVE_V3_1_4_EXACT_PROJECT_SESSION_READY_OBSERVED"
 STATE = ROOT / "docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE.json"
-CURRENT_DOCS = [ROOT / "START_HERE.md", ROOT / "docs/ACTIVE_CONTEXT.md", ROOT / "docs/DEVELOPMENT_GATES.md", ROOT / "docs/planning/CURRENT_CONFIRMED_DECISIONS.md", ROOT / "docs/planning/CURRENT_UNRESOLVED_GATES.md"]
+CURRENT_DOCS = [
+    ROOT / "START_HERE.md",
+    ROOT / "docs/ACTIVE_CONTEXT.md",
+    ROOT / "docs/DEVELOPMENT_GATES.md",
+    ROOT / "docs/planning/CURRENT_CONFIRMED_DECISIONS.md",
+    ROOT / "docs/planning/CURRENT_UNRESOLVED_GATES.md",
+]
 CANON = ROOT / "docs/planning/CANON_SYNC_STATE.json"
 GRILL = ROOT / "docs/planning/GRILL_ME_BATCH_MERGE_STATE.json"
+CURRENT_CANON = ROOT / "docs/planning/CANON_SYNC_STATE_SYNC20.json"
+CURRENT_AUTHORITY = ROOT / "docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE_SYNC20.json"
 
 
 class V44PostMergeCanonSyncTests(unittest.TestCase):
@@ -48,7 +60,7 @@ class V44PostMergeCanonSyncTests(unittest.TestCase):
         self.assertTrue(data["claims"]["spell_workflow_task2_authorized"])
         self.assertTrue(data["claims"]["spell_workflow_task2_merged_main_verified"])
 
-    def test_current_cold_start_docs_use_v45_and_keep_historical_merge_roles(self) -> None:
+    def test_current_cold_start_docs_use_v45_keep_history_and_show_task8_merge_subgate(self) -> None:
         for path in CURRENT_DOCS:
             text = path.read_text(encoding="utf-8")
             self.assertIn("GM-CONTRACT-V4-5-BINDING-01", text, str(path))
@@ -63,11 +75,12 @@ class V44PostMergeCanonSyncTests(unittest.TestCase):
             self.assertIn("spell_workflow_task2_authorized: true", text, str(path))
             self.assertIn(TASK2_MERGED, text, str(path))
             self.assertIn(TASK7_MERGED, text, str(path))
-            self.assertIn(TASK8_NEXT, text, str(path))
+            self.assertIn(CURRENT_TASK8_STATUS, text, str(path))
+            self.assertIn(CURRENT_TASK8_GATE, text, str(path))
             self.assertNotIn("spell_workflow_task2_authorized: false", text, str(path))
             self.assertNotIn("BLOCKED_BY_GUT_ADOPTION_SPEC", text, str(path))
 
-    def test_machine_current_state_surfaces_use_v45_live_main_authority_and_task7(self) -> None:
+    def test_historical_machine_snapshots_preserve_task8_product_checkpoint(self) -> None:
         canon = json.loads(CANON.read_text(encoding="utf-8"))
         grill = json.loads(GRILL.read_text(encoding="utf-8"))
         self.assertEqual("4.5", canon["active_contract"]["version"])
@@ -83,7 +96,7 @@ class V44PostMergeCanonSyncTests(unittest.TestCase):
         workflow = canon["spell_workflow_main"]
         self.assertTrue(workflow["spell_workflow_task2_authorized"])
         self.assertEqual(TASK7_MERGED, workflow["status"])
-        self.assertEqual(TASK8_NEXT, workflow["next_task"])
+        self.assertEqual(HISTORICAL_TASK8_PRODUCT, workflow["next_task"])
         self.assertEqual(TASK3_READY, workflow["task2_readiness"])
         self.assertEqual("MERGED_MAIN_VERIFIED", workflow["task2_execution_status"])
         self.assertEqual(TASK2_MAIN, workflow["main_merge_commit"])
@@ -92,29 +105,39 @@ class V44PostMergeCanonSyncTests(unittest.TestCase):
         self.assertEqual("4.5", grill["active_contract"]["version"])
         self.assertEqual("GM-CONTRACT-V4-5-BINDING-01", grill["active_contract"]["binding_decision_id"])
         self.assertEqual(0, grill["current_count"])
-        self.assertEqual("LIVE_GITHUB_DEFAULT_BRANCH_READBACK", grill["current_work"]["project_main_authority"])
-        self.assertEqual(GUT_FORMAL_ADOPTION_MAIN, grill["current_work"]["gut_formal_adoption_main"])
-        self.assertEqual(POST_MERGE_CANON_SYNC_MAIN, grill["current_work"]["post_merge_canon_sync_merge"])
-        self.assertEqual("GUT_FORMALLY_ADOPTED", grill["current_work"]["gut_formal_adoption"])
-        self.assertEqual("PASS_EXACT_TREE_IDENTITY", grill["current_work"]["higodot_vendor_integrity"])
-        self.assertEqual(HERA_PASS, grill["current_work"]["hera_status"])
-        self.assertEqual(SHARED_CORE_PASS, grill["current_work"]["windows_android_shared_core"])
-        self.assertTrue(grill["current_work"]["spell_workflow_task2_authorized"])
         self.assertEqual(TASK7_MERGED, grill["current_work"]["status"])
-        self.assertEqual("MERGED_MAIN_VERIFIED", grill["current_work"]["spell_workflow_task2"])
-        self.assertEqual(TASK2_MAIN, grill["current_work"]["spell_workflow_merged_main"])
-        self.assertEqual(TASK2_RECEIPT_PASS, grill["current_work"]["spell_workflow_task2_authoring_receipt_status"])
-        self.assertEqual(TASK8_NEXT, grill["current_work"]["spell_workflow_next_task"])
+        self.assertEqual(HISTORICAL_TASK8_PRODUCT, grill["current_work"]["spell_workflow_next_task"])
 
-    def test_remaining_broader_blockers_and_acceptance_are_preserved(self) -> None:
+    def test_sync20_machine_overlays_hold_current_task8_and_live_tool_state(self) -> None:
+        current_canon = json.loads(CURRENT_CANON.read_text(encoding="utf-8"))
+        current_authority = json.loads(CURRENT_AUTHORITY.read_text(encoding="utf-8"))
+        self.assertEqual(CURRENT_SYNC, current_canon["sync_id"])
+        self.assertEqual(CURRENT_SYNC, current_authority["sync_id"])
+        self.assertEqual(CURRENT_TASK8_STATUS, current_canon["spell_workflow"]["status"])
+        self.assertEqual(CURRENT_TASK8_GATE, current_canon["spell_workflow"]["next_gate"])
+        self.assertEqual(LIVE_READY, current_authority["higodot"]["live_status"])
+        self.assertEqual("LIVE_QA_AND_OBSERVABILITY_ONLY", current_authority["hera"]["authority"])
+        self.assertEqual("NONE", current_authority["hera"]["required_source_delta"])
+
+    def test_remaining_blockers_reflect_local_access_and_task8_merge_gates(self) -> None:
         text = (ROOT / "docs/planning/CURRENT_UNRESOLVED_GATES.md").read_text(encoding="utf-8")
-        for blocker in ("AUDIO_VAULT_PATH_UNVERIFIED", "VISUAL_AUDIO_COMPLETE_NOT_PROVEN", "LOCAL_SYNC_BLOCKED_NO_LOCAL_ACCESS", "GODOT_RUN_BLOCKED_NO_LOCAL_ACCESS"):
+        for blocker in (
+            "AUDIO_VAULT_PATH_UNVERIFIED",
+            "VISUAL_AUDIO_COMPLETE_NOT_PROVEN",
+            "TASK8_PROTECTED_DELTA_HIGODOT_RECEIPT_PENDING",
+            "TASK8_HERA_ACCEPTANCE_PENDING",
+            "TASK8_PR_EXACT_HEAD_CI_REVIEW_MERGE_PENDING",
+        ):
             self.assertIn(blocker, text)
         self.assertIn(SHARED_CORE_PASS, text)
         self.assertIn("THREE_SCREEN_RUNTIME_AWAITING_TASKS_2_9", text)
         self.assertIn(TASK2_MERGED, text)
         self.assertIn(TASK7_MERGED, text)
-        self.assertIn(TASK8_NEXT, text)
+        self.assertIn(CURRENT_TASK8_STATUS, text)
+        self.assertIn(CURRENT_TASK8_GATE, text)
+        self.assertIn(LIVE_READY, text)
+        self.assertNotIn("LOCAL_SYNC_BLOCKED_NO_LOCAL_ACCESS", text)
+        self.assertNotIn("GODOT_RUN_BLOCKED_NO_LOCAL_ACCESS", text)
         self.assertNotIn("WINDOWS_ANDROID_SHARED_CORE_NOT_VALIDATED", text)
         self.assertNotIn("SPELL_WORKFLOW_THREE_SCREEN_RUNTIME_NOT_RUN", text)
         self.assertNotIn("HIGODOT_VENDOR_TREE_MISMATCH_OFFICIAL_V3_1_2", text)

--- a/tests/test_v4_5_contract_binding.py
+++ b/tests/test_v4_5_contract_binding.py
@@ -18,13 +18,17 @@ CURRENT_DOCS = [
 CANON = ROOT / "docs/planning/CANON_SYNC_STATE.json"
 AUTHORITY = ROOT / "docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE.json"
 GRILL = ROOT / "docs/planning/GRILL_ME_BATCH_MERGE_STATE.json"
+CURRENT_CANON = ROOT / "docs/planning/CANON_SYNC_STATE_SYNC20.json"
+CURRENT_AUTHORITY = ROOT / "docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE_SYNC20.json"
 
 DECISION = "GM-CONTRACT-V4-5-BINDING-01"
 SYNC_ID = "GR-SYNC-20260811-02-CONTRACT-V4-5-R2-BINDING"
 BASE_CURRENT_OBSERVED = "315c66eea9614c284b9c11c4d522141065dfa4b0"
 BASE_SOURCE_SNAPSHOT = "7ce3fb64fa6303c5da6c7fc27c979f7233b761ac"
 TASK7 = "TASK7_MERGED_MAIN_VERIFIED"
-TASK8 = "TASK8_SPELL_USE_SCREEN"
+TASK8_PRODUCT = "TASK8_SPELL_USE_SCREEN"
+TASK8_STATUS = "TASK8_LOCAL_REFINEMENT_GREEN_UNMERGED_MERGE_GATES_PENDING"
+TASK8_GATE = "TASK8_RECEIPT_HERA_REVIEW_PR"
 HERA_PASS = "HERA_V1_0_0_EXACT_PAIR_LIVE_CANARY_PASS"
 SHARED_CORE_PASS = "WINDOWS_ANDROID_SHARED_CORE_STRUCTURAL_PASS"
 
@@ -56,7 +60,7 @@ class V45ContractBindingTests(unittest.TestCase):
             self.assertIn(token, text)
         self.assertIn("USER_EXPLICIT_EXECUTION_REQUEST_PRESENT", text)
         self.assertIn(TASK7, text)
-        self.assertIn(TASK8, text)
+        self.assertIn(TASK8_PRODUCT, text)
         self.assertIn(HERA_PASS, text)
         self.assertIn(SHARED_CORE_PASS, text)
 
@@ -67,14 +71,17 @@ class V45ContractBindingTests(unittest.TestCase):
             self.assertIn(DECISION, text, str(path))
             self.assertIn(SYNC_ID, text, str(path))
             self.assertIn(TASK7, text, str(path))
-            self.assertIn(TASK8, text, str(path))
+            self.assertIn(TASK8_STATUS, text, str(path))
+            self.assertIn(TASK8_GATE, text, str(path))
             self.assertIn("GM-CONTRACT-V4-4-BINDING-01", text, str(path))
             self.assertNotIn("v4_5_binding: USER_DECISION_REQUIRED", text, str(path))
 
-    def test_machine_current_state_promotes_v45_without_erasing_existing_authorities(self) -> None:
+    def test_machine_binding_history_and_sync20_current_overlay_coexist(self) -> None:
         canon = json.loads(CANON.read_text(encoding="utf-8"))
         authority = json.loads(AUTHORITY.read_text(encoding="utf-8"))
         grill = json.loads(GRILL.read_text(encoding="utf-8"))
+        current_canon = json.loads(CURRENT_CANON.read_text(encoding="utf-8"))
+        current_authority = json.loads(CURRENT_AUTHORITY.read_text(encoding="utf-8"))
 
         self.assertEqual("4.5", canon["active_contract"]["version"])
         self.assertEqual(DECISION, canon["active_contract"]["binding_decision_id"])
@@ -83,12 +90,14 @@ class V45ContractBindingTests(unittest.TestCase):
         self.assertEqual("4.5", grill["active_contract"]["version"])
         self.assertEqual(DECISION, grill["active_contract"]["binding_decision_id"])
 
-        self.assertEqual("LIVE_GITHUB_DEFAULT_BRANCH_READBACK", canon["project_main_authority"])
-        self.assertEqual(HERA_PASS, canon["hera"]["status"])
-        self.assertEqual(SHARED_CORE_PASS, canon["platform_validation"]["status"])
-        self.assertEqual("PASS_EXACT_TREE_IDENTITY", authority["higodot"]["vendor_integrity"])
-        self.assertEqual(HERA_PASS, authority["hera"]["status"])
-        self.assertTrue(authority["claims"]["gut_formally_adopted"])
+        self.assertEqual("4.5", current_canon["active_contract"]["version"])
+        self.assertEqual(DECISION, current_canon["active_contract"]["binding_decision_id"])
+        self.assertEqual("GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT", current_authority["sync_id"])
+        self.assertEqual("GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01", current_authority["decision_id"])
+        self.assertEqual(TASK8_STATUS, current_canon["spell_workflow"]["status"])
+        self.assertEqual(TASK8_GATE, current_canon["spell_workflow"]["next_gate"])
+        self.assertEqual("LIVE_V3_1_4_EXACT_PROJECT_SESSION_READY_OBSERVED", current_authority["higodot"]["live_status"])
+        self.assertEqual("LIVE_QA_AND_OBSERVABILITY_ONLY", current_authority["hera"]["authority"])
         self.assertEqual(TASK7, grill["current_work"]["status"])
 
     def test_v44_binding_remains_historical_evidence(self) -> None:


### PR DESCRIPTION
## Goal

Bind Base `PROJECT_DEDICATED_LOCAL_EXECUTION_ENVIRONMENT_FIRST` into GRIMOIRE under existing Decision `GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01`.

Approved project flow:
- `ASSUME_PREVIOUS_POWERSHELL_CLOSED`
- new self-contained one-block PowerShell launcher before every Codex prompt
- dedicated GRIMOIRE Godot → project-scoped HiGodot profile/ports → project CODEX_HOME → Hera profile when live QA is required → exact-worktree Codex
- missing dedicated environment routes to `CREATE_OR_REPAIR_DEDICATED_LOCAL_ENVIRONMENT_FIRST`
- Hera remains `LIVE_QA_AND_OBSERVABILITY_ONLY`; persistent source mutation forbidden; Task8 acceptance requires `HERA_SOURCE_DELTA: NONE`

## Base authority

- Base merged main consumed: `6d2feba2bc49fda2d8d273248b55087853615d5d`
- Base project pin remains v9.4.3; no pin update performed.

## Current local evidence boundary

User-supplied Task8 execution observed exact project session:
- `task8-spell-use-screen-v2@3cfa`
- Godot 4.7.1
- HiGodot server/plugin 3.1.4 / 3.1.4
- readiness `ready`

The tool did not surface a separate `expected_version` field, so no expected/actual equality is claimed.

Task8 local refinement evidence is recorded as:
- focused GUT: 15 tests / 90 assertions / 0 failures
- predecessor regression: 42 suites / 1,588 assertions / 0 failures

Task8 remains unmerged. This PR does not contain Task8 product source and does not promote it to merged/complete.

## Machine-current strategy

The pre-Sync20 machine files are preserved as historical snapshots rather than overwritten:
- `docs/planning/CANON_SYNC_STATE.json`
- `docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE.json`

Current machine overlays are added and prioritized by `START_HERE.md`:
- `docs/planning/CANON_SYNC_STATE_SYNC20.json`
- `docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE_SYNC20.json`

Historical Sync19 evidence still records that live v3.1.4 handshake was pending at that time; Sync20 current overlays record the later exact-project v3.1.4/ready observation without inventing an expected_version field.

## Adversarial refinement

Validated findings fixed before merge:
- `OMISSION`: stale current-state consumers/tests still exposed the old live-handshake/local-access blockers.
- `CONFLICT`: Task8 product-unit identity (`TASK8_SPELL_USE_SCREEN`) was being conflated with its current next merge subgate. Current state now uses `TASK8_LOCAL_REFINEMENT_GREEN_UNMERGED_MERGE_GATES_PENDING` + `TASK8_RECEIPT_HERA_REVIEW_PR`, while historical snapshots preserve earlier product markers.
- `COMPLEMENT_GAP`: Task8 protected-delta HiGodot receipt, Hera acceptance, product PR/CI/merge remain intentionally pending next-product gates.
- `DUPLICATE_WORK`: none; same-goal open PR recheck found only #132.

Final classification: `NO_MATERIAL_FOLLOWUP` for this operating-policy Sync20 work unit.

## Exact-head verification

Exact PR head: `afb1cd68f5e9b5f67cbb2da1268898d90988bc9b`

- all 12 check runs are terminal; no failure, queued, in-progress, or null conclusion remains
- Validate Spell Workflow Current-State Sync: success
- Validate GRIMOIRE planning and Base v9.4.3: success
- Validate visual and platform gates: success
- Validate Godot Authoring and GUT Authority Gate: success on final head
- other applicable checks: success or intentional path-filter skip
- changed files: docs/tests only; no `.gd`, `.tscn`, `.tres`, `.res`, `project.godot`, addon, or Task8 product source
- unresolved review threads: 0
- Hera shared-token plaintext is not recorded; only policy prohibition is documented

## Sync

`GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT`

After merged-main readback, Google Sheet will be updated under the same Decision/Sync ID. Sheet update will not mark Task8 product merged or complete.