### PR TITLE
docs: persist Task8 handoff and BCP continuation

### DIFF
--- a/.github/workflows/validate-current-state-sync.yml
+++ b/.github/workflows/validate-current-state-sync.yml
@@ -9,4 +9,8 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
-      - run: python -m unittest tests.test_spell_workflow_current_state_sync -v
+      - run: >-
+          python -m unittest
+          tests.test_spell_workflow_current_state_sync
+          tests.test_task8_handoff_bcp_continuation
+          -v

--- a/docs/ACTIVE_CONTEXT.md
+++ b/docs/ACTIVE_CONTEXT.md
@@ -231,6 +231,37 @@ HIGODOT_AUTHORING_RECEIPT_UNVERIFIED_FOR_DIRECT_LOCAL_TOOL_STATE_COMMIT
 
 자동·Editor·CI·GUT·Hera 증거로 사람/기기/성능/전체 Vertical Slice 증거를 승격하지 않는다.
 
+## Sync21 continuation overlay — current handoff authority
+
+This section is the current continuation overlay for Task8 resume and supersedes older pending-receipt wording in this file **only for resume routing**. Historical Sync20/Task8 markers remain in place for compatibility consumers.
+
+```yaml
+continuation_sync: GR-SYNC-20260812-21-TASK8-HANDOFF-BCP
+state_observed_at_project_main: d1e4d747ee1f28b8a29adcd25726fd975a81d168
+base_main_observed_for_handoff: 1d6cc79ae95ffb67ba4de618f010a6540fc6e02c
+product_status: TASK8_LOCAL_ACCEPTANCE_PASS_UNMERGED
+product_branch_local: feat/task8-spell-use-screen-v2
+product_head_local: 8c611f601aa98397ed1558e92ab207e0e8347a9b
+product_remote_branch_at_handoff: NOT_PRESENT
+product_pr: NONE
+resume_gate: TASK8_PR_PREP_REVERIFY_PENDING
+current_higodot_session: HIGODOT_CURRENT_SESSION_REVALIDATION_REQUIRED
+remote_authority_route: REMOTE_AUTHORITY_RECEIPT
+local_executor_route: LOCAL_EXECUTION_RECEIPT
+codex_capability_failure: EXECUTOR_CAPABILITY_BLOCKER
+codex_remote_retry: DO_NOT_RETRY_BLOCKED_REMOTE_CHECK_IN_CODEX
+remote_write_precondition: FRESH_GITHUB_CONNECTOR_READBACK_REQUIRED_BEFORE_REMOTE_WRITE
+codex_session_reuse: CURRENT_DEDICATED_CODEX_REUSE_ALLOWED_FOR_CODEX_ONLY_CONTINUATION
+base_proposal_state: BASE_PROPOSAL_STATE_PENDING_CONCURRENT_RACE_CHECK
+handoff_product_git_write: NO_STAGE_COMMIT_PUSH_DURING_HANDOFF
+```
+
+Observed acceptance checkpoint before the later PR-prep interruption: exact session `task8-spell-use-screen-v2@b680`, focused GUT `15 tests / 90 assertions / 0 failures`, predecessor `42 suites / 1,588 assertions / 0 failures`, and `HERA_SOURCE_DELTA_NONE_OBSERVED`. `HISTORICAL_EDIT_OPERATION_RECEIPT_NOT_RETROACTIVELY_PROVABLE` remains an evidence ceiling rather than being upgraded.
+
+The later Codex PR-prep attempt produced `CODEX_FETCH_HEAD_PERMISSION_DENIED` and `CODEX_GITHUB_NETWORK_BLOCKED`; it did not edit source or stage/commit/push. Resume therefore revalidates local HiGodot/test readiness but does not throw away the accepted prior checkpoint.
+
+Learning application lives at `docs/planning/sync/GR-SYNC-20260812-21-TASK8-HANDOFF-BCP.md`. Task8 remains `TASK8_LOCAL_REFINEMENT_GREEN_UNMERGED_MERGE_GATES_PENDING`; the compatibility locator `TASK8_RECEIPT_HERA_REVIEW_PR` remains searchable until its older consumers are deliberately migrated.
+
 ## Contract boundary
 
-저장소 current canon은 v4.5 r2 / `GM-CONTRACT-V4-5-BINDING-01`이다. v4.4 / `GM-CONTRACT-V4-4-BINDING-01`과 HiGodot v3.1.3은 historical provenance로 보존한다. Sync20은 운영 실행환경 consumer이며 제품 규칙을 변경하지 않는다.
+저장소 current canon은 v4.5 r2 / `GM-CONTRACT-V4-5-BINDING-01`이다. v4.4 / `GM-CONTRACT-V4-4-BINDING-01`과 HiGodot v3.1.3은 historical provenance로 보존한다. Sync20은 운영 실행환경 consumer이며 제품 규칙을 변경하지 않는다. Sync21은 Task8 product를 변경하지 않는 continuation/handoff overlay다.

--- a/docs/planning/CURRENT_UNRESOLVED_GATES.md
+++ b/docs/planning/CURRENT_UNRESOLVED_GATES.md
@@ -214,20 +214,54 @@ A Hera-discovered product defect returns to HiGodot persistent authoring, then G
 | `AUDIO_RIGHTS_UNVERIFIED` | `BLOCKING_FOR_AUDIO_INGESTION` |
 | `VISUAL_AUDIO_COMPLETE_NOT_PROVEN` | `BLOCKING_FOR_FINAL_VISUAL_AUDIO_COMPLETION` |
 
