### PR TITLE
docs(planning): reconcile v4.7 Frostbloom entry canon

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,15 @@ Task 8 Spell Use Screen은 기존 Task 5 Stage 3 권위를 소비하는 UI이며
 - Soft Storybook 배경 + 선명한 Anime Cel 캐릭터.
 - Navy/Gold UI + 고대비 Blue Glyph.
 - 고정 3/4 Field, 같은 장소 Half-body Dialogue, 별도 Battle, Result 후 Field 복귀.
-- 동반 정령·수호 소환수 상태 표현.
+- 고정 주인공 1명, 전투 상시 초상 1개.
+- 동반 정령·수호 소환수 상태 배지.
 - 우측 Writing Panel은 축소 Rail에서 작성 시 확장.
+- Grimoire 파생 화면을 Main보다 먼저 설계한다.
 - AI-generated look을 줄이고 스타일 일관성·가독성·세계관/핵심 시스템 적합성을 우선한다.
+
+잠긴 기준 이미지 SHA-256:
+
+`b55ce1dec6c2521668602d1ce6547526e7f40b8c7c9b6f5276d9289a67f14f7a`
 
 기존 승인·잠금 Visual의 원본은 별도 승인 없이 수정·재생성하지 않습니다.
 

--- a/README.md
+++ b/README.md
@@ -6,21 +6,21 @@
 
 | 항목 | 현재 기준 |
 |---|---|
-| 1차 플랫폼 | `PC` |
-| 후속 플랫폼 | `Mobile` |
-| 엔진 기준 후보 | `Godot 4.7.1 stable` |
 | 제품 단계 | `DEMO_FIRST_VERTICAL_SLICE` |
-| 기획 | `APPROVED` |
-| Art Style | `APPROVED_A_MODIFIED_LOCKED` |
-| Art Bible | `APPROVED_DUAL_STANDARD_ART_BIBLE` |
-| 전투 규칙 | `APPROVED_SITUATION_RESOLUTION_RULES` |
-| 다음 제품 Gate | `ASSET-SPEC-01` |
-| 병행 설계 | `BOSS-PHASE-01` |
-| Codex | `BLOCKED` |
-| 구현 | `NOT_STARTED` |
-| Runtime·사람 검증 | `NOT_RUN` |
+| 현행 Slice | `서리꽃 온실의 심장 / SINGLE_INCIDENT_SPIRAL` |
+| 주문 회로 | `FIVE_POINT_STAR` |
+| Spell Workflow | `Task 3~7 MERGED_MAIN_VERIFIED` |
+| Task 8 | `LOCAL_ACCEPTANCE_PASS_UNMERGED / PR_PREP_REVERIFY_PENDING` |
+| Frostbloom Graybox | `INTERNAL_PACK_PASS` |
+| 제품 Runtime | `PARTIAL_FOUNDATION_IMPLEMENTED` |
+| Human validation | `NOT_RUN` |
+| Device validation | `NOT_RUN` |
+| Performance validation | `NOT_RUN` |
+| Full Vertical Slice validation | `NOT_RUN` |
+| Windows export | `NOT_RUN` |
+| Android export/device | `NOT_RUN` |
 
-저장소에는 아직 실행 가능한 Godot 제품 프로젝트가 없습니다. 외부 Godot 실행 파일은 개발 도구 참고 자료이며 프로젝트 소스나 배포 자산이 아닙니다.
+현재 저장소에는 Godot `4.7.x` 프로젝트와 Star Circuit Runtime POC, Spell Workflow Task 3~7의 병합 구현이 존재합니다. 이는 완성형 제품 Vertical Slice가 끝났다는 뜻이 아닙니다. Task 8 제품 변경은 local acceptance 기록만 있고 `main`에는 아직 병합되지 않았으며, Human/Device/Performance/Export/Full Slice 증거는 계속 `NOT_RUN`입니다.
 
 ## 시작 순서
 
@@ -28,90 +28,172 @@
 2. `START_HERE.md`
 3. `docs/ACTIVE_CONTEXT.md`
 4. `docs/planning/CURRENT_CONFIRMED_DECISIONS.md`
-5. `docs/planning/DECISION_LOG_ADDENDUM_2026-08-01F.md`
-6. `docs/planning/GRIMOIRE_PLANNING_CANON_2026-07-31.md`
-7. `docs/planning/ART_BIBLE_01_APPROVAL_2026-08-01.md`
-8. `docs/planning/BATTLE_RULES_01_APPROVAL_2026-08-01.md`
-9. `docs/DEVELOPMENT_GATES.md`
-10. `docs/DESIGN_DOCUMENT_REGISTRY.json`
+5. `docs/planning/CURRENT_UNRESOLVED_GATES.md`
+6. `docs/planning/FROSTBLOOM_INTERNAL_VERTICAL_SLICE_01_APPROVAL_2026-08-11.md`
+7. `docs/planning/WORLD_CHARACTER_THREE_YEAR_STORY_01_APPROVAL_2026-08-11.md`
+8. `docs/planning/YEAR_ONE_GROWTH_ECONOMY_TEST_VALUES_01_APPROVAL_2026-08-11.md`
+9. `docs/superpowers/specs/2026-08-06-spell-workflow-ui-v2-design.md`
+10. `docs/DEVELOPMENT_GATES.md`
 
