### PR TITLE
chore: adopt Base reuse profile manifest

### DIFF
--- a/docs/base-reuse-adoption.json
+++ b/docs/base-reuse-adoption.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "base_source_commit": "8553678f70e22f193a2336b591f677dcfa5a8965",
+  "modules": {
+    "RM-TOOL-001": {"state": "planned"},
+    "RM-SYS-001": {"state": "not_applicable"},
+    "RM-SYS-003": {"state": "planned"},
+    "RM-VIS-001": {"state": "planned"},
+    "RM-VIS-002": {"state": "planned"}
+  }
+}

--- a/tests/test_base_v9_adoption.py
+++ b/tests/test_base_v9_adoption.py
@@ -62,5 +62,29 @@ class BaseV943AdoptionTests(unittest.TestCase):
         ):
             self.assertTrue((ROOT / path).is_file(), path)
 
+    def test_base_reuse_adoption_manifest_is_project_bounded(self) -> None:
+        manifest = load("docs/base-reuse-adoption.json")
+        self.assertEqual(1, manifest["schema_version"])
+        self.assertEqual(
+            "8553678f70e22f193a2336b591f677dcfa5a8965",
+            manifest["base_source_commit"],
+        )
+        states = {
+            module_id: config["state"]
+            for module_id, config in manifest["modules"].items()
+        }
+        self.assertEqual(
+            {
+                "RM-TOOL-001": "planned",
+                "RM-SYS-001": "not_applicable",
+                "RM-SYS-003": "planned",
+                "RM-VIS-001": "planned",
+                "RM-VIS-002": "planned",
+            },
+            states,
+        )
+        self.assertEqual("not_applicable", states["RM-SYS-001"])
+        self.assertNotIn("enabled", states.values())
+
 
 if __name__ == "__main__": unittest.main()


### PR DESCRIPTION
## Goal
Install the Base reusable-module adoption profile in GRIMOIRE without changing the current FIVE_POINT_STAR runtime, explicit Commit semantics, scenes, data, assets, or project.godot.

## Scope
Manifest-only adoption infrastructure. P0 modules remain `planned` except Grid=`not_applicable`; no reusable runtime source is vendored because this bounded change has no approved runtime consumer.

## TDD evidence
- RED exact head `4f284ca08d543fc9c2d3afc7c23b278dbd8939c2`: `Validate GRIMOIRE planning and Base v9.4.3` failed at workflow-consumed `python -m unittest tests.test_base_v9_adoption` because `docs/base-reuse-adoption.json` was absent.
- GREEN exact head `f2971b0273a7eca1c6e3c59b346d72467bdce016`:
  - Validate GRIMOIRE planning and Base v9.4.3: SUCCESS
  - Validate Godot 4.7.1 toolchain: SUCCESS
  - Validate Star Circuit Runtime POC: SUCCESS
  - Validate Star Physical Validation Pack: SUCCESS
  - Validate Godot Authoring and GUT Authority Gate: SUCCESS
  - Validate Spell Workflow Current-State Sync: SUCCESS

## Change
- add `docs/base-reuse-adoption.json`
- extend existing Base v9 adoption regression with the manifest contract

## Boundary
No `src/`, `scenes/`, `data/`, `assets/`, `addons/`, `project.godot`, FIVE_POINT_STAR runtime, target/commit semantics, balance, save, or visual canon changes.

## Merge gate
Current main remains `293cde60ca19bfa6528b90807f7f4622037f2dd0`; unresolved review threads 0. Squash merge only if exact head remains `f2971b0273a7eca1c6e3c59b346d72467bdce016`.