+## Sync21 handoff gate — current resume routing
+
+`GR-SYNC-20260812-21-TASK8-HANDOFF-BCP` is the current continuation overlay for Task8 resume. The older `TASK8_LOCAL_REFINEMENT_GREEN_UNMERGED_MERGE_GATES_PENDING` and `TASK8_RECEIPT_HERA_REVIEW_PR` strings remain as compatibility locators, but the narrower current execution state is:
+
+```yaml
+product_status: TASK8_LOCAL_ACCEPTANCE_PASS_UNMERGED
+product_branch_local: feat/task8-spell-use-screen-v2
+product_head_local: 8c611f601aa98397ed1558e92ab207e0e8347a9b
+product_remote_branch_at_handoff: NOT_PRESENT
+product_pr: NONE
+resume_gate: TASK8_PR_PREP_REVERIFY_PENDING
+higodot_current_session: HIGODOT_CURRENT_SESSION_REVALIDATION_REQUIRED
+accepted_higodot_checkpoint: task8-spell-use-screen-v2@b680
+accepted_focused_gut: 15 tests / 90 assertions / 0 failures
+accepted_predecessor_regression: 42 suites / 1,588 assertions / 0 failures
+accepted_hera_delta: HERA_SOURCE_DELTA_NONE_OBSERVED
+historical_edit_receipt_limit: HISTORICAL_EDIT_OPERATION_RECEIPT_NOT_RETROACTIVELY_PROVABLE
+codex_fetch_head: CODEX_FETCH_HEAD_PERMISSION_DENIED
+codex_network: CODEX_GITHUB_NETWORK_BLOCKED
+capability_classification: EXECUTOR_CAPABILITY_BLOCKER
+remote_authority_route: REMOTE_AUTHORITY_RECEIPT
+local_executor_route: LOCAL_EXECUTION_RECEIPT
+codex_remote_retry: DO_NOT_RETRY_BLOCKED_REMOTE_CHECK_IN_CODEX
+remote_write_precondition: FRESH_GITHUB_CONNECTOR_READBACK_REQUIRED_BEFORE_REMOTE_WRITE
+codex_session_reuse: CURRENT_DEDICATED_CODEX_REUSE_ALLOWED_FOR_CODEX_ONLY_CONTINUATION
+base_proposal_state: BASE_PROPOSAL_STATE_PENDING_CONCURRENT_RACE_CHECK
+handoff_product_git_write: NO_STAGE_COMMIT_PUSH_DURING_HANDOFF
+```
+
+The exact next product step is fresh local PR-prep revalidation, not repetition of the already-completed full acceptance workflow unless current evidence requires it. A currently established dedicated Codex session may continue Codex-only steps; recreate the dedicated environment via fresh PowerShell only when the current executor/session must be rebuilt or when the required operation exceeds the current Codex capability boundary.
+
+Learning details, Base reuse decisions, and the non-recursive continuation checkpoint are owned by `docs/planning/sync/GR-SYNC-20260812-21-TASK8-HANDOFF-BCP.md`.
+
 ## 현재 허용
 
 ```yaml
 allowed_next_actions:
-  - FRESH_DEDICATED_LOCAL_ENVIRONMENT_BOOTSTRAP
-  - FRESH_EXACT_PROJECT_HIGODOT_RECEIPT
-  - TASK8_PROTECTED_DELTA_HIGODOT_RECEIPT_READBACK
+  - TASK8_PR_PREP_REVERIFY_PENDING
+  - FRESH_GITHUB_CONNECTOR_REMOTE_AUTHORITY_READBACK
+  - CURRENT_CODEX_LOCAL_IDENTITY_AND_HIGODOT_REVALIDATION
   - GUT_DETERMINISTIC_TASK8_REGRESSION_AS_REQUIRED
-  - HERA_TASK8_ACCEPTANCE_QA_OBSERVABILITY_ONLY_WITH_SOURCE_DELTA_NONE
-  - INDEPENDENT_ADVERSARIAL_REVIEW
-  - TASK8_EXACT_HEAD_PR_CI_MERGE
+  - EXACT_NINE_PATH_TASK8_ADVERSARIAL_REVIEW
+  - POWER_SHELL_ONLY_FOR_GIT_WRITE_IF_CURRENT_CODEX_CAPABILITY_BLOCKS_REQUIRED_OPERATION
+  - TASK8_EXACT_HEAD_PR_CI_MERGE_AFTER_REVALIDATION
   - PROPAGATE_APPROVED_DEVICE_MATRIX_INTO_TASK9_ACCEPTANCE
   - VERIFY_GODOT_MULTIPLE_ASPECT_POLICY_BEFORE_TASK9
 forbidden_next_actions:
+  - RETRY_ALREADY_CLASSIFIED_CODEX_GITHUB_NETWORK_PROBE_AS_PRODUCT_GATE
   - PERSISTENT_GODOT_PRODUCT_AUTHORING_OUTSIDE_HIGODOT
   - LET_HERA_PERSISTENTLY_MUTATE_SOURCE
   - STORE_HERA_SHARED_TOKEN_PLAINTEXT

--- a/docs/planning/sync/GR-SYNC-20260812-21-TASK8-HANDOFF-BCP.md
+++ b/docs/planning/sync/GR-SYNC-20260812-21-TASK8-HANDOFF-BCP.md
@@ -1,0 +1,242 @@
+# GR-SYNC-20260812-21-TASK8-HANDOFF-BCP
+
+## Purpose
+
+Pause Task8 product mutation at a safe boundary, persist the exact continuation state, apply project-side lessons, and prepare reusable learning for Base proposal-only storage without promoting Task8 to merged/complete.
+
+Decisions remain unchanged:
+
+- product: `GM-SPELL-WORKFLOW-UI-V2-01`
+- tool authority: `GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01`
+- contract binding: `GM-CONTRACT-V4-5-BINDING-01`
+
+No new product decision is introduced by this sync.
+
+## Fresh authority snapshot
+
+Observed for this handoff work unit:
+
+```yaml
+project_repository: alsdmlals4-eng/GRIMOIRE-
+project_default_branch: main
+project_main_at_handoff: d1e4d747ee1f28b8a29adcd25726fd975a81d168
+project_open_prs_before_handoff_pr: 0
+base_repository: alsdmlals4-eng/Base
+base_main_at_handoff: 1d6cc79ae95ffb67ba4de618f010a6540fc6e02c
+base_open_prs_at_handoff_start: 0
+base_project_pin: v9.4.3
+base_pin_change: NONE
+sheet_base_sha_observed: 1d6cc79ad9dfa694558524ccc5ebf11ec7df7d8c
+sheet_base_sha_disposition: CONFLICT_STALE_FULL_SHA_PREFIX_ONLY_MATCH
+```
+
+The Google Sheet remained correct that Task8 product is unmerged, but its recorded full latest-Base SHA did not equal the fresh GitHub Base main SHA. This is metadata drift; it does not change the v9.4.3 project pin or product authority.
+
+## Task8 product preservation boundary
+
+The product work is intentionally paused, not completed.
+
+```yaml
+local_product_branch: feat/task8-spell-use-screen-v2
+local_product_head: 8c611f601aa98397ed1558e92ab207e0e8347a9b
+remote_product_branch_at_handoff: NOT_PRESENT
+product_pr_at_handoff: NONE
+product_merge_state: UNMERGED_LOCAL_WORK
+continuation_status: TASK8_LOCAL_ACCEPTANCE_PASS_UNMERGED
+next_product_gate: TASK8_PR_PREP_REVERIFY_PENDING
+handoff_mutation_boundary: NO_STAGE_COMMIT_PUSH_DURING_HANDOFF
+```
+
+The intended product commit remains the previously reviewed nine-path Task8 delta. This handoff PR does not copy, stage, commit, normalize, restore, reset, clean, or otherwise rewrite that local product worktree.
+
+Known unrelated/representation-only local state remains outside this handoff scope, including `project.godot`, `.import` representation noise, `addons/gut/gui/EditorRadioButton.tres`, `artifacts/task8-red/manifest.json`, and `artifacts/foundation-poc/glyph-fixture-rows.json`.
+
+## Accepted local evidence vs current readiness
+
+The latest completed local acceptance cycle before PR-prep interruption observed:
+
+```yaml
+higodot_session_observed: task8-spell-use-screen-v2@b680
+higodot_server_version: 3.1.4
+higodot_plugin_version: 3.1.4
+higodot_readiness: ready
+godot_version: 4.7.1
+expected_version: NOT_SURFACED_DO_NOT_CLAIM
+protected_delta_readback: FRESH_PROTECTED_DELTA_READBACK_PASS
+historical_edit_operation_receipt: HISTORICAL_EDIT_OPERATION_RECEIPT_NOT_RETROACTIVELY_PROVABLE
+focused_gut: 15 tests / 90 assertions / 0 failures
+predecessor_regression: 42 suites / 1,588 assertions / 0 failures
+hera_source_delta: HERA_SOURCE_DELTA_NONE_OBSERVED
+hera_authority: LIVE_QA_AND_OBSERVABILITY_ONLY
+```
+
+This evidence remains valid as an observed acceptance checkpoint, but it is not reused as proof that the currently open/next Codex session is still attached to the same live HiGodot session.
+
+The later PR-prep attempt observed:
+
+```text
+CODEX_FETCH_HEAD_PERMISSION_DENIED
+CODEX_GITHUB_NETWORK_BLOCKED
+HIGODOT_CURRENT_SESSION_REVALIDATION_REQUIRED
+```
+
+Specifically:
+
+- linked-worktree shared Git metadata write to `FETCH_HEAD` was denied inside the Codex sandbox;
+- `git ls-remote` from the same Codex sandbox could not reach `github.com:443`;
+- a fresh `godot-ai.session_manage(list)` returned no connected session in that interrupted attempt;
+- cached diff was empty and no source edit, staging, commit, push, reset, restore, clean, rebase, or amend occurred.
+
+Therefore the acceptance checkpoint is preserved, while current PR-prep readiness is `TASK8_PR_PREP_REVERIFY_PENDING` rather than promoted to stage/commit/push-ready.
+
+## Continuation capability split
+
+The project now records an explicit resume distinction:
+
+```text
+REMOTE_AUTHORITY_RECEIPT
++
+LOCAL_EXECUTION_RECEIPT
+=
+CURRENT_TASK_RESUME_DECISION
+```
+
+`REMOTE_AUTHORITY_RECEIPT` may come from the current ChatGPT GitHub connector when the local Codex sandbox cannot reach GitHub or cannot write shared linked-worktree metadata. It must identify repository/ref/exact SHA and be freshly read for the current work unit.
+
+`LOCAL_EXECUTION_RECEIPT` remains local and must prove the exact worktree/branch/HEAD, cached/staged state, current HiGodot exact-project session/readiness when required, and current test results.
+
+A local executor's inability to perform a remote check is classified as `EXECUTOR_CAPABILITY_BLOCKER`, not as evidence that the remote repository or product is invalid.
+
+Operational rules:
+
+```text
+DO_NOT_RETRY_BLOCKED_REMOTE_CHECK_IN_CODEX
+FRESH_GITHUB_CONNECTOR_READBACK_REQUIRED_BEFORE_REMOTE_WRITE
+CURRENT_DEDICATED_CODEX_REUSE_ALLOWED_FOR_CODEX_ONLY_CONTINUATION
+```
+
+The existing project-dedicated-environment rule remains the fresh-session default. The added project-specific continuation rule is narrower: when the exact dedicated Codex session is already established and remains open, a next step that is Codex-only may continue in that session without forcing a new PowerShell. If the environment/session must be recreated, or a required Git/network/shared-metadata operation is unavailable in the current Codex sandbox, use the project-dedicated PowerShell path for that boundary only.
+
+## Exact next Task8 resume sequence
+
+After this handoff/BCP closure completes, resume Task8 with:
+
+```text
+fresh ChatGPT GitHub remote-authority receipt
+→ current dedicated Codex local identity check
+→ godot-ai.session_manage(list)
+→ exact Task8 session activation/recovery if needed
+→ require server/plugin 3.1.4/3.1.4 + readiness ready
+→ cached diff empty
+→ focused Task8 GUT fresh 15/90/0
+→ predecessor Task5/6/7 regression fresh 42/1588/0
+→ git diff --check
+→ exact nine-path adversarial review
+→ if Codex Git metadata boundary still blocks stage/commit/push, use a short fresh PowerShell only for exact allowlisted Git write operations
+→ product PR exact-head CI/review
+→ merge
+→ merged-main readback
+```
+
+Do not retry Codex GitHub network probes merely to reproduce an already-classified capability failure.
+
+## Learning Closure
+
+### LRN-GR-20260812-01 — split remote authority from local executor capability
+
+```yaml
+classification: BASE_CANDIDATE
+project_application: PROJECT_APPLICATION = APPLIED
+project_owner: GR-SYNC-20260812-21-TASK8-HANDOFF-BCP + current continuation owners
+project_verification: focused continuation regression + project PR exact-head CI
+base_existing_solution_verdict: ABSORB_EXISTING_OWNER_MATERIAL_COMPLEMENT
+base_proposal_state: BASE_PROPOSAL_STATE_PENDING_CONCURRENT_RACE_CHECK
+closure: OPEN_UNTIL_BASE_PROPOSAL_STORAGE_MERGED_OR_REUSED
+```
+
+Observed principle: a sandboxed local executor can remain authoritative for local identity/tests while a separate trusted connector supplies fresh remote repository identity. Capability failures must not be confused with project failures, and remote freshness must still be re-read before remote writes/merge.
+
+### LRN-GR-20260812-02 — hidden/orphan exact-project editor recovery
+
+```yaml
+classification: NO_PROMOTION
+existing_solution: REUSE_EXISTING_BCP
+base_locator: BCP-2026-015-external-runtime-session-same-snapshot-recovery
+additional_owner: Base project-dedicated local execution environment contract
+project_application: PROJECT_APPLICATION = APPLIED
+project_verification: prior exact orphan identity + bounded process cleanup evidence
+closure: CLOSED_NO_DUPLICATE_BCP
+```
+
+The observed hidden Task8 Godot process had exact-project identity but no visible window and no live parent. This is already covered by current same-snapshot process/transport/session recovery plus project-dedicated execution safety. A second broad runtime-recovery BCP would duplicate existing ownership.
+
+### LRN-GR-20260812-03 — current dedicated Codex reuse for Codex-only continuation
+
+```yaml
+classification: PROJECT_ONLY
+project_application: PROJECT_APPLICATION = APPLIED
+project_owner: current continuation/handoff route
+rule: CURRENT_DEDICATED_CODEX_REUSE_ALLOWED_FOR_CODEX_ONLY_CONTINUATION
+fresh_session_default_preserved: ASSUME_PREVIOUS_POWERSHELL_CLOSED
+base_promotion: NO_PROMOTION_PROJECT_WORKFLOW_PREFERENCE
+closure: CLOSED_PROJECT_APPLICATION
+```
+
+This does not weaken the project-dedicated environment requirement. It only prevents unnecessary fresh-shell churn when the already-established exact Codex session remains the current executor and the next operation stays within its proven capabilities.
+
+## Learning Closure table
+
+| Learning ID | Classification | Project application | Project verification | Base proposal | Closure |
+|---|---|---|---|---|---|
+| `LRN-GR-20260812-01` | `BASE_CANDIDATE` | `APPLIED` | project PR exact-head CI pending | `BASE_PROPOSAL_STATE_PENDING_CONCURRENT_RACE_CHECK` | `OPEN` |
+| `LRN-GR-20260812-02` | `NO_PROMOTION` | `APPLIED` | prior runtime recovery evidence + current handoff regression | `REUSE_EXISTING_BCP` / BCP-015 | `CLOSED` |
+| `LRN-GR-20260812-03` | `PROJECT_ONLY` | `APPLIED` | current handoff regression | N/A | `CLOSED` |
+
+Overall Learning Closure remains open until LRN-01 is either stored as a non-duplicate Base proposal or safely converted to `REUSE_EXISTING_BCP / CONCURRENT_SAME_GOAL` after the final Base race check.
+
+## Continuation checkpoint
+
+```yaml
+continuation_checkpoint:
+  state_observed_at_main: d1e4d747ee1f28b8a29adcd25726fd975a81d168
+  task8_local_branch: feat/task8-spell-use-screen-v2
+  task8_local_head: 8c611f601aa98397ed1558e92ab207e0e8347a9b
+  task8_product_pr: NONE
+  task8_product_merge: NONE
+  current_status: TASK8_LOCAL_ACCEPTANCE_PASS_UNMERGED
+  next_executable_step: TASK8_PR_PREP_REVERIFY_PENDING
+  base_proposal: BASE_PROPOSAL_STATE_PENDING_CONCURRENT_RACE_CHECK
+  closure_pr: PENDING
+  closure_head_sha: PENDING
+  self_merge_sha_required_in_file: false
+  resume_rule: FETCH_LATEST_MAIN_BEFORE_USE
+```
+
+## Preserved evidence ceilings
+
+```text
+HUMAN_NOT_RUN
+DEVICE_NOT_RUN
+PERFORMANCE_NOT_RUN
+FULL_VERTICAL_SLICE_NOT_RUN
+WINDOWS_EXPORT_NOT_RUN
+ANDROID_EXPORT_NOT_RUN
+ANDROID_DEVICE_NOT_RUN
+```
+
+No automated, Editor, CI, GUT, Hera, handoff, or Base proposal evidence promotes these states.
+
+## Handoff classification
+
+```yaml
+product_change: NONE
+product_merge_claim: NONE
+project_application: APPLIED_PENDING_PR_VALIDATION
+base_proposal: PENDING_FINAL_CONCURRENCY_PREFLIGHT
+base_active_implementation: FORBIDDEN_IN_THIS_STAGE
+post_change_monitor_initial_classification:
+  sheet_base_full_sha: CONFLICT
+  task8_old_pending_receipt_markers: COMPLEMENT_GAP_STALE_LOWER_CONSUMER
+  duplicate_runtime_recovery_bcp: DUPLICATE_WORK_AVOIDED_BY_REUSE_BCP_015
+  forced_new_shell_for_live_codex_only_step: COMPLEMENT_GAP_PROJECT_WORKFLOW_REFINED
+```

--- a/docs/superpowers/plans/2026-08-12-task8-handoff-bcp-closure.md
+++ b/docs/superpowers/plans/2026-08-12-task8-handoff-bcp-closure.md
@@ -1,0 +1,153 @@
+# Task8 Handoff and BCP Closure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pause Task8 product mutation safely, persist a restartable GRIMOIRE continuation checkpoint, close applicable project learning, and store any reusable learning as a Base proposal-only BCP without colliding with concurrent projects.
+
+**Architecture:** GRIMOIRE remains the product and continuation authority. The first project PR updates existing continuation owners and adds one focused regression without touching Task8 product files. Reusable learning is then proposed in Base only under `[수정제안서]/**` using the current Base proposal schema and a final concurrency race check. A final small GRIMOIRE closure updates the BCP locator and keeps Task8 explicitly unmerged and resumable.
+
+**Tech Stack:** GitHub repository docs/tests, Python `unittest`, Google Sheets continuation readback, Base proposal registry/schema/validator.
+
+## Global Constraints
+
+- Current target project is `alsdmlals4-eng/GRIMOIRE-`; other projects are read-only comparison evidence.
+- Project Decision remains `GM-SPELL-WORKFLOW-UI-V2-01`; tool authority remains `GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01`.
+- Task8 product branch remains `feat/task8-spell-use-screen-v2` at local handoff head `8c611f601aa98397ed1558e92ab207e0e8347a9b`; this handoff work does not stage, commit, push, or rewrite that local product delta.
+- Preserve legacy current-state compatibility markers until their existing consumers/tests are intentionally migrated.
+- Do not reset, restore, clean, normalize, or adopt known Task8 representation noise or unrelated untracked artifacts.
+- Base writes are restricted to `[수정제안서]/**`; Base active implementation is forbidden in this stage.
+- New Base proposal status must start as `SUBMITTED`; machine ID/path come from the current Registry/template/validator and must be rechecked against latest Base main and all open proposal PRs immediately before write and merge.
+- The final project continuation state must not create a recursive PR solely to write its own merge SHA.
+
+---
+
+### Task 1: Add a fail-first continuation contract
+
+**Files:**
+- Create: `tests/test_task8_handoff_bcp_continuation.py`
+
+**Interfaces:**
+- Consumes: current `docs/ACTIVE_CONTEXT.md` and `docs/planning/CURRENT_UNRESOLVED_GATES.md`.
+- Produces: exact markers required from the new Sync21 handoff checkpoint.
+
+- [ ] **Step 1: Write the failing unittest**
+
+Require the new Sync ID, exact local Task8 branch/head, observed acceptance evidence, current PR-prep interruption state, Codex-only session reuse rule, Base-candidate pending state, and preservation of legacy current-state compatibility markers.
+
+- [ ] **Step 2: Observe intended RED**
+
+Use the repository Python test route on the test-only head. Expected failure: the new Sync21 document/markers are absent while existing historical compatibility markers remain present.
+
+- [ ] **Step 3: Keep the RED limited to handoff state**
+
+Confirm no `.gd`, `.tscn`, `.uid`, `project.godot`, addon, Task8 artifact, or unrelated source path was changed by the RED commit.
+
+### Task 2: Persist the GRIMOIRE handoff and project-learning application
+
+**Files:**
+- Create: `docs/planning/sync/GR-SYNC-20260812-21-TASK8-HANDOFF-BCP.md`
+- Modify: `docs/ACTIVE_CONTEXT.md`
+- Modify: `docs/planning/CURRENT_UNRESOLVED_GATES.md`
+- Test: `tests/test_task8_handoff_bcp_continuation.py`
+
+**Interfaces:**
+- Consumes: Task8 local acceptance evidence, current remote project/Base/Sheet reads, existing BCP-015 and Base dedicated-local-execution contracts.
+- Produces: one restartable Sync21 checkpoint and a closed project-side learning record.
+
+- [ ] **Step 1: Record current facts without product promotion**
+
+Record project main observed at handoff, exact local Task8 branch/head, no remote Task8 product branch/PR, local acceptance evidence, current PR-prep revalidation requirement, and all preserved NOT_RUN evidence ceilings.
+
+- [ ] **Step 2: Separate historical acceptance from current live readiness**
+
+Preserve the successful exact-project HiGodot/GUT/Hera acceptance evidence as historical/current-work-unit evidence while marking the later empty HiGodot session and interrupted PR-prep as requiring a fresh revalidation before staging.
+
+- [ ] **Step 3: Apply three learning records**
+
+`LRN-GR-20260812-01`: split remote-authority freshness from local-executor verification; classify as `BASE_CANDIDATE` with project application in the handoff route.
+
+`LRN-GR-20260812-02`: hidden/orphan exact-project editor recovery reuses existing BCP-015 and Base dedicated-local-execution contracts; classify as `NO_PROMOTION / REUSE_EXISTING_BCP`.
+
+`LRN-GR-20260812-03`: while an already-established dedicated Codex session remains open, Codex-only continuation may reuse it; a fresh PowerShell is required only when the environment/session must be recreated or a required operation exceeds the current Codex capability boundary. Classify as `PROJECT_ONLY`.
+
+- [ ] **Step 4: Run focused and existing current-state regressions**
+
+Run `python -m unittest tests.test_task8_handoff_bcp_continuation tests.test_spell_workflow_current_state_sync -v`. Expected: PASS while legacy Task8 unmerged/current-next markers remain intact.
+
+### Task 3: Review and merge the project handoff PR
+
+**Files:**
+- Review only the Task 1-2 project delta.
+
+**Interfaces:**
+- Consumes: exact project PR head and current project main.
+- Produces: merged project application evidence for Base proposal provenance.
+
+- [ ] **Step 1: PR influence and scope check**
+
+Require no same-goal open project PR, no product/addon changes, no Task8 local branch mutation, and no unrelated docs/canon migration.
+
+- [ ] **Step 2: Exact-head validation**
+
+Require applicable GitHub checks terminal/success, zero unresolved review threads, exact reviewed head unchanged, and current main freshness.
+
+- [ ] **Step 3: Merge and read back new main**
+
+Merge with expected-head protection, fetch the new project main, verify all handoff files/markers exist, and run the project `POST_CHANGE_MONITOR_LOOP` classification.
+
+### Task 4: Store the reusable Base proposal with concurrency protection
+
+**Files:**
+- Create: `[수정제안서]/<CURRENT_VALID_BCP_ID>/PROPOSAL.md`
+- Modify: `[수정제안서]/PROPOSAL_REGISTRY.json`
+
+**Interfaces:**
+- Consumes: merged GRIMOIRE project application evidence and current Base README/Registry/template/validator/open proposal PRs.
+- Produces: one proposal-only `SUBMITTED` BCP or a `REUSE_EXISTING_BCP / CONCURRENT_SAME_GOAL` result if another chat wins the same goal first.
+
+- [ ] **Step 1: Final identity and same-goal preflight**
+
+Fresh-read Base main, open proposal-only PRs, current Registry, proposal template, validator, and same-goal proposals. Never assume `BCP-2026-021` remains free.
+
+- [ ] **Step 2: Create only the own proposal delta**
+
+If no same-goal proposal exists, create the next current-schema ID/path and append exactly one Registry entry to the latest Registry semantic union. Status is `SUBMITTED`; source project and merged project commit are exact. If another chat already created the same goal, do not create a duplicate top-level BCP.
+
+- [ ] **Step 3: Proposal validation and adversarial review**
+
+Require Proposal file ↔ Registry identity closure, no duplicate ID/path, all required headings, project provenance, counterexamples/non-use/rollback, and changed paths only under `[수정제안서]/**`.
+
+- [ ] **Step 4: Final Base race check and merge**
+
+Immediately before merge, re-read Base main, open proposal PRs, Registry, same-goal state, current exact head/checks/threads. If Base advanced, rebuild only the own delta on latest main and revalidate. Merge proposal-only PR and read back Base new main. Do not implement the proposal.
+
+### Task 5: Close project continuation and Sheet readback
+
+**Files:**
+- Modify existing GRIMOIRE continuation owners only as needed to store the merged Base proposal locator.
+- Update the focused continuation regression accordingly.
+- Update existing Google Sheet continuation/history surfaces after inspecting their current schema.
+
+**Interfaces:**
+- Consumes: merged project handoff evidence, merged Base proposal locator/new main, live Sheet schema.
+- Produces: Learning Closure `CLOSED` and exact next Task8 executable step.
+
+- [ ] **Step 1: Record Base proposal locator without implementation authority**
+
+Store proposal ID/path/PR/Base new main/status, `proposal_storage_merge_authority = GRANTED`, `base_implementation_authority = NOT_GRANTED_IN_THIS_STAGE`, and next action `SEPARATE_FOLLOWUP_STAGE` for any Base implementation.
+
+- [ ] **Step 2: Preserve Task8 unmerged resume contract**
+
+Next executable step remains fresh Codex-local identity/HiGodot/GUT revalidation, followed by exact nine-path stage/commit/push only after those gates pass. Task8 is not marked merged or complete.
+
+- [ ] **Step 3: Merge the final non-recursive closure PR**
+
+Validate and merge once. Do not open a further PR solely to write this closure PR's own merge SHA.
+
+- [ ] **Step 4: Reconcile Google Sheet**
+
+Fresh-read the target ranges and write only current continuation/history data needed to remove stale Base SHA/Task8 handoff markers. Read back the written cells. Do not promote human/device/performance/export/full-slice evidence.
+
+- [ ] **Step 5: Final `POST_CHANGE_MONITOR_LOOP`**
+
+Re-read both repository mains, both open-PR sets, Base proposal registry, project continuation owners, and Sheet. Classify each retained change as `OMISSION | CONFLICT | COMPLEMENT_GAP | DUPLICATE_WORK | NO_MATERIAL_FOLLOWUP` and stop only with no P0/P1 or open Learning Closure item.

--- a/tests/test_task8_handoff_bcp_continuation.py
+++ b/tests/test_task8_handoff_bcp_continuation.py
@@ -1,0 +1,96 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SYNC_ID = "GR-SYNC-20260812-21-TASK8-HANDOFF-BCP"
+LOCAL_BRANCH = "feat/task8-spell-use-screen-v2"
+LOCAL_HEAD = "8c611f601aa98397ed1558e92ab207e0e8347a9b"
+PROJECT_MAIN_AT_HANDOFF = "d1e4d747ee1f28b8a29adcd25726fd975a81d168"
+BASE_MAIN_AT_HANDOFF = "1d6cc79ae95ffb67ba4de618f010a6540fc6e02c"
+LEGACY_TASK8_STATUS = "TASK8_LOCAL_REFINEMENT_GREEN_UNMERGED_MERGE_GATES_PENDING"
+LEGACY_NEXT_GATE = "TASK8_RECEIPT_HERA_REVIEW_PR"
+
+
+class Task8HandoffBcpContinuationTests(unittest.TestCase):
+    def _read(self, relative_path: str) -> str:
+        return (ROOT / relative_path).read_text(encoding="utf-8")
+
+    def test_current_continuation_owners_route_to_sync21_without_product_promotion(self) -> None:
+        for relative_path in (
+            "docs/ACTIVE_CONTEXT.md",
+            "docs/planning/CURRENT_UNRESOLVED_GATES.md",
+        ):
+            with self.subTest(path=relative_path):
+                text = self._read(relative_path)
+                self.assertIn(SYNC_ID, text)
+                self.assertIn("TASK8_LOCAL_ACCEPTANCE_PASS_UNMERGED", text)
+                self.assertIn("TASK8_PR_PREP_REVERIFY_PENDING", text)
+                self.assertIn("CURRENT_DEDICATED_CODEX_REUSE_ALLOWED_FOR_CODEX_ONLY_CONTINUATION", text)
+                self.assertIn(LEGACY_TASK8_STATUS, text)
+                self.assertIn(LEGACY_NEXT_GATE, text)
+                self.assertNotIn("TASK8_MERGED_MAIN_VERIFIED", text)
+
+    def test_sync21_preserves_exact_resume_identity_and_evidence_limits(self) -> None:
+        text = self._read(
+            "docs/planning/sync/GR-SYNC-20260812-21-TASK8-HANDOFF-BCP.md"
+        )
+        for required in (
+            SYNC_ID,
+            LOCAL_BRANCH,
+            LOCAL_HEAD,
+            PROJECT_MAIN_AT_HANDOFF,
+            BASE_MAIN_AT_HANDOFF,
+            "task8-spell-use-screen-v2@b680",
+            "15 tests / 90 assertions / 0 failures",
+            "42 suites / 1,588 assertions / 0 failures",
+            "HERA_SOURCE_DELTA_NONE_OBSERVED",
+            "HISTORICAL_EDIT_OPERATION_RECEIPT_NOT_RETROACTIVELY_PROVABLE",
+            "CODEX_FETCH_HEAD_PERMISSION_DENIED",
+            "CODEX_GITHUB_NETWORK_BLOCKED",
+            "HIGODOT_CURRENT_SESSION_REVALIDATION_REQUIRED",
+            "BASE_PROPOSAL_STATE_PENDING_CONCURRENT_RACE_CHECK",
+            "HUMAN_NOT_RUN",
+            "DEVICE_NOT_RUN",
+            "PERFORMANCE_NOT_RUN",
+            "FULL_VERTICAL_SLICE_NOT_RUN",
+        ):
+            with self.subTest(required=required):
+                self.assertIn(required, text)
+        self.assertNotIn("TASK8_MERGED_MAIN_VERIFIED", text)
+
+    def test_learning_closure_routes_duplicate_runtime_lesson_to_existing_owner(self) -> None:
+        text = self._read(
+            "docs/planning/sync/GR-SYNC-20260812-21-TASK8-HANDOFF-BCP.md"
+        )
+        for required in (
+            "LRN-GR-20260812-01",
+            "BASE_CANDIDATE",
+            "LRN-GR-20260812-02",
+            "REUSE_EXISTING_BCP",
+            "BCP-2026-015-external-runtime-session-same-snapshot-recovery",
+            "LRN-GR-20260812-03",
+            "PROJECT_ONLY",
+            "PROJECT_APPLICATION = APPLIED",
+        ):
+            with self.subTest(required=required):
+                self.assertIn(required, text)
+
+    def test_resume_contract_separates_remote_authority_from_local_executor_capability(self) -> None:
+        text = self._read(
+            "docs/planning/sync/GR-SYNC-20260812-21-TASK8-HANDOFF-BCP.md"
+        )
+        for required in (
+            "REMOTE_AUTHORITY_RECEIPT",
+            "LOCAL_EXECUTION_RECEIPT",
+            "EXECUTOR_CAPABILITY_BLOCKER",
+            "DO_NOT_RETRY_BLOCKED_REMOTE_CHECK_IN_CODEX",
+            "FRESH_GITHUB_CONNECTOR_READBACK_REQUIRED_BEFORE_REMOTE_WRITE",
+            "NO_STAGE_COMMIT_PUSH_DURING_HANDOFF",
+        ):
+            with self.subTest(required=required):
+                self.assertIn(required, text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Goal

Persist a restartable Task8 continuation checkpoint while leaving the local Task8 product delta untouched, then supply project-application evidence for a separate Base proposal-only learning step.

Decisions remain unchanged:
- product: `GM-SPELL-WORKFLOW-UI-V2-01`
- tool authority: `GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01`

## Scope

Changed paths are limited to:
- `.github/workflows/validate-current-state-sync.yml`
- `docs/ACTIVE_CONTEXT.md`
- `docs/planning/CURRENT_UNRESOLVED_GATES.md`
- `docs/planning/sync/GR-SYNC-20260812-21-TASK8-HANDOFF-BCP.md`
- `docs/superpowers/plans/2026-08-12-task8-handoff-bcp-closure.md`
- `tests/test_task8_handoff_bcp_continuation.py`

No `.gd`, `.tscn`, `.uid`, `project.godot`, addon, Task8 local artifact, or unrelated product path is changed.

## TDD evidence

RED head `ca5301a876bc6f3bd1421e14b675c4a6fbbeac45` connected the new focused continuation contract to `Validate Spell Workflow Current-State Sync`. Run #146 failed exactly because Sync21/current-owner markers were not implemented; the pre-existing current-state tests remained green.

GREEN exact reviewed head: `71d0a814043275b9453c9bdb218eac1be9ae31fa`.

- Validate Spell Workflow Current-State Sync: success
- Validate GRIMOIRE planning and Base v9.4.3: success
- Validate Godot Authoring and GUT Authority Gate: success
- Validate Godot 4.7.1 toolchain: success
- Validate visual and platform gates: success
- Validate Star Physical Validation Pack: success
- Validate Star Circuit Runtime POC: first attempt failed while downloading Godot with external HTTP 525; the same exact-head job was re-run without source changes and succeeded through runtime/render evidence
- GUT Formal Adoption Validation: skipped/non-applicable for this docs/test delta; not counted as PASS

## Continuation result

- Task8 product remains `TASK8_LOCAL_ACCEPTANCE_PASS_UNMERGED`.
- exact local product branch/head remain `feat/task8-spell-use-screen-v2` / `8c611f601aa98397ed1558e92ab207e0e8347a9b`.
- no remote Task8 product branch/PR existed at handoff start.
- prior exact-project acceptance checkpoint (`@b680`, Task8 15/90/0, predecessor 42/1588/0, `HERA_SOURCE_DELTA_NONE_OBSERVED`) is preserved as observed evidence.
- current product resume gate is `TASK8_PR_PREP_REVERIFY_PENDING`; a fresh live HiGodot/session/test revalidation is required before product Git writes.
- Codex `FETCH_HEAD` permission denial and GitHub-network failure are recorded as executor capability blockers, not product failures.

## Learning closure in this PR

- `LRN-GR-20260812-01` — `BASE_CANDIDATE`: separate fresh remote-authority receipt from local-executor receipt when a sandbox cannot perform GitHub/shared-metadata operations. Project application is included here; Base proposal storage follows only after this PR merges.
- `LRN-GR-20260812-02` — `NO_PROMOTION / REUSE_EXISTING_BCP`: hidden/orphan exact-project editor recovery reuses BCP-015 plus the dedicated-local-execution contract; no duplicate BCP.
- `LRN-GR-20260812-03` — `PROJECT_ONLY`: an already-established dedicated Codex session may continue Codex-only work; fresh PowerShell remains the default when the environment/session must be recreated or a required operation exceeds current Codex capability.

## Adversarial review

- `DUPLICATE_WORK`: avoided by reusing BCP-015 for runtime-session recovery.
- `CONFLICT`: legacy Task8 compatibility markers are preserved for existing consumers; Sync21 is an explicit continuation overlay rather than a silent rewrite.
- `COMPLEMENT_GAP`: the new focused test is wired into an existing workflow, so the handoff rule has a live CI consumer.
- product-authority leakage: none; no Task8 product file is changed and no merged-product claim is made.
- Base implementation leakage: none; Base work remains a separate proposal-only stage under `[수정제안서]/**`.

## Merge gate

Merge only if the exact head above is unchanged, current main has not advanced incompatibly, all applicable exact-head checks are terminal, unresolved review threads remain zero, and no new same-goal project PR appears. After merge, read back new main and run the project post-change monitor before Base proposal creation.