-## Vertical Slice
+## 핵심 제품 약속
 
 ```text
-첫 수업·교내 연습
-→ 자유일정 A
-→ 첫 실기시험
-→ 자유일정 B
-→ 학교축제
-→ 자유일정 C
-→ 첫 현장실습
-→ 귀환·마도서 기록
+상황·문맥 읽기
+→ 필요한 의미 판단
+→ 글자 획득·작성
+→ FIVE_POINT_STAR 회로 설계
+→ 주문 Preview·확정
+→ 대상 선택·최종 결과 Preview
+→ 명시적 사용
+→ 불안정도·환경·관계 변화
+→ 결과·대가·발견을 마도서에 기록
+→ 다음 상황에서 학습 적용
 ```
 
-- 목표 `45~50분`, 콘텐츠 상한 `53분`, 하드 상한 `60분`.
-- 글자 `흐름 / 집중 / 분산`.
-- 자유일정 `휴식 / 준비 / 교류`.
-- 직접 작성 성공 7회, 안내형 복구 포함 목표 상한 10회.
-- 메인 동반 정령 초기 형상 1개, 수호형 보조 소환수 1체.
-- 마도서는 해결 과정·결과·부작용·발견을 기록하며 자동 주문 Stock이 아닙니다.
+플레이어는 정답 주문을 단순 소비하는 대신 자신이 이해한 글자 의미와 문맥으로 해결책을 설계합니다. 학교의 `정식`은 절대 진리가 아니라 검증된 안전 선례이며, 플레이어는 `원문 / 정식 / 문맥 / 개정`의 관계를 배우며 무엇을 바꿀 수 있고 무엇을 바꾸지 말아야 하는지 판단합니다.
+
+## 현행 Vertical Slice — 서리꽃 온실의 심장
+
+현재 데모의 사람 플레이 대상은 여러 학교 이벤트를 짧게 훑는 Campus Montage가 아니라 **하나의 사건을 깊게 파는 `SINGLE_INCIDENT_SPIRAL`**입니다.
+
+```text
+서리꽃 온실 사건 진입
+→ 상황·문맥 조사
+→ 제한된 자유 선택과 준비
+→ 글자 획득·작성
+→ FIVE_POINT_STAR 주문 설계·사용
+→ 첫 실제 상태 개선
+→ 과거 개정 흔적 발견
+→ 새 문맥에서 두 번째 주요 판단·주문
+→ 시설·생명·정령·관계·발견 결과
+→ 귀환·마도서 복기
+```
+
+핵심 계약:
+
+- 실제 플레이 목표 `46분`, 콘텐츠 재작업 기준 `53분`, 하드 상한 `60분`.
+- 직접 작성 성공 `7회`, 안내형 복구 포함 상한 `10회`.
+- 조사 노드 `4개 중 2개 선택`; 모든 조합이 합리적 완료를 허용해야 함.
+- 대표 자유일정 창은 `1개`; 네 선택이 특정 정답 하나로 수렴하지 않도록 한다.
+- 주요 FIVE_POINT_STAR Commit 최소 `2회`.
+- 첫 주요 해결은 실제 상태를 개선하며, 이후 옛 개정 기록이 발견되어도 그 선택을 가짜 선택으로 되돌리지 않는다.
+- 강한 정령/압력 Encounter `1개`; mob wave·HP sponge를 기본 구조로 사용하지 않는다.
+- 결과 축: `시설 / 생명 / 정령 / 관계 / 발견`.
+- 학교축제와 장기 커리큘럼은 이 46분 Slice 안에서 플레이하지 않고 장기 제품의 `PREVIEW_ONLY`로 취급한다.
+
+1학년 전체는 별도로 7 Chapter `2 / 2 / 3` 구조를 유지하며, `서리꽃 온실의 심장`은 Chapter 6의 확장 사건과 Internal Slice의 압축 검증판을 구분합니다.
+
+## 주문 언어·회로
+
+현행 주문 설계는 단순 `흐름 / 집중 / 분산` 3종만을 정본으로 사용하지 않습니다.
+
+### Main Glyph 5종
+
+- `HEAT` — 열 발생·전달
+- `FLOW` — 에너지·물질의 이동과 방향 전환
+- `PROTECT` — 보호막·피해 완화
+- `COOL` — 열 제거·과열 진정
+- `MEND` — 균열·파손·구조 손상 회복
+
+### Auxiliary Glyph 5종
+
+- `FOCUS` — 범위를 좁히고 정밀도·성공률 보정
+- `DISPERSE` — 범위를 넓히고 국소 강도 완화
+- `STABILIZE` — 실패 편차·역류 위험 감소
+- `SUSTAIN` — 지속시간 증가와 추가 비용
+- `AMPLIFY` — 출력 증가와 마나·위험 증가
+
+회로는 중앙 Main 정확히 `1` + 외곽 Auxiliary `0~5`의 `FIVE_POINT_STAR`를 사용합니다. Historical `3×3` 회로는 provenance이며 현행 신규 설계 권위가 아닙니다.
+
+## Spell Workflow 구현 경계
+
+```text
+글자 그리기
+→ 회로 배치
+→ 주문 사용
+```
+
+현재 `main`에 병합된 범위:
+
+- Task 3 / PR #104 — immutable `PreparedSpell` + exactly-once inventory
+- Task 4 / PR #105 — Stage 2 atomic glyph preparation
+- Task 5 / PR #106 — Stage 3 target/use atomic transaction
+- Task 6 / PR #108 — glyph drawing workflow screen
+- Task 7 / PR #110 — circuit placement workflow screen
+
+Task 8 Spell Use Screen은 기존 Task 5 Stage 3 권위를 소비하는 UI이며 새 target/use/Mana/result authority를 만들지 않습니다. 과거 local acceptance 증거는 병합 완료 증거가 아니며 현재 remote `main`에는 Task 8 제품 PR이 존재하지 않습니다.
+
+## 전투·상황 해결
+
+```text
+강한 적 또는 불안정한 현상
+→ 공격/위험 Timer 아래 상황 판단·글자 작성
+→ 주문 설계·최종 결과 Preview
+→ 명시적 주문 사용
+→ 불안정도·환경 변화
+→ 진정·해결 또는 다음 압박
+```
+
+- 기본 목표는 HP 0 처치가 아니라 `불안정도 0 → 진정·해결`.
+- 판단·작성 중 Timer는 진행하지만 시스템 해결·연출 중에는 멈춘다.
+- 플레이어 HP 0 또는 선언된 치명적 환경 붕괴는 패배가 될 수 있다.
+- 환경 보존도·부작용·남은 상태·해결 방식이 결과 품질을 바꾼다.
+- 수호 소환수는 다음 공격 피해를 완화하지만 Timer·작성·판단을 대행하지 않는다.
+
+## 마도서
+
+마도서는 자동 주문 Stock이나 정답 목록이 아닙니다.
+
+```text
+관찰·가설
+→ 사용한 글자와 회로
+→ 대상·문맥
+→ 결과
+→ 부작용·대가
+→ 새 발견
+```
+
+을 남기는 학습 기록이며, 이후 사건에서 플레이어가 과거 경험을 근거로 더 나은 결정을 내리게 하는 Meta Loop의 핵심입니다.
+
+## 세계·3년 성장
+
+세계는 `원문 / 정식 / 문맥 / 개정`의 네 층으로 이해합니다.
+
+- 1학년 질문: **정답은 왜 맞는가?**
+- 2학년 질문: **누가 세계를 바꿀 권리가 있는가?**
+- 3학년 질문: **무엇을 바꾸지 않을 책임이 있는가?**
+
+1학년 계열은 `유동학(FLOW) / 변성학(HEAT) / 결계학(PROTECT)`이며 `FOCUS / DISPERSE`는 공통 조율 문법입니다.
 
 ## Art Bible
 
 - Soft Storybook 배경 + 선명한 Anime Cel 캐릭터.
 - Navy/Gold UI + 고대비 Blue Glyph.
 - 고정 3/4 Field, 같은 장소 Half-body Dialogue, 별도 Battle, Result 후 Field 복귀.
