### PR TITLE
docs: finalize Sync20 Sheet readback

### DIFF
--- a/docs/planning/CANON_SYNC_STATE_SYNC20.json
+++ b/docs/planning/CANON_SYNC_STATE_SYNC20.json
@@ -12,8 +12,16 @@
   },
   "base": {
     "project_pin": "9.4.3",
-    "current_main_observed": "6d2feba2bc49fda2d8d273248b55087853615d5d",
+    "sync20_source_main": "6d2feba2bc49fda2d8d273248b55087853615d5d",
+    "latest_main_observed_post_merge": "1d6cc79ad9dfa694558524ccc5ebf11ec7df7d8c",
+    "latest_change_disposition": "NO_MATERIAL_FOLLOWUP_UNRELATED_TO_DEDICATED_LOCAL_EXECUTION",
     "pin_update": "NOT_APPROVED_NOT_PERFORMED"
+  },
+  "project_sync": {
+    "source_merge_main": "3eb629e7e162adb59e3c879a50f6361569ddcd22",
+    "source_pr": 132,
+    "merged_main_readback": "PASS",
+    "sheet_write_readback": "PASS"
   },
   "tool_authority": {
     "decision_id": "GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01",
@@ -40,7 +48,7 @@
   },
   "sheet_sync": {
     "spreadsheet_id": "19FftrZ4WzB-CXa9Q-y25iKMhmEs1Ip4Ea3ramf2xKqM",
-    "sync20_status": "PENDING_POST_MERGE",
+    "sync20_status": "SHEET_WRITE_READBACK_PASS",
     "tracked_v3_1_4_sync19": "SHEET_WRITE_READBACK_PASS"
   },
   "preserved_limits": [

--- a/docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE_SYNC20.json
+++ b/docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE_SYNC20.json
@@ -6,15 +6,23 @@
   "superseded_file_role": "SYNC19_HISTORICAL_MACHINE_SNAPSHOT",
   "base": {
     "project_pin": "9.4.3",
-    "current_main_observed": "6d2feba2bc49fda2d8d273248b55087853615d5d",
+    "sync20_source_main": "6d2feba2bc49fda2d8d273248b55087853615d5d",
+    "latest_main_observed_post_merge": "1d6cc79ad9dfa694558524ccc5ebf11ec7df7d8c",
+    "latest_change_disposition": "NO_MATERIAL_FOLLOWUP_UNRELATED_TO_DEDICATED_LOCAL_EXECUTION",
     "pin_update": "NOT_APPROVED_NOT_PERFORMED"
+  },
+  "project_sync": {
+    "source_merge_main": "3eb629e7e162adb59e3c879a50f6361569ddcd22",
+    "source_pr": 132,
+    "merged_main_readback": "PASS",
+    "sheet_write_readback": "PASS"
   },
   "local_execution": {
     "policy": "PROJECT_DEDICATED_LOCAL_EXECUTION_ENVIRONMENT_FIRST",
     "fresh_shell": "ASSUME_PREVIOUS_POWERSHELL_CLOSED",
     "missing_environment": "CREATE_OR_REPAIR_DEDICATED_LOCAL_ENVIRONMENT_FIRST",
     "launcher_order": "NEW_POWERSHELL_THEN_DEDICATED_GODOT_THEN_PROJECT_HIGODOT_THEN_PROJECT_CODEX_HOME_THEN_HERA_IF_REQUIRED_THEN_EXACT_WORKTREE_CODEX",
-    "sheet_status": "PENDING_POST_MERGE"
+    "sheet_status": "SHEET_WRITE_READBACK_PASS"
   },
   "higodot": {
     "release": "v3.1.4",

--- a/tests/test_godot_authoring_gut_authority_contract.py
+++ b/tests/test_godot_authoring_gut_authority_contract.py
@@ -30,7 +30,8 @@ CURRENT_SURFACES = [
 
 CURRENT_CONTRACT = "GM-CONTRACT-V4-5-BINDING-01"
 HISTORICAL_V44_CONTRACT = "GM-CONTRACT-V4-4-BINDING-01"
-CURRENT_BASE_MAIN = "6d2feba2bc49fda2d8d273248b55087853615d5d"
+SYNC20_SOURCE_BASE = "6d2feba2bc49fda2d8d273248b55087853615d5d"
+LATEST_BASE_OBSERVED = "1d6cc79ad9dfa694558524ccc5ebf11ec7df7d8c"
 CURRENT_SYNC = "GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT"
 HIGODOT_V314_TREE = "69010571e11123dfc4e09483f80cb9e6ca93511a"
 HIGODOT_LIVE = "LIVE_V3_1_4_EXACT_PROJECT_SESSION_READY_OBSERVED"
@@ -69,11 +70,15 @@ class GodotAuthoringGutAuthorityContractTests(unittest.TestCase):
         state = json.loads(CURRENT_STATE.read_text(encoding="utf-8"))
         self.assertEqual(CURRENT_SYNC, state["sync_id"])
         self.assertEqual("GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01", state["decision_id"])
-        self.assertEqual(CURRENT_BASE_MAIN, state["base"]["current_main_observed"])
+        self.assertEqual(SYNC20_SOURCE_BASE, state["base"]["sync20_source_main"])
+        self.assertEqual(LATEST_BASE_OBSERVED, state["base"]["latest_main_observed_post_merge"])
+        self.assertEqual("NO_MATERIAL_FOLLOWUP_UNRELATED_TO_DEDICATED_LOCAL_EXECUTION", state["base"]["latest_change_disposition"])
         self.assertEqual("9.4.3", state["base"]["project_pin"])
         self.assertEqual("PROJECT_DEDICATED_LOCAL_EXECUTION_ENVIRONMENT_FIRST", state["local_execution"]["policy"])
         self.assertEqual("ASSUME_PREVIOUS_POWERSHELL_CLOSED", state["local_execution"]["fresh_shell"])
         self.assertEqual("CREATE_OR_REPAIR_DEDICATED_LOCAL_ENVIRONMENT_FIRST", state["local_execution"]["missing_environment"])
+        self.assertEqual("SHEET_WRITE_READBACK_PASS", state["local_execution"]["sheet_status"])
+        self.assertEqual("PASS", state["project_sync"]["sheet_write_readback"])
 
         higodot = state["higodot"]
         self.assertEqual("v3.1.4", higodot["release"])
@@ -99,6 +104,14 @@ class GodotAuthoringGutAuthorityContractTests(unittest.TestCase):
         self.assertFalse(state["claims"]["direct_local_upgrade_receipt_verified"])
         self.assertFalse(state["claims"]["task8_merged_main_verified"])
         self.assertFalse(state["claims"]["task8_hera_acceptance_pass"])
+
+    def test_sync20_canon_records_sheet_readback(self):
+        canon = json.loads(CURRENT_CANON.read_text(encoding="utf-8"))
+        self.assertEqual(CURRENT_SYNC, canon["sync_id"])
+        self.assertEqual(SYNC20_SOURCE_BASE, canon["base"]["sync20_source_main"])
+        self.assertEqual(LATEST_BASE_OBSERVED, canon["base"]["latest_main_observed_post_merge"])
+        self.assertEqual("SHEET_WRITE_READBACK_PASS", canon["sheet_sync"]["sync20_status"])
+        self.assertEqual("PASS", canon["project_sync"]["sheet_write_readback"])
 
     def test_sync19_machine_snapshot_and_vendor_evidence_remain_historical(self):
         old = json.loads(SYNC19_STATE.read_text(encoding="utf-8"))

--- a/tests/test_hera_v1_pair_canon_reconciliation.py
+++ b/tests/test_hera_v1_pair_canon_reconciliation.py
@@ -27,7 +27,9 @@ TASK3_READY = "TASK3_READY_AFTER_POST_MERGE_CANON"
 TASK2_MAIN = "975b2ad278d07bf9bfa06a9f4c1fc20a9fb1bac0"
 TASK2_RECEIPT_PASS = "TASK2_HIGODOT_RECEIPT_READBACK_PASS"
 TASK7_MERGED = "TASK7_MERGED_MAIN_VERIFIED"
-TASK8_NEXT = "TASK8_SPELL_USE_SCREEN"
+HISTORICAL_TASK8_PRODUCT = "TASK8_SPELL_USE_SCREEN"
+CURRENT_TASK8_STATUS = "TASK8_LOCAL_REFINEMENT_GREEN_UNMERGED_MERGE_GATES_PENDING"
+CURRENT_TASK8_GATE = "TASK8_RECEIPT_HERA_REVIEW_PR"
 
 class HeraV1PairCanonReconciliationTests(unittest.TestCase):
     def test_live_evidence_preserves_historical_canary_scope(self) -> None:
@@ -44,7 +46,7 @@ class HeraV1PairCanonReconciliationTests(unittest.TestCase):
         self.assertFalse(data["claims"]["persistent_project_source_mutation_allowed_to_hera"])
         self.assertFalse(data["claims"]["spell_workflow_task2_authorized"])
 
-    def test_current_docs_close_hera_pair_blocker_and_show_later_task2_approval(self) -> None:
+    def test_current_docs_close_hera_pair_blocker_and_show_current_task8_hera_gate(self) -> None:
         unresolved = UNRESOLVED.read_text(encoding="utf-8")
         gates = DEVELOPMENT_GATES.read_text(encoding="utf-8")
         self.assertNotIn(STALE_BLOCKER, unresolved)
@@ -57,7 +59,8 @@ class HeraV1PairCanonReconciliationTests(unittest.TestCase):
             self.assertIn("spell_workflow_task2_authorized: true", text, str(path))
             self.assertIn(TASK2_MERGED, text, str(path))
             self.assertIn(TASK7_MERGED, text, str(path))
-            self.assertIn(TASK8_NEXT, text, str(path))
+            self.assertIn(CURRENT_TASK8_STATUS, text, str(path))
+            self.assertIn(CURRENT_TASK8_GATE, text, str(path))
             self.assertNotIn("spell_workflow_task2_authorized: false", text, str(path))
 
     def test_machine_state_closes_hera_and_structural_platform_gate_but_keeps_real_limits(self) -> None:
@@ -73,7 +76,7 @@ class HeraV1PairCanonReconciliationTests(unittest.TestCase):
         self.assertTrue(canon["spell_workflow_main"]["spell_workflow_task2_authorized"])
         self.assertTrue(grill["current_work"]["spell_workflow_task2_authorized"])
         self.assertEqual(TASK7_MERGED, canon["spell_workflow_main"]["status"])
-        self.assertEqual(TASK8_NEXT, canon["spell_workflow_main"]["next_task"])
+        self.assertEqual(HISTORICAL_TASK8_PRODUCT, canon["spell_workflow_main"]["next_task"])
         self.assertEqual(TASK3_READY, canon["spell_workflow_main"]["task2_readiness"])
         self.assertEqual("MERGED_MAIN_VERIFIED", canon["spell_workflow_main"]["task2_execution_status"])
         self.assertEqual(TASK2_MAIN, canon["spell_workflow_main"]["main_merge_commit"])

--- a/tests/test_higodot_v3_1_4_tracked_reconciliation.py
+++ b/tests/test_higodot_v3_1_4_tracked_reconciliation.py
@@ -25,7 +25,8 @@ CURRENT_SYNC_ID = "GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT"
 UPSTREAM_TAG_COMMIT = "96cc8b8c3d25ce487e24801d01d5214fea150349"
 V314_TREE = "69010571e11123dfc4e09483f80cb9e6ca93511a"
 DIRECT_TOOL_STATE_COMMIT = "257a0dba33f8288d24b1cd291bb407f4505224b4"
-CURRENT_BASE_MAIN = "6d2feba2bc49fda2d8d273248b55087853615d5d"
+SYNC20_SOURCE_BASE = "6d2feba2bc49fda2d8d273248b55087853615d5d"
+LATEST_BASE_OBSERVED = "1d6cc79ad9dfa694558524ccc5ebf11ec7df7d8c"
 RECEIPT_LIMIT = "HIGODOT_AUTHORING_RECEIPT_UNVERIFIED_FOR_DIRECT_LOCAL_TOOL_STATE_COMMIT"
 HISTORICAL_LIVE_GATE = "LIVE_V3_1_4_HANDSHAKE_NOT_VERIFIED"
 CURRENT_LIVE = "LIVE_V3_1_4_EXACT_PROJECT_SESSION_READY_OBSERVED"
@@ -62,12 +63,16 @@ class HiGodotV314TrackedReconciliationTests(unittest.TestCase):
         old_state = json.loads(SYNC19_STATE.read_text(encoding="utf-8"))
         self.assertIn(HISTORICAL_LIVE_GATE, json.dumps(old_state))
 
-    def test_sync20_current_machine_state_records_exact_project_live_ready(self) -> None:
+    def test_sync20_current_machine_state_records_exact_project_live_ready_and_sheet_readback(self) -> None:
         data = json.loads(CURRENT_STATE.read_text(encoding="utf-8"))
         self.assertEqual(CURRENT_SYNC_ID, data["sync_id"])
         self.assertEqual(DECISION, data["decision_id"])
-        self.assertEqual(CURRENT_BASE_MAIN, data["base"]["current_main_observed"])
+        self.assertEqual(SYNC20_SOURCE_BASE, data["base"]["sync20_source_main"])
+        self.assertEqual(LATEST_BASE_OBSERVED, data["base"]["latest_main_observed_post_merge"])
+        self.assertEqual("NO_MATERIAL_FOLLOWUP_UNRELATED_TO_DEDICATED_LOCAL_EXECUTION", data["base"]["latest_change_disposition"])
         self.assertEqual("9.4.3", data["base"]["project_pin"])
+        self.assertEqual("SHEET_WRITE_READBACK_PASS", data["local_execution"]["sheet_status"])
+        self.assertEqual("PASS", data["project_sync"]["sheet_write_readback"])
         higodot = data["higodot"]
         self.assertEqual("v3.1.4", higodot["release"])
         self.assertEqual(V314_TREE, higodot["tracked_plugin_subtree"])

--- a/tests/test_v4_4_live_main_readback_semantics.py
+++ b/tests/test_v4_4_live_main_readback_semantics.py
@@ -13,9 +13,19 @@ THREE_SCREEN_PENDING = "THREE_SCREEN_RUNTIME_AWAITING_TASKS_2_9"
 TASK2_MERGED = "TASK2_MERGED_MAIN_VERIFIED"
 TASK3_READY = "TASK3_READY_AFTER_POST_MERGE_CANON"
 TASK2_RECEIPT_PASS = "TASK2_HIGODOT_RECEIPT_READBACK_PASS"
-CURRENT_DOCS = [ROOT / "START_HERE.md", ROOT / "docs/ACTIVE_CONTEXT.md", ROOT / "docs/DEVELOPMENT_GATES.md", ROOT / "docs/planning/CURRENT_CONFIRMED_DECISIONS.md", ROOT / "docs/planning/CURRENT_UNRESOLVED_GATES.md"]
+TASK8_STATUS = "TASK8_LOCAL_REFINEMENT_GREEN_UNMERGED_MERGE_GATES_PENDING"
+TASK8_GATE = "TASK8_RECEIPT_HERA_REVIEW_PR"
+LIVE_READY = "LIVE_V3_1_4_EXACT_PROJECT_SESSION_READY_OBSERVED"
+CURRENT_DOCS = [
+    ROOT / "START_HERE.md",
+    ROOT / "docs/ACTIVE_CONTEXT.md",
+    ROOT / "docs/DEVELOPMENT_GATES.md",
+    ROOT / "docs/planning/CURRENT_CONFIRMED_DECISIONS.md",
+    ROOT / "docs/planning/CURRENT_UNRESOLVED_GATES.md",
+]
 CANON = ROOT / "docs/planning/CANON_SYNC_STATE.json"
 GRILL = ROOT / "docs/planning/GRILL_ME_BATCH_MERGE_STATE.json"
+
 
 class V44LiveMainReadbackSemanticsTests(unittest.TestCase):
     def test_current_docs_use_live_github_main_authority_not_a_frozen_current_sha(self) -> None:
@@ -27,7 +37,7 @@ class V44LiveMainReadbackSemanticsTests(unittest.TestCase):
             self.assertNotIn(f"current_main: {GUT_FORMAL_ADOPTION_MAIN}", text, str(path))
             self.assertNotIn(f"project_main: {GUT_FORMAL_ADOPTION_MAIN}", text, str(path))
 
-    def test_machine_state_names_historical_merge_shas_by_role(self) -> None:
+    def test_historical_machine_state_names_historical_merge_shas_by_role(self) -> None:
         canon = json.loads(CANON.read_text(encoding="utf-8"))
         grill = json.loads(GRILL.read_text(encoding="utf-8"))
         self.assertEqual("LIVE_GITHUB_DEFAULT_BRANCH_READBACK", canon["project_main_authority"])
@@ -42,17 +52,33 @@ class V44LiveMainReadbackSemanticsTests(unittest.TestCase):
         self.assertEqual(87, work["post_merge_canon_sync_pr"])
         self.assertEqual(POST_MERGE_CANON_SYNC_MAIN, work["post_merge_canon_sync_merge"])
 
-    def test_protected_decisions_and_real_remaining_limits_are_preserved(self) -> None:
+    def test_protected_decisions_and_current_remaining_limits_are_preserved(self) -> None:
         combined = "\n".join(path.read_text(encoding="utf-8") for path in CURRENT_DOCS)
         for token in (
-            "GM-STAR-CIRCUIT-MASTERY-BALANCE-01", "FIVE_POINT_STAR", "GUT_FORMALLY_ADOPTED",
-            "higodot_vendor_integrity: PASS_EXACT_TREE_IDENTITY", "hera_exact_pair: PASS", HERA_PASS,
-            "spell_workflow_task2_authorized: true", TASK2_MERGED, TASK3_READY, TASK2_RECEIPT_PASS,
-            SHARED_CORE_PASS, THREE_SCREEN_PENDING,
-            "VISUAL_AUDIO_COMPLETE_NOT_PROVEN", "LOCAL_SYNC_BLOCKED_NO_LOCAL_ACCESS",
-            "GODOT_RUN_BLOCKED_NO_LOCAL_ACCESS",
+            "GM-STAR-CIRCUIT-MASTERY-BALANCE-01",
+            "FIVE_POINT_STAR",
+            "GUT_FORMALLY_ADOPTED",
+            "higodot_vendor_integrity: PASS_EXACT_TREE_IDENTITY",
+            "hera_exact_pair: PASS",
+            HERA_PASS,
+            "spell_workflow_task2_authorized: true",
+            TASK2_MERGED,
+            TASK3_READY,
+            TASK2_RECEIPT_PASS,
+            SHARED_CORE_PASS,
+            THREE_SCREEN_PENDING,
+            LIVE_READY,
+            TASK8_STATUS,
+            TASK8_GATE,
+            "TASK8_PROTECTED_DELTA_HIGODOT_RECEIPT_PENDING",
+            "TASK8_HERA_ACCEPTANCE_PENDING",
+            "TASK8_PR_EXACT_HEAD_CI_REVIEW_MERGE_PENDING",
+            "VISUAL_AUDIO_COMPLETE_NOT_PROVEN",
         ):
             self.assertIn(token, combined)
+
+        self.assertNotIn("LOCAL_SYNC_BLOCKED_NO_LOCAL_ACCESS", combined)
+        self.assertNotIn("GODOT_RUN_BLOCKED_NO_LOCAL_ACCESS", combined)
         self.assertNotIn("spell_workflow_task2_authorized: false", combined)
         self.assertNotIn("spell_workflow_task2_readiness: READY_FOR_HIGODOT_AUTHORING", combined)
         self.assertNotIn("spell_workflow_task2_execution_status: AUTHORIZED_AWAITING_HIGODOT_CHANNEL", combined)
@@ -61,6 +87,7 @@ class V44LiveMainReadbackSemanticsTests(unittest.TestCase):
         self.assertNotIn("SPELL_WORKFLOW_THREE_SCREEN_RUNTIME_NOT_RUN", combined)
         self.assertNotIn("HIGODOT_VENDOR_TREE_MISMATCH_OFFICIAL_V3_1_2", combined)
         self.assertNotIn("HERA_CLI_ADDON_PAIR_UNVERIFIED", combined)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_v4_4_live_main_readback_semantics.py
+++ b/tests/test_v4_4_live_main_readback_semantics.py
@@ -37,7 +37,7 @@ class V44LiveMainReadbackSemanticsTests(unittest.TestCase):
             self.assertNotIn(f"current_main: {GUT_FORMAL_ADOPTION_MAIN}", text, str(path))
             self.assertNotIn(f"project_main: {GUT_FORMAL_ADOPTION_MAIN}", text, str(path))
 
-    def test_historical_machine_state_names_historical_merge_shas_by_role(self) -> None:
+    def test_historical_machine_state_names_historical_merge_shas_and_task3_readiness_by_role(self) -> None:
         canon = json.loads(CANON.read_text(encoding="utf-8"))
         grill = json.loads(GRILL.read_text(encoding="utf-8"))
         self.assertEqual("LIVE_GITHUB_DEFAULT_BRANCH_READBACK", canon["project_main_authority"])
@@ -45,6 +45,7 @@ class V44LiveMainReadbackSemanticsTests(unittest.TestCase):
         self.assertEqual(GUT_FORMAL_ADOPTION_MAIN, canon["gut_formal_adoption_main"])
         self.assertEqual(87, canon["post_merge_canon_sync"]["pull_request"])
         self.assertEqual(POST_MERGE_CANON_SYNC_MAIN, canon["post_merge_canon_sync"]["merge_commit"])
+        self.assertEqual(TASK3_READY, canon["spell_workflow_main"]["task2_readiness"])
         work = grill["current_work"]
         self.assertEqual("LIVE_GITHUB_DEFAULT_BRANCH_READBACK", work["project_main_authority"])
         self.assertNotIn("project_main", work)
@@ -63,7 +64,6 @@ class V44LiveMainReadbackSemanticsTests(unittest.TestCase):
             HERA_PASS,
             "spell_workflow_task2_authorized: true",
             TASK2_MERGED,
-            TASK3_READY,
             TASK2_RECEIPT_PASS,
             SHARED_CORE_PASS,
             THREE_SCREEN_PENDING,


### PR DESCRIPTION
## Goal

Finalize the already-approved `GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT` after GRIMOIRE merged-main and Google Sheet readback.

Same Decision remains `GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01`.

## Finalized facts

- Sync20 source Base main: `6d2feba2bc49fda2d8d273248b55087853615d5d`
- later Base observation: `1d6cc79ad9dfa694558524ccc5ebf11ec7df7d8c`
- later Base change classified `NO_MATERIAL_FOLLOWUP_UNRELATED_TO_DEDICATED_LOCAL_EXECUTION`
- Base project pin remains v9.4.3
- Sync20 source GRIMOIRE merge: `3eb629e7e162adb59e3c879a50f6361569ddcd22` / PR #132
- Google Sheet Sync20 write/readback: PASS
- current machine overlays now say `SHEET_WRITE_READBACK_PASS`

Task8 remains `TASK8_LOCAL_REFINEMENT_GREEN_UNMERGED_MERGE_GATES_PENDING`; next gate remains `TASK8_RECEIPT_HERA_REVIEW_PR`.

Hera remains `LIVE_QA_AND_OBSERVABILITY_ONLY`, persistent source mutation forbidden, Task8 acceptance requires `HERA_SOURCE_DELTA: NONE`.

## Adversarial/debugging refinements

CI exposed stale current-state tests that were still treating historical markers as current requirements. Each was corrected without rewriting the historical snapshots:
- historical `TASK3_READY_AFTER_POST_MERGE_CANON` remains asserted on old machine canon, not current human docs;
- historical `TASK8_SPELL_USE_SCREEN` checkpoint remains in pre-Sync20 machine snapshots, while current docs use Task8 local-green status + receipt/Hera merge subgate;
- historical Hera v1.0.0 canary remains preserved, while current assertions validate Task8 Hera pending/source-delta-NONE semantics;
- obsolete local-access blockers are no longer required in current docs.

## Exact-head verification

Exact head: `2ec3f6a36900d694314c554d7c4c1ae4bf5a727d`

Emitted workflows:
- Validate Spell Workflow Current-State Sync: success
- Validate Godot Authoring and GUT Authority Gate: success
- Validate GRIMOIRE planning and Base v9.4.3: success
- Validate Star Physical Validation Pack: success
- Validate Star Circuit Runtime POC: success
- Validate Godot 4.7.1 toolchain: success
- GUT Formal Adoption Validation: intentional path-filter skip

Adversarial merge review:
- product `.gd/.tscn/.tres/.res/project.godot` delta: NONE
- Hera authoring escalation: NONE
- shared-token plaintext: NONE
- historical Sync19 snapshots rewritten: NO
- same-goal open PR: only #133
- unresolved review threads: 0
- classification: `NO_MATERIAL_FOLLOWUP`

No Task8 product completion is claimed by this finalization.