-- 고정 주인공 1명, 전투 상시 초상 1개.
-- 동반 정령·수호 소환수 상태 배지.
+- 동반 정령·수호 소환수 상태 표현.
 - 우측 Writing Panel은 축소 Rail에서 작성 시 확장.
-- Grimoire 파생 화면을 Main보다 먼저 설계.
+- AI-generated look을 줄이고 스타일 일관성·가독성·세계관/핵심 시스템 적합성을 우선한다.
 
-잠긴 기준 이미지 SHA-256:
+기존 승인·잠금 Visual의 원본은 별도 승인 없이 수정·재생성하지 않습니다.
 
-`b55ce1dec6c2521668602d1ce6547526e7f40b8c7c9b6f5276d9289a67f14f7a`
+## 현재 구현·검증 원칙
 
-원본은 수정·재생성하지 않습니다.
+- 새 시스템·핵심 규칙·콘텐츠 구조·UX 흐름은 결정 관련 벤치마킹 후 설계한다.
+- 제품 코드·Scene·Resource는 승인된 authoring 경계를 따른다.
+- 시스템-only PoC/자동 테스트를 Human/Player Experience PASS로 승격하지 않는다.
+- Human/Device/Performance/Full Slice 검증을 실제로 실행하기 전까지 `NOT_RUN`을 유지한다.
+- Task 8 제품 구현과 Frostbloom Runtime은 기존 권위를 재사용하며 중복 transaction/Mana/result/save 시스템을 만들지 않는다.
 
-## 전투
-
-```text
-강한 적 1개체·공격 Timer
-→ 우측 글자 작성
-→ [구현]
-→ 마나 검증·즉시 시전
-→ 적 불안정도·환경 변화
-→ 진정 또는 다음 공격
-```
-
-- 일반 적은 단일 페이즈.
-- 판단·작성 중 Timer 진행, 시스템 해결 중 정지.
-- 기본 적은 HP 0 처치가 아니라 `불안정도 0 → 진정·해결`.
-- 플레이어 HP 0 또는 선언된 치명적 환경 붕괴가 패배.
-- 환경 보존도·부작용·남은 HP·해결 방식이 결과 품질을 결정.
-- 수호 소환수는 다음 공격 피해를 완화하지만 Timer·작성·판단을 대행하지 않습니다.
-
-## Base v9.3
-
-- Release Commit: `30ca6c7b5f93521f0eb0eed42d01437cd43c50ae`.
-- Evidence Commit: `462a86db192d23d0f386281a1eb54b0a8cbad62e`.
-- Registry SHA-256: `9847bb2b225c776ad7916930f0f48c490bc2a898bea8e02ea1fdd0e6caac60c1`.
-- Canonical Adapter: `skills/PROJECT_BASE_ADAPTER.json`.
-- Generated View Check: `python tools/generate_project_operating_views.py --check`.
-
-## 작업 원칙
-
-- 새 시스템·핵심 규칙·콘텐츠 구조·UX 흐름은 벤치마킹 후 설계.
-- 주요 변경·승인은 같은 Decision ID로 GitHub 권위 문서·계획 데이터·Google Sheet에 즉시 반영.
-- 작업 브랜치 동기화와 main 병합 상태를 구분.
-- 실행하지 않은 Runtime·성능·접근성·사람 검증을 완료 처리하지 않음.
-- Godot 제품 구현은 Asset Spec·Audio·통합 검수·Codex Plan·기술 검수 뒤 시작.
-
-## 다음 경로
+## 다음 제품 경로
 
 ```text
-ASSET-SPEC-01
-→ BOSS-PHASE-01·Grimoire/Main 파생 화면
-→ AUDIO-DIRECTION-01
-→ 기획·아트 통합 검수
-→ Codex Plan 승인·기술 검수
-→ 구현
+Task 8 PR-prep fresh revalidation
+→ Task 8 exact-head PR / CI / merge / merged-main readback
+→ Task 9 responsive/mobile landscape acceptance
+→ Frostbloom release-near Vertical Slice runtime integration
+→ 실제 후보 UI/아트/애니메이션/VFX/음악/SFX 연결
+→ Human usability + Player experience evidence
+→ Windows/Android delivery validation
 ```
+
+기획 단계에서는 위 구현 경로를 실행 완료로 간주하지 않습니다.

--- a/docs/planning/sync/GR-SYNC-20260820-22-V47-ENTRY-RECONCILIATION.md
+++ b/docs/planning/sync/GR-SYNC-20260820-22-V47-ENTRY-RECONCILIATION.md
@@ -20,6 +20,7 @@ human_validation: NOT_RUN
 device_validation: NOT_RUN
 performance_validation: NOT_RUN
 full_slice_validation: NOT_RUN
+notion_sync: PASS_READBACK
 ```
 
 ## 1. 승인 재확인
@@ -69,7 +70,7 @@ spell_workflow_task8: LOCAL_ACCEPTANCE_PASS_UNMERGED
 - `GRIMOIRE::LOOP::VERTICAL_SLICE_SCHEDULE` — Campus Montage 45~50분 구조
 - `GRIMOIRE::SYSTEM::CORE_GLYPHS` — `흐름 / 집중 / 분산` 3종만 current처럼 표시
 
-두 항목은 repository current decision과 충돌한다. Notion은 사람용 정본이므로 repository sync/merge 뒤 같은 결정 의미로 정리하고 destination readback한다.
+두 항목은 repository current decision과 충돌했다. Notion은 사람용 정본이므로 같은 승인 의미로 정리하고 destination readback했다.
 
 ## 4. 최소 3개 대안
 
@@ -189,14 +190,38 @@ GREEN target:
 
 그 전에는 Campus Montage를 복구하지 않는다.
 
-## 10. Notion sync target
+## 10. Notion sync / readback
 
-Repository merge/readback 뒤:
+2026-08-20 KST에 repository current canon을 기준으로 사람용 stale consumer를 직접 동기화하고 destination readback했다.
 
-- Project Home — 현재 Slice/부분 구현 상태 표현 확인
-- `GRIMOIRE::LOOP::VERTICAL_SLICE_SCHEDULE` — Frostbloom Single-Incident로 수정
-- `GRIMOIRE::SYSTEM::CORE_GLYPHS` — Main 5 + Auxiliary 5 / FIVE_POINT_STAR grammar로 수정
-- destination readback 필수
+### Project Home
+
+- page: `GRIMOIRE: 세계를 다시 쓰는 법`
+- 기획: `APPROVED · Frostbloom SINGLE_INCIDENT_SPIRAL current`
+- 구현: `PARTIAL FOUNDATION · Spell Workflow Task 3~7 merged / Task 8 unmerged`
+- Runtime: `Star Circuit POC exists · Full Vertical Slice NOT_RUN`
+- Human / Device / Performance: `NOT_RUN`
+- result: `PASS_READBACK`
+
+### Core System — Vertical Slice 일정
+
+- Record Key: `GRIMOIRE::LOOP::VERTICAL_SLICE_SCHEDULE`
+- Revision: `2`
+- Summary: `서리꽃 온실의 심장 하나를 깊게 파는 46분 SINGLE_INCIDENT_SPIRAL Vertical Slice.`
+- FIVE_POINT_STAR / first real improvement / old revision / five-axis result / Grimoire review를 한 사건 흐름으로 반영
+- Festival / long curriculum: `PREVIEW_ONLY`
+- result: `PASS_READBACK`
+
+### Core System — 주문 글자 문법
+
+- Record Key: `GRIMOIRE::SYSTEM::CORE_GLYPHS`
+- Revision: `2`
+- Main: `HEAT / FLOW / PROTECT / COOL / MEND`
+- Auxiliary: `FOCUS / DISPERSE / STABILIZE / SUSTAIN / AMPLIFY`
+- topology: `FIVE_POINT_STAR center Main exactly 1 + Auxiliary 0..5`
+- result: `PASS_READBACK`
+
+Notion은 이 동기화로 새 product behavior authority를 만들지 않는다. Source SHA는 동기화 시점 repository main `ca5d004b42e19f775163188da18020de4d5aa2e7`이며, GitHub PR #138은 그 이미 존재하는 current structured canon을 README/consumer에서 정합화하는 작업이다.
 
 ## 11. Next planning axis
 
@@ -214,3 +239,21 @@ Repository merge/readback 뒤:
 ```
 
 다음 중요한 사용자 결정이 나오기 전까지 세부 수치·표현은 가역적 권장안으로 다룬다.
+
+## 12. Validation state
+
+```yaml
+adversarial_full_loops_completed: 5
+validated_findings:
+  - RESTORE_LOCKED_ART_BIBLE_HASH_AND_PROTECTED_DETAILS
+  - CLARIFY_RECONCILIATION_NOT_NEW_PRODUCT_DECISION
+  - STRENGTHEN_README_REGRESSION_GUARDS
+  - CONFIRM_MAIN_UNCHANGED_DURING_REVIEW
+  - CONFIRM_ONLY_CURRENT_PR_OPEN
+local_clean_checkout_test: NOT_RUN_NETWORK_BLOCKED
+remote_github_actions: PENDING_NO_RUN_SURFACED
+merge: BLOCKED_UNTIL_REMOTE_CI_EVIDENCE
+notion_readback: PASS
+```
+
+Remote CI가 확인되기 전에는 PR #138을 병합 완료로 주장하지 않는다.

--- a/docs/planning/sync/GR-SYNC-20260820-22-V47-ENTRY-RECONCILIATION.md
+++ b/docs/planning/sync/GR-SYNC-20260820-22-V47-ENTRY-RECONCILIATION.md
@@ -1,0 +1,209 @@
+# GR-SYNC-20260820-22 — v4.7 Entry Reconciliation
+
+```yaml
+sync_id: GR-SYNC-20260820-22-V47-ENTRY-RECONCILIATION
+decision_id: GM-V47-ENTRY-01
+project: "GRIMOIRE: 세계를 다시 쓰는 법"
+date_kst: 2026-08-20
+work_mode: PLAN
+approval: USER_APPROVED_RECOMMENDED_OPTION
+product_behavior_change: NONE
+canon_reconciliation: REQUIRED
+persistent_godot_mutation: NONE
+src_scene_resource_asset_mutation: NONE
+task8_local_workstream_mutation: NONE
+human_validation: NOT_RUN
+device_validation: NOT_RUN
+performance_validation: NOT_RUN
+full_slice_validation: NOT_RUN
+```
+
+## 1. 결정
+
+사용자는 2026-08-20 KST에 다음 권장안을 승인했다.
+
+> 완성형 데모/Vertical Slice의 현행 정본은 `GM-FROSTBLOOM-INTERNAL-VERTICAL-SLICE-01`의 `서리꽃 온실의 심장 / SINGLE_INCIDENT_SPIRAL`을 유지한다. 과거 `첫 수업 → 자유일정 → 실기시험 → 축제 → 현장실습` Campus Montage는 현재 46분 Slice의 플레이 구조로 사용하지 않고, 장기 학교생활/1학년 커리큘럼의 참고·Preview 범위로만 남긴다.
+
+이 결정은 새 Slice를 만드는 것이 아니라 이미 승인된 최신 GitHub structured canon을 사용자 재확인으로 잠그고, 오래된 lower consumer를 정리하는 reconciliation이다.
+
+## 2. Authority recovery
+
+작업 시작 관찰:
+
+```yaml
+base_main: 8553678f70e22f193a2336b591f677dcfa5a8965
+project_main: ca5d004b42e19f775163188da18020de4d5aa2e7
+open_project_prs_before_current_work: 0
+current_planning_owner: GM-FROSTBLOOM-INTERNAL-VERTICAL-SLICE-01
+slice_model: SINGLE_INCIDENT_SPIRAL
+frostbloom_graybox_status: INTERNAL_PACK_PASS
+spell_workflow_merged: TASK3_TO_TASK7
+spell_workflow_task8: LOCAL_ACCEPTANCE_PASS_UNMERGED
+```
+
+`CURRENT_CONFIRMED_DECISIONS.md`는 이미 Frostbloom `SINGLE_INCIDENT_SPIRAL`, `festival: PREVIEW_ONLY`, `FIVE_POINT_STAR`, Human/Device/Performance/Full Slice `NOT_RUN`을 current planning decision으로 소유하므로 새 제품 Decision으로 대체하지 않는다.
+
+## 3. 발견된 stale consumer
+
+### README
+
+작업 시작 README는 다음 오래된 주장을 포함했다.
+
+- 저장소에 실행 가능한 Godot 제품 프로젝트가 없다는 주장
+- 구현 `NOT_STARTED`
+- Campus Montage를 현행 Vertical Slice로 제시
+- 기초 글자 `흐름 / 집중 / 분산`만을 Slice 정본으로 제시
+
+실제 repository에는 `project.godot`, Star Circuit Runtime POC, Spell Workflow Task3~7 merged implementation이 존재하고, current planning canon은 Frostbloom Single-Incident + FIVE_POINT_STAR다.
+
+### Notion human-facing consumers
+
+관찰된 오래된 Notion Core System records:
+
+- `GRIMOIRE::LOOP::VERTICAL_SLICE_SCHEDULE` — Campus Montage 45~50분 구조
+- `GRIMOIRE::SYSTEM::CORE_GLYPHS` — `흐름 / 집중 / 분산` 3종만 current처럼 표시
+
+두 항목은 repository current decision과 충돌한다. Notion은 사람용 정본이므로 repository sync/merge 뒤 같은 결정 의미로 정리하고 destination readback한다.
+
+## 4. 최소 3개 대안
+
+### A. Frostbloom Single-Incident 유지 — 승인
+
+- 한 사건 안에서 조사 → 의미 추론 → 글자 → FIVE_POINT_STAR → 대상/위험 판단 → 결과 → 마도서 복기를 반복한다.
+- 최신 승인 canon을 보존한다.
+- 핵심 재미의 반복 밀도가 가장 높다.
+- 제작 범위와 QA 범위를 통제하기 쉽다.
+
+### B. Campus Montage 복귀 — 제외
+
+- 학교생활 폭은 빠르게 보여줄 수 있다.
+- 그러나 수업/시험/축제/현장실습 간 context switch가 많아 각 핵심 시스템의 깊은 검증이 약해진다.
+- 최신 승인 Frostbloom canon을 되돌리는 비용이 발생한다.
+
+### C. 짧은 학교 프롤로그 + Frostbloom Hybrid — 재검토 후보
+
+- 학교 판타지 노출을 강화할 수 있다.
+- 하지만 현재 Slice 범위를 늘리고 새 content/presentation dependency를 만든다.
+- 실제 Human test에서 `마법 시스템은 이해하지만 마법학교 RPG 정체성이 전달되지 않는다`는 반복 증거가 생길 때만 재검토한다.
+
+## 5. Benchmark / industry research
+
+2026-08-20 current official-source recheck:
+
+### Chants of Sennaar — ADAPT
+
+Source: https://www.focus-entmt.com/en/news/chants-of-sennaar-shows-its-details-in-a-gameplay-overview-and-offers-a-free-demo-to-all-players
+
+- glyph 의미를 관찰·대화·문맥에서 추론하고 notebook을 통해 학습을 축적한다.
+- GRIMOIRE에는 `문맥에서 의미 추론 → 마도서 기록 → 다음 상황에 적용` 원리를 ADAPT한다.
+- 단일 정답 번역 퍼즐 구조를 그대로 복제하지 않는다.
+
+### Magicka — ADAPT
+
+Source: https://www.paradoxinteractive.com/games/magicka/about
+
+- 요소를 조합해 즉시 spell 결과를 확인하는 dynamic spellcasting을 제공한다.
+- GRIMOIRE에는 `소수 문법 요소의 조합 실험 + 빠른 결과 피드백`을 ADAPT한다.
+- 수천 조합의 action-comedy 폭증과 friendly-fire 중심 구조는 AVOID한다.
+
+### Baba Is You — REFERENCE_ONLY / ADAPT principle
+
+Source: https://www.hempuli.com/baba/
+
+- 규칙 자체를 조작하고 세계의 반응을 즉시 확인한다.
+- GRIMOIRE에는 `내 규칙 변경이 세계 상태 변화로 즉시 읽힌다`는 피드백 원리를 참고한다.
+- 하나의 정확한 문장/정답을 찾는 퍼즐 구조는 현재 핵심 자유도를 약화할 수 있어 직접 채택하지 않는다.
+
+### BOOK OF HOURS — ADAPT meta loop
+
+Source: https://weatherfactory.biz/book-of-hours/
+
+- 책·지식·역사를 수집·연구·정리하는 행위가 진행 경험을 만든다.
+- GRIMOIRE에는 마도서를 단순 Stock이 아니라 `가설/시도/결과/발견` 지식 축적으로 만드는 Meta Loop 원리를 ADAPT한다.
+- 본편 전투/상황 해결을 느리게 만드는 대량 수동 카탈로그 작업은 AVOID한다.
+
+## 6. Creative synthesis
+
+```yaml
+fun_hypothesis: "배운 마법 문법을 한 사건의 서로 다른 문맥에 다시 적용하며, 내 판단이 실제 세계 상태와 마도서 기록을 바꾸는 것이 재미의 핵심이다."
+core_tension_or_delight: "정답을 아는가가 아니라, 제한된 정보에서 무엇을 보호하고 어떤 부작용을 감수할지 결정한다."
+meaningful_choice: "조사 정보 선택 + Main/Auxiliary 조합 + 대상 + 위험/비용 Commit"
+player_expression: "동일 사건을 서로 다른 합리적 주문/보호 우선순위로 해결"
+discovery_or_surprise: "첫 해결 뒤 과거 개정 흔적이 새 문맥을 제공하지만 기존 선택을 가짜로 만들지 않음"
+novelty_delta: "언어 추론 + 주문 조합 + 규칙 변화 + 지식 기록을 마법학교 책임/윤리 성장에 묶음"
+clone_or_trade_dress_risk: LOW_IF_PRINCIPLES_ONLY
+player_evidence_status: NOT_RUN
+```
+
+## 7. TDD / acceptance-first
+
+RED contract first:
+
+`tests/test_frostbloom_internal_vertical_slice_contract.py`에 README current-consumer 회귀 조건을 먼저 추가했다.
+
+RED reason:
+
+- 기존 README에 Campus Montage 문자열 존재
+- 기존 README에 `저장소에는 아직 실행 가능한 Godot 제품 프로젝트가 없습니다.` 존재
+- 기존 README에 `| 구현 | NOT_STARTED |` 의미 존재
+- current Single-Incident/Task3~8 상태가 사람용 시작 문서에 반영되지 않음
+
+GREEN target:
+
+- README가 `서리꽃 온실의 심장 / SINGLE_INCIDENT_SPIRAL`을 현행 Slice로 표시
+- `FIVE_POINT_STAR`와 current spell grammar를 표시
+- Task3~7 merged / Task8 unmerged 경계를 과장 없이 표시
+- Human/Device/Performance/Full Slice `NOT_RUN` 유지
+- stale Campus Montage를 현행 Slice로 다시 노출하지 않음
+
+## 8. 보호 범위
+
+변경 금지:
+
+- `src/**`
+- Godot Scene/Resource
+- `project.godot`
+- addons/vendor
+- Task8 local branch/delta
+- FIVE_POINT_STAR runtime authority
+- Mana/inventory/result/save transaction ownership
+- approved locked Visual originals
+- Human/Device/Performance/Export evidence ceilings
+
+## 9. Long-term fit / revisit
+
+승인안 A는 release-near Slice에서 핵심 시스템을 반복 검증하는 데 가장 적합하다.
+
+재검토 조건:
+
+1. 실제 Human playtest에서 다수 관찰자가 주문 시스템은 이해하지만 `마법학교 성장 RPG`라는 제품 판타지를 식별하지 못한다.
+2. 첫 10~15분에 학교/인물/학습 맥락이 없어 주문 행위가 무맥락 퍼즐처럼 느껴진다는 반복 증거가 생긴다.
+3. 짧은 프롤로그 추가가 Slice 총 길이/콘텐츠 비용을 거의 늘리지 않고 정체성 이해를 유의하게 개선한다는 evidence가 생긴다.
+
+그 전에는 Campus Montage를 복구하지 않는다.
+
+## 10. Notion sync target
+
+Repository merge/readback 뒤:
+
+- Project Home — 현재 Slice/부분 구현 상태 표현 확인
+- `GRIMOIRE::LOOP::VERTICAL_SLICE_SCHEDULE` — Frostbloom Single-Incident로 수정
+- `GRIMOIRE::SYSTEM::CORE_GLYPHS` — Main 5 + Auxiliary 5 / FIVE_POINT_STAR grammar로 수정
+- destination readback 필수
+
+## 11. Next planning axis
+
+이 reconciliation 이후 다음 기획은 구현 Task8 자체가 아니라 **완성형 Frostbloom 첫 세션의 플레이어 경험 구조**를 우선 정교화한다.
+
+```text
+대표 문제
+→ 플레이어가 처음 읽는 정보
+→ 첫 의미 추론
+→ 첫 글자 획득/작성
+→ 첫 FIVE_POINT_STAR 설계
+→ 첫 결과/부작용
+→ 첫 마도서 기록
+→ 두 번째 상황에서 배운 규칙의 전이
+```
+
+다음 중요한 사용자 결정이 나오기 전까지 세부 수치·표현은 가역적 권장안으로 다룬다.

--- a/docs/planning/sync/GR-SYNC-20260820-22-V47-ENTRY-RECONCILIATION.md
+++ b/docs/planning/sync/GR-SYNC-20260820-22-V47-ENTRY-RECONCILIATION.md
@@ -2,13 +2,17 @@
 
 ```yaml
 sync_id: GR-SYNC-20260820-22-V47-ENTRY-RECONCILIATION
-decision_id: GM-V47-ENTRY-01
+reconciliation_id: GM-V47-ENTRY-01
+existing_product_decision_owner: GM-FROSTBLOOM-INTERNAL-VERTICAL-SLICE-01
 project: "GRIMOIRE: 세계를 다시 쓰는 법"
 date_kst: 2026-08-20
 work_mode: PLAN
 approval: USER_APPROVED_RECOMMENDED_OPTION
+product_decision_change: NONE
 product_behavior_change: NONE
 canon_reconciliation: REQUIRED
+current_conversation_execution_contract: USER_SUPPLIED_V4_7
+repository_contract_binding_mutation: NONE_IN_THIS_RECONCILIATION
 persistent_godot_mutation: NONE
 src_scene_resource_asset_mutation: NONE
 task8_local_workstream_mutation: NONE
@@ -18,13 +22,15 @@ performance_validation: NOT_RUN
 full_slice_validation: NOT_RUN
 ```
 
-## 1. 결정
+## 1. 승인 재확인
 
 사용자는 2026-08-20 KST에 다음 권장안을 승인했다.
 
 > 완성형 데모/Vertical Slice의 현행 정본은 `GM-FROSTBLOOM-INTERNAL-VERTICAL-SLICE-01`의 `서리꽃 온실의 심장 / SINGLE_INCIDENT_SPIRAL`을 유지한다. 과거 `첫 수업 → 자유일정 → 실기시험 → 축제 → 현장실습` Campus Montage는 현재 46분 Slice의 플레이 구조로 사용하지 않고, 장기 학교생활/1학년 커리큘럼의 참고·Preview 범위로만 남긴다.
 
-이 결정은 새 Slice를 만드는 것이 아니라 이미 승인된 최신 GitHub structured canon을 사용자 재확인으로 잠그고, 오래된 lower consumer를 정리하는 reconciliation이다.
+이 승인은 새 Slice나 새 제품 Decision을 만드는 것이 아니다. 이미 승인된 최신 GitHub structured canon을 사용자가 재확인하고 오래된 lower consumer를 정리하도록 허용한 reconciliation이다. 제품 의미의 owner는 계속 `GM-FROSTBLOOM-INTERNAL-VERTICAL-SLICE-01`이다.
+
+현재 대화 실행에는 사용자가 제공한 `PROJECT_TOTAL_PLANNING_IMPLEMENTATION_AND_DELIVERY_INSTRUCTION_v4.7`을 적용한다. 저장소에 남아 있는 v4.5 r2 계약 바인딩 자체를 이 reconciliation에서 별도 migration하지는 않는다.
 
 ## 2. Authority recovery
 
@@ -41,7 +47,7 @@ spell_workflow_merged: TASK3_TO_TASK7
 spell_workflow_task8: LOCAL_ACCEPTANCE_PASS_UNMERGED
 ```
 
-`CURRENT_CONFIRMED_DECISIONS.md`는 이미 Frostbloom `SINGLE_INCIDENT_SPIRAL`, `festival: PREVIEW_ONLY`, `FIVE_POINT_STAR`, Human/Device/Performance/Full Slice `NOT_RUN`을 current planning decision으로 소유하므로 새 제품 Decision으로 대체하지 않는다.
+`CURRENT_CONFIRMED_DECISIONS.md`는 이미 Frostbloom `SINGLE_INCIDENT_SPIRAL`, `festival: PREVIEW_ONLY`, `FIVE_POINT_STAR`, Human/Device/Performance/Full Slice `NOT_RUN`을 current planning decision으로 소유한다. 따라서 이 파일에 중복된 새 제품 Decision을 만들지 않는다.
 
 ## 3. 발견된 stale consumer
 
@@ -155,6 +161,7 @@ GREEN target:
 - Task3~7 merged / Task8 unmerged 경계를 과장 없이 표시
 - Human/Device/Performance/Full Slice `NOT_RUN` 유지
 - stale Campus Montage를 현행 Slice로 다시 노출하지 않음
+- 기존 승인·잠금 Art Bible 핵심과 기준 이미지 SHA를 보존
 
 ## 8. 보호 범위
 

--- a/tests/test_frostbloom_internal_vertical_slice_contract.py
+++ b/tests/test_frostbloom_internal_vertical_slice_contract.py
@@ -45,11 +45,15 @@ class FrostbloomInternalVerticalSliceContractTests(unittest.TestCase):
     def test_readme_uses_current_single_incident_slice(self):
         text = README.read_text(encoding="utf-8")
         for token in (
-            "서리꽃 온실의 심장",
-            "SINGLE_INCIDENT_SPIRAL",
+            "서리꽃 온실의 심장 / SINGLE_INCIDENT_SPIRAL",
             "FIVE_POINT_STAR",
-            "Task 3~7",
-            "Task 8",
+            "Task 3~7 MERGED_MAIN_VERIFIED",
+            "LOCAL_ACCEPTANCE_PASS_UNMERGED / PR_PREP_REVERIFY_PENDING",
+            "Human validation | `NOT_RUN`",
+            "Device validation | `NOT_RUN`",
+            "Performance validation | `NOT_RUN`",
+            "Full Vertical Slice validation | `NOT_RUN`",
+            "b55ce1dec6c2521668602d1ce6547526e7f40b8c7c9b6f5276d9289a67f14f7a",
         ):
             self.assertIn(token, text)
         for stale in (

--- a/tests/test_frostbloom_internal_vertical_slice_contract.py
+++ b/tests/test_frostbloom_internal_vertical_slice_contract.py
@@ -5,11 +5,12 @@ ROOT = Path(__file__).resolve().parents[1]
 CANON = ROOT / "docs/planning/FROSTBLOOM_INTERNAL_VERTICAL_SLICE_01_APPROVAL_2026-08-11.md"
 BENCH = ROOT / "docs/planning/FROSTBLOOM_INTERNAL_VERTICAL_SLICE_IMPLEMENTATION_BENCHMARK_2026-08-11.md"
 PLAN = ROOT / "docs/superpowers/plans/2026-08-11-frostbloom-internal-vertical-slice-implementation-plan.md"
+README = ROOT / "README.md"
 
 
 class FrostbloomInternalVerticalSliceContractTests(unittest.TestCase):
     def test_required_planning_artifacts_exist(self):
-        for path in (CANON, BENCH, PLAN):
+        for path in (CANON, BENCH, PLAN, README):
             self.assertTrue(path.is_file(), path)
 
     def test_approved_slice_contract_tokens(self):
@@ -40,6 +41,24 @@ class FrostbloomInternalVerticalSliceContractTests(unittest.TestCase):
         self.assertIn("첫 `W6` 주요 해결은 반드시 실제 상태를 개선", text)
         self.assertIn("정답 루트 버튼으로 노출하지 않는다", text)
         self.assertIn("Historical 3×3", text)
+
+    def test_readme_uses_current_single_incident_slice(self):
+        text = README.read_text(encoding="utf-8")
+        for token in (
+            "서리꽃 온실의 심장",
+            "SINGLE_INCIDENT_SPIRAL",
+            "FIVE_POINT_STAR",
+            "Task 3~7",
+            "Task 8",
+        ):
+            self.assertIn(token, text)
+        for stale in (
+            "첫 수업·교내 연습\n→ 자유일정 A\n→ 첫 실기시험",
+            "학교축제\n→ 자유일정 C\n→ 첫 현장실습",
+            "저장소에는 아직 실행 가능한 Godot 제품 프로젝트가 없습니다.",
+            "| 구현 | `NOT_STARTED` |",
+        ):
+            self.assertNotIn(stale, text)
 
     def test_benchmark_was_performed_before_plan(self):
         text = BENCH.read_text(encoding="utf-8")


### PR DESCRIPTION
## Goal

Reconcile stale human-facing GRIMOIRE planning consumers with the already-approved `GM-FROSTBLOOM-INTERNAL-VERTICAL-SLICE-01` / `SINGLE_INCIDENT_SPIRAL` direction after the user's `GM-V47-ENTRY-01` reaffirmation.

## Scope

Planning/docs/tests only. No `src/`, Scene, Resource, addon, `project.godot`, Task8 local branch, runtime behavior, asset, or balance mutation.

## TDD

The first commit is intentionally RED: the existing Frostbloom planning contract now requires README to reflect the current Single-Incident slice and actual Task3~7/Task8 implementation boundary. The stale README still advertises the older campus montage and `NOT_STARTED` product state.

## Protected decisions

- `GM-FROSTBLOOM-INTERNAL-VERTICAL-SLICE-01`
- `GM-SPELL-WORKFLOW-UI-V2-01`
- `GM-STAR-CIRCUIT-MASTERY-BALANCE-01`
- `FIVE_POINT_STAR`
- Human/device/performance/full-slice evidence remains `NOT_RUN`.

## Next

After RED confirmation: minimally update stale README/current human-facing Notion consumers, add reconciliation evidence, rerun exact-head CI, adversarial review, then merge if all gates are clean.