### PR TITLE
docs(planning): lock portfolio preview evidence echo

### DIFF
--- a/data/testing/frostbloom_portfolio_preview_v1.json
+++ b/data/testing/frostbloom_portfolio_preview_v1.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": 1,
+  "fixture_id": "FROSTBLOOM_PORTFOLIO_PREVIEW_V1",
+  "decision_id": "GM-FROSTBLOOM-PORTFOLIO-PREVIEW-EVIDENCE-ECHO-01",
+  "parent_decision": "GM-FROSTBLOOM-INTERNAL-VERTICAL-SLICE-01",
+  "predecessor_refinement": "GM-FROSTBLOOM-RESULT-GRIMOIRE-CAUSAL-DEBRIEF-01",
+  "segment": {
+    "start_minute": 44,
+    "end_minute": 46
+  },
+  "contract": "EVIDENCE_ECHO_ONE_OPEN_QUESTION",
+  "mentor_echo": {
+    "contract": "MENTOR_RESPONSE_DESCRIPTIVE_NOT_VERDICT",
+    "max_echo_elements": 3,
+    "actual_receipts_only": true,
+    "allowed_echo_slots": [
+      "PLAYER_PRINCIPLE",
+      "ACTUAL_IMPROVEMENT_OR_COST",
+      "DISCOVERY_OR_UNRESOLVED_TENSION"
+    ],
+    "can_add_new_fact": false,
+    "can_grade": false,
+    "can_rescore_result": false,
+    "can_recommend_hidden_best_answer": false,
+    "hidden_portfolio_score": false
+  },
+  "portfolio_receipt": {
+    "contract": "PORTFOLIO_RECEIPT",
+    "fields": [
+      "principle_saved",
+      "causal_evidence_linked",
+      "unresolved_tension_carried"
+    ],
+    "replays_five_axis_result": false,
+    "replays_full_causal_thread": false,
+    "adds_grade": false,
+    "adds_reward_track": false
+  },
+  "open_question": {
+    "contract": "OPEN_QUESTION_NOT_OBJECTIVE",
+    "source_scope": "OBSERVED_DISCOVERY_OR_REMAINING_UNCERTAINTY_ONLY",
+    "count": 1,
+    "quest_marker": false,
+    "reward": false,
+    "required_tracking": false,
+    "choice_branch": false,
+    "mandatory_followup": false
+  },
+  "festival": {
+    "contract": "FESTIVAL_PREVIEW_ONLY",
+    "glimpse_count": 1,
+    "allowed_channels": [
+      "VISUAL",
+      "AUDIO",
+      "SHORT_DIALOGUE"
+    ],
+    "playable": false,
+    "starts_second_incident": false,
+    "starts_new_tutorial": false,
+    "introduces_required_system": false,
+    "lore_dump": false
+  },
+  "session_end": {
+    "contract": "NO_NEW_GAMEPLAY_DECISION",
+    "allowed_input_role": "SESSION_CLOSE_CONFIRMATION_ONLY",
+    "new_gameplay_decision": false,
+    "next_quest_choice": false,
+    "new_branch_selection": false
+  },
+  "timing_test_values": [
+    {
+      "phase": "MAREN_EVIDENCE_ECHO",
+      "start": "44:00",
+      "end": "44:40"
+    },
+    {
+      "phase": "PORTFOLIO_RECEIPT",
+      "start": "44:40",
+      "end": "45:10"
+    },
+    {
+      "phase": "OPEN_QUESTION_FESTIVAL_GLIMPSE",
+      "start": "45:10",
+      "end": "46:00"
+    }
+  ],
+  "hard_guards": [
+    "NO_MENTOR_GRADE",
+    "NO_RESULT_RESCORING",
+    "NO_HIDDEN_PORTFOLIO_SCORE",
+    "NO_HIDDEN_BEST_ANSWER",
+    "OPEN_QUESTION_NOT_OBJECTIVE",
+    "NO_NEXT_QUEST_CHOICE",
+    "FESTIVAL_PREVIEW_ONLY",
+    "NO_SECOND_INCIDENT",
+    "NO_NEW_TUTORIAL",
+    "NO_LORE_DUMP",
+    "NO_NEW_GAMEPLAY_DECISION"
+  ],
+  "human_validation": "NOT_RUN",
+  "device_validation": "NOT_RUN",
+  "performance_validation": "NOT_RUN",
+  "full_slice_validation": "NOT_RUN"
+}

--- a/docs/planning/CURRENT_CONFIRMED_DECISIONS.md
+++ b/docs/planning/CURRENT_CONFIRMED_DECISIONS.md
@@ -39,8 +39,10 @@ w6_refinement: GM-FROSTBLOOM-W6-BOUNDED-CONSEQUENCE-FORECAST-01
 w6_refinement_sync: GR-SYNC-20260820-25-W6-BOUNDED-CONSEQUENCE-FORECAST
 w7_refinement: GM-FROSTBLOOM-W7-PRESERVED-FACT-CONTEXT-DELTA-01
 w7_refinement_sync: GR-SYNC-20260820-26-W7-PRESERVED-FACT-CONTEXT-DELTA
-current_planning_refinement: GM-FROSTBLOOM-RESULT-GRIMOIRE-CAUSAL-DEBRIEF-01
-current_planning_refinement_sync: GR-SYNC-20260820-27-RESULT-GRIMOIRE-CAUSAL-DEBRIEF
+result_grimoire_refinement: GM-FROSTBLOOM-RESULT-GRIMOIRE-CAUSAL-DEBRIEF-01
+result_grimoire_refinement_sync: GR-SYNC-20260820-27-RESULT-GRIMOIRE-CAUSAL-DEBRIEF
+current_planning_refinement: GM-FROSTBLOOM-PORTFOLIO-PREVIEW-EVIDENCE-ECHO-01
+current_planning_refinement_sync: GR-SYNC-20260820-28-PORTFOLIO-PREVIEW-EVIDENCE-ECHO
 frostbloom_first_10_minute_contract: FIRST_10_MIN_CLASS_TO_GUIDED_PRACTICUM
 frostbloom_first_10_minute_target_minutes: 10
 frostbloom_10_23_contract: FREE_SCHEDULE_LENS_ONLY_SEQUENTIAL_PICK_2_OF_4
@@ -54,6 +56,10 @@ frostbloom_result_grimoire_contract: LAYERED_CAUSAL_DEBRIEF_PLAYER_PRINCIPLE
 frostbloom_result_contract: FIVE_AXIS_RESULT_SNAPSHOT_NO_GLOBAL_SUCCESS_GRADE
 frostbloom_grimoire_causality: CAUSAL_THREAD_ACTUAL_RECEIPTS_ONLY
 frostbloom_player_principle: SHORT_PLAYER_PRINCIPLE_NAMING_UNGRADED
+frostbloom_portfolio_preview_contract: EVIDENCE_ECHO_ONE_OPEN_QUESTION
+frostbloom_mentor_echo: MENTOR_RESPONSE_DESCRIPTIVE_NOT_VERDICT
+frostbloom_open_question: OPEN_QUESTION_NOT_OBJECTIVE
+frostbloom_festival_close: FESTIVAL_PREVIEW_ONLY
 year_one_chapters: 7
 year_one_term_distribution: 2_2_3
 world_model: PRECEDENT_CONTEXT_REVISION
@@ -72,7 +78,7 @@ frostbloom_implementation_plan: docs/superpowers/plans/2026-08-11-frostbloom-int
 frostbloom_graybox_pack: docs/testing/frostbloom_graybox/README.md
 frostbloom_graybox_status: INTERNAL_PACK_PASS
 frostbloom_runtime_implementation: BLOCKED_BY_TASK8_DEPENDENCY
-next_planning_axis: FROSTBLOOM_PORTFOLIO_PREVIEW_EXPERIENCE
+next_planning_axis: FROSTBLOOM_FIRST_SESSION_END_TO_END_REVIEW
 current_process_axis: PREWORK_BENCHMARK_INDUSTRY_RESEARCH_ACTIVE
 github_actions_decision: GM-PUBLIC-REPO-FREE-GITHUB-ACTIONS-01
 repo_wide_actions_full_sha: PASS
@@ -507,6 +513,38 @@ full_slice_validation: NOT_RUN
 Causal Thread는 실제 observation/W6/result/context-delta/W7/result receipt만 순서대로 조직한다. 시스템은 사실을 연결할 수 있지만 미관찰 원인을 발명하거나 “사실 최적해는 이것이었다”라는 사후 정답 해설을 추가할 수 없다. `intent_tags`는 사후 중립 descriptor로만 남는다.
 
 `actual result / cost·forgone value / discoveries / remaining uncertainty`를 분리한 뒤 마지막에 플레이어가 짧은 원리명을 자기 언어로 붙인다. 시스템은 원리문을 대신 작성하거나 정답 카드로 제시하지 않고, wording을 채점하거나 즉시 stat/route 보상에 연결하지 않는다. 실제 5분 달성, mobile 입력 부담, 인과 이해도, 원리명 품질은 Human/Device test 전까지 `NOT_RUN`이다.
+
+## GM-FROSTBLOOM-PORTFOLIO-PREVIEW-EVIDENCE-ECHO-01 — active child refinement
+
+```yaml
+decision_id: GM-FROSTBLOOM-PORTFOLIO-PREVIEW-EVIDENCE-ECHO-01
+parent_decision: GM-FROSTBLOOM-INTERNAL-VERTICAL-SLICE-01
+predecessor_refinement: GM-FROSTBLOOM-RESULT-GRIMOIRE-CAUSAL-DEBRIEF-01
+sync_id: GR-SYNC-20260820-28-PORTFOLIO-PREVIEW-EVIDENCE-ECHO
+approval: USER_APPROVED_RECOMMENDED_OPTION_A
+canon_document: docs/planning/FROSTBLOOM_PORTFOLIO_PREVIEW_EVIDENCE_ECHO_01_APPROVAL_2026-08-20.md
+research_receipt: docs/planning/research/2026-08-20-portfolio-preview-evidence-echo-research-receipt.md
+fixture: data/testing/frostbloom_portfolio_preview_v1.json
+segment: MINUTE_44_TO_46
+contract: EVIDENCE_ECHO_ONE_OPEN_QUESTION
+mentor_contract: MENTOR_RESPONSE_DESCRIPTIVE_NOT_VERDICT
+portfolio_contract: PORTFOLIO_RECEIPT
+open_question_contract: OPEN_QUESTION_NOT_OBJECTIVE
+festival_contract: FESTIVAL_PREVIEW_ONLY
+session_end_contract: NO_NEW_GAMEPLAY_DECISION
+base_main_observed_for_refinement: 3cdb82f94af402fedcc9c1e80902d1d01b8d3ab3
+project_main_parent_for_refinement: 7d760559f218dcd6513748a2fc8123f174e699b9
+human_validation: NOT_RUN
+device_validation: NOT_RUN
+performance_validation: NOT_RUN
+full_slice_validation: NOT_RUN
+```
+
+44~46분은 새 평가나 후속 임무를 만들지 않고, 실제 플레이 evidence에 대한 짧은 인정과 저장 확인, curiosity hook으로 첫 세션을 닫는다. Maren은 `PLAYER_PRINCIPLE / ACTUAL_IMPROVEMENT_OR_COST / DISCOVERY_OR_UNRESOLVED_TENSION` 중 최대 3개 실제 receipt만 되받아주며 새로운 사실·hidden best answer·grade·result rescore를 추가하지 않는다.
+
+Portfolio Receipt는 `principle_saved / causal_evidence_linked / unresolved_tension_carried`만 확인하며 5축 Result나 Causal Thread를 다시 펼치거나 새 점수/보상 트랙으로 환산하지 않는다. 마지막 질문은 실제 Discovery 또는 Remaining Uncertainty에서 파생된 1개 질문이며 `OPEN_QUESTION_NOT_OBJECTIVE`를 따른다. quest marker, reward, required tracking, branch 선택이 아니다.
+
+Festival은 `PREVIEW_ONLY`로 한 개의 짧은 visual/audio/dialogue glimpse만 허용한다. playable second incident, 새 tutorial/system intro, lore dump를 시작하지 않는다. 세션 종료 입력은 close confirmation 역할만 가지며 새 gameplay decision을 요구하지 않는다. 실제 2분 달성, mentor tone 수용성, curiosity hook 이해도는 Human/Device test 전까지 `NOT_RUN`이다.
 
 ## GM-SPELL-WORKFLOW-UI-V2-01 — current implementation state
 

--- a/docs/planning/FROSTBLOOM_PORTFOLIO_PREVIEW_EVIDENCE_ECHO_01_APPROVAL_2026-08-20.md
+++ b/docs/planning/FROSTBLOOM_PORTFOLIO_PREVIEW_EVIDENCE_ECHO_01_APPROVAL_2026-08-20.md
@@ -1,0 +1,339 @@
+# GM-FROSTBLOOM-PORTFOLIO-PREVIEW-EVIDENCE-ECHO-01 — Portfolio / Preview Evidence Echo
+
+## 1. 상태
+
+```yaml
+decision_id: GM-FROSTBLOOM-PORTFOLIO-PREVIEW-EVIDENCE-ECHO-01
+parent_decision: GM-FROSTBLOOM-INTERNAL-VERTICAL-SLICE-01
+predecessor_refinement: GM-FROSTBLOOM-RESULT-GRIMOIRE-CAUSAL-DEBRIEF-01
+sync_id: GR-SYNC-20260820-28-PORTFOLIO-PREVIEW-EVIDENCE-ECHO
+approved_at_kst: 2026-08-20
+approval: USER_APPROVED_RECOMMENDED_OPTION_A
+work_mode: PLAN
+segment: MINUTE_44_TO_46
+contract: EVIDENCE_ECHO_ONE_OPEN_QUESTION
+mentor_contract: MENTOR_RESPONSE_DESCRIPTIVE_NOT_VERDICT
+portfolio_contract: PORTFOLIO_RECEIPT
+open_question_contract: OPEN_QUESTION_NOT_OBJECTIVE
+festival_contract: FESTIVAL_PREVIEW_ONLY
+session_end_contract: NO_NEW_GAMEPLAY_DECISION
+human_validation: NOT_RUN
+device_validation: NOT_RUN
+performance_validation: NOT_RUN
+full_slice_validation: NOT_RUN
+```
+
+사용자는 2026-08-20 KST에 마지막 44~46분 Portfolio / Preview의 권장 A안 **Evidence Echo + One Open Question**을 승인하고 연속 진행을 요청했다.
+
+이 결정은 새 평가 시스템이나 후속 퀘스트 시스템을 만드는 것이 아니다. 39~44분 Result / Grimoire에서 이미 정리한 결과·인과·플레이어 원리를 반복 채점하지 않고, **게임이 플레이어의 실제 행동을 기억하고 있음을 짧게 인정한 뒤 세션을 닫고 다음 세계에 대한 궁금증만 남기는 마감 계약**이다.
+
+## 2. 플레이어 약속
+
+```yaml
+player_promise: "멘토는 내가 실제로 한 일을 기억해 되돌려주지만, 내 선택을 정답/오답 점수로 다시 평가하지 않는다."
+closing_experience: "내 원리와 실제 사건 결과가 저장되었다는 감각을 얻고, 다음에는 무엇을 더 알아볼 수 있을지 질문 하나만 품은 채 세션을 끝낸다."
+evidence_ceiling: STRUCTURAL_ONLY_UNTIL_HUMAN_DEVICE_TEST
+```
+
+## 3. 44~46분 흐름
+
+```text
+44:00~44:40  MAREN_EVIDENCE_ECHO
+44:40~45:10  PORTFOLIO_RECEIPT
+45:10~46:00  ONE_OPEN_QUESTION + FESTIVAL_GLIMPSE
+```
+
+위 배분은 Human Slice용 가역적 `TEST_VALUE`다. 46분 상위 종료 목표를 유지하는 범위에서 Human test 후 조정할 수 있다.
+
+## 4. 44:00~44:40 · Maren Evidence Echo
+
+### 4.1 역할
+
+Maren의 마지막 반응은 `MENTOR_RESPONSE_DESCRIPTIVE_NOT_VERDICT`다.
+
+```yaml
+max_echo_elements: 3
+source_scope: ACTUAL_RECEIPTS_ONLY
+allowed_echo_slots:
+  - PLAYER_PRINCIPLE
+  - ACTUAL_IMPROVEMENT_OR_COST
+  - DISCOVERY_OR_UNRESOLVED_TENSION
+new_fact: FORBIDDEN
+mentor_grade: NO_MENTOR_GRADE
+result_rescore: NO_RESULT_RESCORING
+hidden_portfolio_score: FORBIDDEN
+hidden_best_answer: FORBIDDEN
+```
+
+Maren은 실제 기록에서 최대 세 요소만 되받아준다.
+
+예시 구조:
+
+```text
+"네가 붙인 원리는 [player principle]이군."
+"이번에 실제로 [improvement/cost]가 남았고,"
+"[discovery/unresolved tension]은 아직 열린 문제다."
+```
+
+위 문구는 구조 예시일 뿐 최종 대사 정본이 아니다.
+
+멘토는 다음을 말하지 않는다.
+
+```text
+정답이었다 / 틀렸다
+최고의 해법이었다
+A/B/C 등급
+이번 선택은 90점
+다음에는 반드시 X를 써라
+사실 숨은 최적해는 Y였다
+```
+
+39~44분의 `NO_GLOBAL_SUCCESS_GRADE`, `CAUSAL_THREAD_ACTUAL_RECEIPTS_ONLY`, `PRINCIPLE_NOT_GRADED`를 우회하지 않는다.
+
+## 5. 44:40~45:10 · Portfolio Receipt
+
+Portfolio Receipt는 결과 화면의 재방송이 아니라 **저장 확인**이다.
+
+```yaml
+contract: PORTFOLIO_RECEIPT
+fields:
+  - principle_saved
+  - causal_evidence_linked
+  - unresolved_tension_carried
+replay_five_axis_result: false
+replay_full_causal_thread: false
+new_grade: false
+new_reward_track: false
+```
+
+플레이어가 확인해야 하는 것은 세 가지다.
+
+1. 내가 붙인 원리가 저장되었다.
+2. 그 원리가 실제 사건의 관찰/회로/Target/결과와 연결되어 있다.
+3. 끝까지 해결하지 않은 긴장·불확실성도 지워지지 않고 기록된다.
+
+이 Receipt는 Year-One portfolio의 장기 평가 숫자를 표시하거나 이번 사건을 새 점수로 환산하지 않는다.
+
+## 6. 45:10~46:00 · One Open Question
+
+### 6.1 질문의 소스
+
+마지막 질문은 현재 플레이어가 실제로 확인한 `DISCOVERY` 또는 `Remaining Uncertainty`에서만 파생한다.
+
+```yaml
+contract: OPEN_QUESTION_NOT_OBJECTIVE
+source_scope: OBSERVED_DISCOVERY_OR_REMAINING_UNCERTAINTY_ONLY
+count: 1
+quest_marker: false
+reward: false
+required_tracking: false
+choice_branch: false
+mandatory_followup: false
+```
+
+질문은 다음 세션의 curiosity hook이다. 새 quest/objective가 아니다.
+
+가능한 형태:
+
+```text
+"같은 원리가 다른 장소에서도 성립할까?"
+"정령이 반응한 것은 흐름 자체였을까, 변화의 속도였을까?"
+"이번에 남긴 제약은 다음 문맥에서는 비용일까 안전장치일까?"
+```
+
+이 예시도 정답 질문 목록이 아니라 표현 범위 예시다.
+
+금지:
+
+```text
+새 퀘스트 마커
+보상 수치
+필수 추적 체크박스
+다음 조사 2~4개 선택
+다음 route 잠금/해금
+```
+
+## 7. Festival Glimpse
+
+기존 상위 정본의 Festival은 계속 `PREVIEW_ONLY`다.
+
+```yaml
+contract: FESTIVAL_PREVIEW_ONLY
+glimpse_count: 1
+allowed_channels:
+  - VISUAL
+  - AUDIO
+  - SHORT_DIALOGUE
+playable: false
+second_incident: NO_SECOND_INCIDENT
+new_tutorial: FORBIDDEN
+required_system_intro: FORBIDDEN
+lore_dump: NO_LORE_DUMP
+```
+
+Festival glimpse는 학교가 이번 사건 이후에도 살아 있고 더 넓은 생활·관계·마법 문맥이 있다는 감각만 준다. 플레이어를 Festival gameplay로 넘기지 않는다.
+
+예를 들어 다음 중 **한 가지 정도의 짧은 감각**이면 충분하다.
+
+- 복도 끝에 준비 중인 장식과 멀리 들리는 연주.
+- 학생들이 축제용 마법 회로를 시험하는 짧은 배경 연출.
+- 동급생이 “축제 때 그 원리도 써볼 수 있을까?”라고 흘리는 한 문장.
+
+새 NPC 소개, 시스템 튜토리얼, 행사 선택, 두 번째 사건 발단을 동시에 넣지 않는다.
+
+## 8. 세션 종료 입력
+
+```yaml
+contract: NO_NEW_GAMEPLAY_DECISION
+allowed_input_role: SESSION_CLOSE_CONFIRMATION_ONLY
+next_quest_choice: false
+new_branch_selection: false
+new_gameplay_decision: false
+```
+
+`계속`, `마도서 닫기`, `세션 종료`와 같은 확인 입력은 허용한다. 전략적 선택·후속 임무 선택을 요구하지 않는다.
+
+## 9. Existing Solution First
+
+재사용:
+
+```text
+39~44 Five-Axis Result / Causal Thread / Player Principle receipt
+existing Portfolio evidence semantics
+Maren mentor role
+Festival PREVIEW_ONLY
+existing Discovery / Remaining Uncertainty
+```
+
+새로 만들지 않음:
+
+```text
+mentor grade engine
+result rescoring layer
+hidden portfolio incident score
+quest generator
+next-inquiry branch selector
+second incident
+festival gameplay
+new tutorial
+new reward track
+```
+
+## 10. 대안 비교
+
+### A · Evidence Echo + One Open Question — 승인
+- 실제 행동에 대한 반응성과 세션 소유감을 가장 잘 보존한다.
+- 채점/새 퀘스트 없이 다음 궁금증을 남긴다.
+- 기존 PREVIEW_ONLY 경계와 2분 cap에 가장 잘 맞는다.
+
+### B · Mentor Evaluation + Teaser — 기각
+- 명료하지만 멘토가 Result/Grimoire 위에 새 최종 등급을 씌울 위험이 있다.
+
+### C · Cinematic Festival Stinger — 기각
+- 연출 후킹은 강하지만 직전 플레이어 원리·대가·인과를 덮고 광고성 마감이 될 위험이 있다.
+
+### D · Next-Inquiry Choice Hook — 기각
+- agency는 높지만 새 branch/objective authority를 만들고 첫 세션 종료를 늦춘다.
+
+## 11. Fresh benchmark disposition
+
+Research receipt:
+
+`docs/planning/research/2026-08-20-portfolio-preview-evidence-echo-research-receipt.md`
+
+Pattern-level disposition:
+
+- **Hades**: ADAPT — 플레이어 행동을 기억하고 반응해 “게임이 내 행동을 보고 있다”는 감각을 만드는 reactive acknowledgement.
+- **Outer Wilds**: ADAPT — 명시적 임무가 아니라 열린 질문과 curiosity가 다음 탐색 동력이 되는 구조.
+- **Heaven's Vault**: ADAPT — 선택·경로를 기억하고 인물/서사가 반응하되 해석을 단일 정답으로 즉시 고정하지 않는 구조.
+- **Pentiment**: REFERENCE_ONLY — 선택의 결과가 이후 공동체에 남는 consequence continuity. 이번 2분에는 대규모 결과 설명을 복제하지 않는다.
+
+콘텐츠·대사·UI 표현을 복제하지 않는다.
+
+## 12. 5회 전체 적대적 검토
+
+### Pass 1 · 숨은 채점 공격
+
+공격:
+- Maren의 “좋았다/아쉬웠다”가 사실상 최종 등급이 되는가?
+
+가드:
+- `MENTOR_RESPONSE_DESCRIPTIVE_NOT_VERDICT`.
+- `NO_MENTOR_GRADE`.
+- 실제 receipt를 되받아주는 묘사만 허용한다.
+
+판정: STRUCTURAL_PASS.
+
+### Pass 2 · 결과 재점수화 공격
+
+공격:
+- Portfolio Receipt가 5축 Result를 다시 합산하거나 최종 성과점수로 바꾸는가?
+
+가드:
+- `NO_RESULT_RESCORING`.
+- Receipt는 `principle_saved / causal_evidence_linked / unresolved_tension_carried` 존재 확인만 한다.
+
+판정: STRUCTURAL_PASS.
+
+### Pass 3 · 열린 질문 퀘스트화 공격
+
+공격:
+- 질문 1개가 사실상 next quest marker가 되는가?
+
+가드:
+- `OPEN_QUESTION_NOT_OBJECTIVE`.
+- reward / tracking / branch / mandatory followup 모두 false.
+
+판정: STRUCTURAL_PASS.
+
+### Pass 4 · Festival scope-creep 공격
+
+공격:
+- Preview가 실제 Festival gameplay, 두 번째 사건, 신규 튜토리얼로 자라는가?
+
+가드:
+- `FESTIVAL_PREVIEW_ONLY`.
+- `NO_SECOND_INCIDENT`.
+- `NO_LORE_DUMP`.
+- glimpse 1개로 제한한다.
+
+판정: STRUCTURAL_PASS.
+
+### Pass 5 · 2분 과부하 공격
+
+공격:
+- mentor feedback + portfolio + hook + festival + 선택지를 모두 넣어 46분 종료가 무너지는가?
+
+가드:
+- echo 최대 3요소.
+- receipt 3필드.
+- open question 1개.
+- festival glimpse 1개.
+- `NO_NEW_GAMEPLAY_DECISION`.
+
+판정: STRUCTURAL_PASS; 실제 2분 달성은 NOT_RUN.
+
+## 13. 재검토 조건
+
+Human/Device test에서 다음이 확인되면 배분·표시량을 재검토한다.
+
+- Maren의 반응을 플레이어가 채점/도덕평가로 읽음.
+- Portfolio Receipt가 불필요한 반복으로 느껴짐.
+- 열린 질문을 플레이어가 반드시 수행해야 할 quest로 오인함.
+- Festival glimpse가 직전 사건의 감정적 마감을 덮음.
+- 2분 cap을 반복적으로 초과함.
+
+재검토 전에도 상위 invariant는 유지한다: **비채점 mentor echo / 저장 확인만 하는 Portfolio / objective 아닌 질문 / Festival PREVIEW_ONLY / 새 gameplay decision 없음**.
+
+## 14. Evidence ceiling
+
+```text
+STRUCTURAL_DESIGN: PASS
+TDD_CONTRACT: REQUIRED
+HUMAN_VALIDATION: NOT_RUN
+DEVICE_VALIDATION: NOT_RUN
+PERFORMANCE_VALIDATION: NOT_RUN
+FULL_SLICE_VALIDATION: NOT_RUN
+FUN_VERIFIED: NO
+TWO_MINUTE_COMPLETION_VERIFIED: NO
+```

--- a/docs/planning/research/2026-08-20-portfolio-preview-evidence-echo-research-receipt.md
+++ b/docs/planning/research/2026-08-20-portfolio-preview-evidence-echo-research-receipt.md
@@ -1,0 +1,103 @@
+# Research Receipt — Frostbloom 44~46 Portfolio / Preview Evidence Echo
+
+```yaml
+work_unit: FROSTBLOOM_44_46_PORTFOLIO_PREVIEW
+research_date_kst: 2026-08-20
+decision_target: GM-FROSTBLOOM-PORTFOLIO-PREVIEW-EVIDENCE-ECHO-01
+base_main_observed: 3cdb82f94af402fedcc9c1e80902d1d01b8d3ab3
+project_main_parent: 7d760559f218dcd6513748a2fc8123f174e699b9
+scope: PATTERN_LEVEL_ONLY
+competitor_expression_copying: FORBIDDEN
+```
+
+## Work question
+
+첫 세션 마지막 2분에서 어떻게 플레이어의 실제 행동과 원리를 인정하면서도 멘토 채점, 결과 재점수화, 새 퀘스트/분기, 두 번째 사건, 긴 예고편으로 scope가 커지는 것을 막을 것인가?
+
+## Existing Solution First
+
+이미 저장소에는 다음 권위가 있다.
+
+- `BEAT_08 — 44–46 PORTFOLIO_AND_PREVIEW`
+- Portfolio evidence records the completed spiral.
+- Festival remains `PREVIEW_ONLY`.
+- no separate exam / second incident / mandatory branch.
+- 39~44 Result/Grimoire는 five-axis result, actual-receipt causality, player-authored principle을 소유한다.
+
+따라서 이번 work unit은 새 평가·퀘스트·Festival 시스템을 만들지 않고 마지막 표시/반응 순서만 refinement한다.
+
+## Sources
+
+### 1. Hades reactive acknowledgement
+
+- Source: Game Developer, “How Supergiant weaves narrative rewards into Hades' cycle of perpetual death”
+- URL: https://www.gamedeveloper.com/design/how-supergiant-weaves-narrative-rewards-into-i-hades-i-cycle-of-perpetual-death
+- Role: developer-interview-based industry source
+- Freshness: evergreen design reference; checked 2026-08-20
+- Relevant observation: Greg Kasavin describes reactivity as a narrative goal so players can feel that the game is paying attention to what happened.
+- Disposition: **ADAPT** the acknowledgement pattern only. Do not copy dialogue, characters, or event-trigger implementation.
+
+### 2. Outer Wilds curiosity-driven exploration
+
+- Source: GDC / Alex Beachum, “Sparking Curiosity-Driven Exploration”
+- URL: https://media.gdcvault.com/GDC%2B2021/beachum_gdc_2021%281%29.pdf
+- Supporting official studio archive: https://www.mobiusdigitalgames.com/news/category/outer-wilds
+- Role: primary/developer design material
+- Freshness: evergreen design reference; checked 2026-08-20
+- Relevant observation: curiosity starts with a question that motivates discovery; Mobius also describes pathing choices as ideally motivated by curiosity rather than random choice.
+- Disposition: **ADAPT** one open question as curiosity fuel, explicitly not a quest/objective.
+
+### 3. Heaven's Vault remembered/reactive choices
+
+- Source: inkle official press kit / game page
+- URL: https://www.inklestudios.com/press/heavensvault/
+- URL: https://www.inklestudios.com/heavensvault/
+- Role: first-party product/design description
+- Freshness: evergreen product reference; checked 2026-08-20
+- Relevant observation: the narrative engine remembers choices and paths, and characters react to what the player says/does; translations can remain uncertain rather than immediately becoming objective truth.
+- Disposition: **ADAPT** remembered evidence and descriptive reaction; preserve uncertainty.
+
+### 4. Pentiment lasting consequences
+
+- Source: Xbox Wire, “Pentiment Available Now”
+- URL: https://news.xbox.com/en-us/2022/11/15/pentiment-available-now/
+- Role: first-party publisher/developer release description
+- Freshness: evergreen product reference; checked 2026-08-20
+- Relevant observation: player decisions and accusations have lasting consequences that persist through the community.
+- Disposition: **REFERENCE_ONLY** for consequence continuity. Do not use the final 2 minutes to replay a broad consequence montage or create a verdict screen.
+
+## Alternatives considered
+
+| Option | Core | Benefit | Primary risk | Disposition |
+|---|---|---|---|---|
+| A · Evidence Echo + One Open Question | evidence acknowledgement → save receipt → open question/glimpse | preserves ownership + curiosity | can still become mentor grading if wording slips | **ADOPT** |
+| B · Mentor Evaluation + Teaser | mentor verdict + teaser | very clear | bypasses no-global-grade via mentor | AVOID |
+| C · Cinematic Festival Stinger | strong audiovisual teaser | high spectacle | buries player's just-authored principle | AVOID for first-slice close |
+| D · Next-Inquiry Choice Hook | choose next inquiry | agency | creates branch/objective authority | AVOID |
+
+## Synthesis
+
+Best-fit pattern:
+
+```text
+ACTUAL PLAYER EVIDENCE
+→ DESCRIPTIVE REACTIVE ACKNOWLEDGEMENT
+→ SAVE/CONTINUITY CONFIRMATION
+→ ONE UNRESOLVED QUESTION
+→ NON-PLAYABLE WORLD GLIMPSE
+→ CLOSE
+```
+
+The system should demonstrate memory, not judgment. The next-session hook should generate curiosity, not obligation.
+
+## 5-pass adversarial summary
+
+1. Mentor grading attack → `MENTOR_RESPONSE_DESCRIPTIVE_NOT_VERDICT`, `NO_MENTOR_GRADE`.
+2. Result rescoring attack → Portfolio receipt only confirms saved/linked/carried state.
+3. Questification attack → `OPEN_QUESTION_NOT_OBJECTIVE`, no reward/marker/tracking/branch.
+4. Festival scope creep → `FESTIVAL_PREVIEW_ONLY`, no playable second incident/tutorial/lore dump.
+5. Two-minute overload → max 3 echo elements + 3 receipt fields + one question + one glimpse + no new gameplay decision.
+
+## Evidence ceiling
+
+Research supports design patterns and risk controls only. It does not prove GRIMOIRE's two-minute pacing, emotional closure, comprehension, mobile readability, or fun. Those remain `NOT_RUN` until Human/Device validation.

--- a/docs/planning/sync/GR-SYNC-20260820-28-PORTFOLIO-PREVIEW-EVIDENCE-ECHO.md
+++ b/docs/planning/sync/GR-SYNC-20260820-28-PORTFOLIO-PREVIEW-EVIDENCE-ECHO.md
@@ -1,0 +1,143 @@
+# GR-SYNC-20260820-28-PORTFOLIO-PREVIEW-EVIDENCE-ECHO
+
+```yaml
+sync_id: GR-SYNC-20260820-28-PORTFOLIO-PREVIEW-EVIDENCE-ECHO
+decision_id: GM-FROSTBLOOM-PORTFOLIO-PREVIEW-EVIDENCE-ECHO-01
+approval: USER_APPROVED_RECOMMENDED_OPTION_A
+work_mode: PLAN
+project_main_parent: 7d760559f218dcd6513748a2fc8123f174e699b9
+base_main_observed: 3cdb82f94af402fedcc9c1e80902d1d01b8d3ab3
+red_head: bb049c2d472337ec4ab77fdb21dd2fbd735e70c9
+pr: 145
+human_validation: NOT_RUN
+device_validation: NOT_RUN
+performance_validation: NOT_RUN
+full_slice_validation: NOT_RUN
+```
+
+## User approval
+
+사용자는 2026-08-20 KST에 `44~46 Portfolio / Preview`의 권장 A안 **Evidence Echo + One Open Question**을 승인하고 진행을 요청했다.
+
+## TDD RED
+
+PR #145의 첫 head `bb049c2d472337ec4ab77fdb21dd2fbd735e70c9`에서 planning CI를 실행했다.
+
+기존 W6/W7/Result-Grimoire 및 다른 planning/runtime contract는 통과했고, 새 Portfolio/Preview 산출물이 아직 없어서 다음 두 테스트가 의도대로 실패했다.
+
+```text
+test_required_planning_artifacts_exist
+test_portfolio_preview_evidence_echo_refinement
+```
+
+직접 원인은 다음 정본 파일의 부재였다.
+
+`docs/planning/FROSTBLOOM_PORTFOLIO_PREVIEW_EVIDENCE_ECHO_01_APPROVAL_2026-08-20.md`
+
+따라서 RED는 기존 회귀가 아니라 새 승인 계약의 미구현을 정확히 증명했다.
+
+## Fresh benchmark / Existing Solution First
+
+Research receipt:
+
+`docs/planning/research/2026-08-20-portfolio-preview-evidence-echo-research-receipt.md`
+
+Fresh research는 승인 직전 같은 work unit에서 수행됐고 승인 후 scope/product decision/key assumptions가 바뀌지 않아 동일 receipt를 사용한다.
+
+Pattern-level synthesis:
+
+- Hades → 실제 플레이 상황을 기억하고 반응하는 acknowledgement.
+- Outer Wilds → 열린 질문/curiosity를 다음 진행 동력으로 사용.
+- Heaven's Vault → 선택과 경로를 기억하고 반응하며 불확실성을 보존.
+- Pentiment → 선택 결과가 이후에도 남는 consequence continuity.
+
+기존 저장소 권위인 BEAT_08, Portfolio evidence, Festival `PREVIEW_ONLY`, 39~44 Result/Grimoire receipt를 재사용한다. 새 grade/quest/Festival gameplay authority는 만들지 않는다.
+
+## Approved contract
+
+```text
+44:00~44:40  MAREN_EVIDENCE_ECHO
+44:40~45:10  PORTFOLIO_RECEIPT
+45:10~46:00  ONE_OPEN_QUESTION + FESTIVAL_GLIMPSE
+```
+
+Hard invariants:
+
+```text
+EVIDENCE_ECHO_ONE_OPEN_QUESTION
+MENTOR_RESPONSE_DESCRIPTIVE_NOT_VERDICT
+PORTFOLIO_RECEIPT
+OPEN_QUESTION_NOT_OBJECTIVE
+FESTIVAL_PREVIEW_ONLY
+NO_MENTOR_GRADE
+NO_RESULT_RESCORING
+NO_HIDDEN_PORTFOLIO_SCORE
+NO_HIDDEN_BEST_ANSWER
+NO_NEXT_QUEST_CHOICE
+NO_SECOND_INCIDENT
+NO_NEW_TUTORIAL
+NO_LORE_DUMP
+NO_NEW_GAMEPLAY_DECISION
+```
+
+Maren은 실제 receipt 중 최대 3개 요소만 되받아준다. Portfolio는 `principle_saved / causal_evidence_linked / unresolved_tension_carried` 저장 상태만 확인한다. 마지막 열린 질문은 실제 Discovery/Remaining Uncertainty에서 1개만 파생하며 objective가 아니다. Festival은 한 개의 비플레이형 glimpse만 허용한다.
+
+## 5-pass adversarial review
+
+### Pass 1 — mentor grading
+- 공격: Maren의 피드백이 Result 위의 최종 점수가 되는가?
+- 가드: `MENTOR_RESPONSE_DESCRIPTIVE_NOT_VERDICT`, `NO_MENTOR_GRADE`.
+- 판정: PASS.
+
+### Pass 2 — result rescoring
+- 공격: Portfolio가 5축 결과를 다시 합산/등급화하는가?
+- 가드: `NO_RESULT_RESCORING`; 저장 상태 3필드만 확인.
+- 판정: PASS.
+
+### Pass 3 — questification
+- 공격: open question이 사실상 next quest가 되는가?
+- 가드: `OPEN_QUESTION_NOT_OBJECTIVE`; marker/reward/tracking/branch/mandatory followup 금지.
+- 판정: PASS.
+
+### Pass 4 — Festival scope creep
+- 공격: glimpse가 두 번째 사건/튜토리얼/긴 lore intro로 확장되는가?
+- 가드: `FESTIVAL_PREVIEW_ONLY`, `NO_SECOND_INCIDENT`, `NO_NEW_TUTORIAL`, `NO_LORE_DUMP`.
+- 판정: PASS.
+
+### Pass 5 — two-minute overload
+- 공격: mentor + portfolio + hook + festival + 선택지를 모두 요구해 46분 종료가 깨지는가?
+- 가드: max 3 echo elements + 3 receipt fields + one question + one glimpse + `NO_NEW_GAMEPLAY_DECISION`.
+- 판정: STRUCTURAL_PASS; 실제 2분 달성은 NOT_RUN.
+
+## Files / projection
+
+Created:
+
+- `data/testing/frostbloom_portfolio_preview_v1.json`
+- `docs/planning/FROSTBLOOM_PORTFOLIO_PREVIEW_EVIDENCE_ECHO_01_APPROVAL_2026-08-20.md`
+- `docs/planning/research/2026-08-20-portfolio-preview-evidence-echo-research-receipt.md`
+- `docs/planning/sync/GR-SYNC-20260820-28-PORTFOLIO-PREVIEW-EVIDENCE-ECHO.md`
+
+Updated:
+
+- `tests/test_frostbloom_internal_vertical_slice_contract.py`
+- `docs/testing/frostbloom_graybox/README.md`
+- `docs/planning/CURRENT_CONFIRMED_DECISIONS.md`
+
+The existing parent `BEAT_08 — 44–46 PORTFOLIO_AND_PREVIEW` remains semantically compatible and is not duplicated into a second full walkthrough authority. The child fixture/canon owns the detailed timing and guards.
+
+## Scope boundary
+
+No product `src`, Scene, Resource, addon, asset, `project.godot`, Task8, balance, or runtime behavior mutation is authorized or performed by this planning refinement.
+
+## Next gate
+
+Before merge:
+
+1. exact-head planning/graybox/JSON/NFC CI GREEN;
+2. applicable runtime regression gates terminal GREEN;
+3. unresolved review threads = 0;
+4. same-goal open PR uniqueness;
+5. project main still equals approved parent or concurrency is classified.
+
+After merge, GitHub main SHA and the four Notion consumer surfaces must be read back. The next planning axis is `FROSTBLOOM_FIRST_SESSION_END_TO_END_REVIEW`; planning completion still requires explicit user declaration.

--- a/docs/testing/frostbloom_graybox/README.md
+++ b/docs/testing/frostbloom_graybox/README.md
@@ -8,6 +8,7 @@ ACTIVE_REFINEMENT_2: GM-FROSTBLOOM-10-23-LENS-INVESTIGATION-01
 ACTIVE_REFINEMENT_3: GM-FROSTBLOOM-W6-BOUNDED-CONSEQUENCE-FORECAST-01
 ACTIVE_REFINEMENT_4: GM-FROSTBLOOM-W7-PRESERVED-FACT-CONTEXT-DELTA-01
 ACTIVE_REFINEMENT_5: GM-FROSTBLOOM-RESULT-GRIMOIRE-CAUSAL-DEBRIEF-01
+ACTIVE_REFINEMENT_6: GM-FROSTBLOOM-PORTFOLIO-PREVIEW-EVIDENCE-ECHO-01
 SCOPE: INTERNAL_DESIGN_VALIDATION_ONLY
 EXECUTION_ORDER: 01 -> 02 -> 03 -> 04 -> 05 -> 06 -> 07
 HUMAN_VALIDATION: NOT_RUN
@@ -21,7 +22,7 @@ TASK8: SEPARATE_PRODUCT_WORKSTREAM_UNCHANGED_BY_PLANNING_OVERLAYS
 
 ## Purpose
 
-This pack attacks the approved Frostbloom Single-Incident Spiral before release-near runtime integration. It checks chronology, information leakage, writing-event distinctness, all six 2-of-4 investigation pairs, four free-schedule choices, W6 bounded forecast/consequence preservation, W7 preserved-fact/context-delta redesign distinctness, five-axis results, layered Grimoire causality/player-principle authorship, and fourteen parent-pack adversarial regressions.
+This pack attacks the approved Frostbloom Single-Incident Spiral before release-near runtime integration. It checks chronology, information leakage, writing-event distinctness, all six 2-of-4 investigation pairs, four free-schedule choices, W6 bounded forecast/consequence preservation, W7 preserved-fact/context-delta redesign distinctness, five-axis results, layered Grimoire causality/player-principle authorship, Portfolio/Preview evidence acknowledgement and non-objective curiosity close, and fourteen parent-pack adversarial regressions.
 
 Active child refinements additionally require:
 
@@ -34,9 +35,11 @@ Active child refinements additionally require:
 - minutes 30–39: `W6_RESULT_ANCHOR` → one `POST_W6_DEEPER_REVISION_COUPLING` → `STILL_TRUE / NEWLY_LEARNED / NEW_TENSION` → W7 changes at least one meaningful judgment dimension → explicit second major Commit;
 - W7 reveal is not an `OLD_REPAIR_RECORD` replay and may not reduce redesign to number-only amplification;
 - minutes 39–44: `FIVE_AXIS_RESULT_SNAPSHOT` → `CAUSAL_THREAD_ACTUAL_RECEIPTS_ONLY` → separate Cost/Forgone/Discovery → `SHORT_PLAYER_PRINCIPLE_NAMING`;
-- Result/Grimoire has no global success grade, may not invent an unobserved cause, and may not system-author/grade/reward the principle wording.
+- Result/Grimoire has no global success grade, may not invent an unobserved cause, and may not system-author/grade/reward the principle wording;
+- minutes 44–46: `MENTOR_RESPONSE_DESCRIPTIVE_NOT_VERDICT` → `PORTFOLIO_RECEIPT` → `OPEN_QUESTION_NOT_OBJECTIVE` + `FESTIVAL_PREVIEW_ONLY` → close;
+- Portfolio/Preview may not add mentor grade/result rescore/hidden best answer, next-quest choice, second incident, lore dump, or any new gameplay decision.
 
-It does **not** prove fun, human comprehension, real 10/23/30/39/44/46-minute completion, forecast fairness, W7 emotional acceptance, Result/Grimoire causal comprehension, principle-entry comfort, accessibility, device behavior, performance, export quality, or Task8 runtime behavior.
+It does **not** prove fun, human comprehension, real 10/23/30/39/44/46-minute completion, forecast fairness, W7 emotional acceptance, Result/Grimoire causal comprehension, principle-entry comfort, Portfolio/Preview emotional closure, open-question interpretation, accessibility, device behavior, performance, export quality, or Task8 runtime behavior.
 
 ## Pack surfaces
 
@@ -53,6 +56,7 @@ Machine-readable 10–23 child overlay: `data/testing/frostbloom_10_23_lens_v1.j
 Machine-readable W6 child overlay: `data/testing/frostbloom_w6_bounded_forecast_v1.json`.
 Machine-readable W7 child overlay: `data/testing/frostbloom_w7_context_delta_v1.json`.
 Machine-readable Result/Grimoire child overlay: `data/testing/frostbloom_result_grimoire_debrief_v1.json`.
+Machine-readable Portfolio/Preview child overlay: `data/testing/frostbloom_portfolio_preview_v1.json`.
 Automated structure contracts: `tests/test_frostbloom_internal_vertical_slice_contract.py` and `tests/test_frostbloom_internal_graybox_pack_contract.py`.
 
 ## Rollup
@@ -63,8 +67,8 @@ READY_WITH_RISKS = zero FAIL and one-or-more in-scope design RISK
 INTERNAL_PACK_PASS = zero FAIL; NOT_TESTABLE_YET may remain only on out-of-scope human/runtime/device/performance questions
 ```
 
-Current internal rollup is `INTERNAL_PACK_PASS`: parent design-structural hard invariants pass and active child overlays add no structural FAIL. Actual elapsed time, comprehension, Lens desirability, investigation-choice reasoning, W6 forecast fairness/readability, W7 reveal acceptance/redesign reasoning, Result/Grimoire comprehension, player-principle input burden, handwriting fatigue, and device behavior remain `NOT_TESTABLE_YET` or `NOT_RUN`.
+Current internal rollup is `INTERNAL_PACK_PASS`: parent design-structural hard invariants pass and active child overlays add no structural FAIL. Actual elapsed time, comprehension, Lens desirability, investigation-choice reasoning, W6 forecast fairness/readability, W7 reveal acceptance/redesign reasoning, Result/Grimoire comprehension, player-principle input burden, Portfolio/Preview closure/mentor-tone/open-question interpretation, handwriting fatigue, and device behavior remain `NOT_TESTABLE_YET` or `NOT_RUN`.
 
 ## Ownership boundary
 
-This pack validates approved Frostbloom content assumptions. It does not own glyph recognition, FIVE_POINT_STAR math, mana, prepared-spell inventory, atomic spell use, result-ledger semantics, generic save I/O, Task8 Spell Use Screen UI, grading, morality scoring, or long-term principle-reward systems. Planning refinements may alter chronology, information framing, and content contracts only; product implementation remains a later separate work unit.
+This pack validates approved Frostbloom content assumptions. It does not own glyph recognition, FIVE_POINT_STAR math, mana, prepared-spell inventory, atomic spell use, result-ledger semantics, generic save I/O, Task8 Spell Use Screen UI, grading, morality scoring, quest-generation authority, or long-term principle-reward systems. Planning refinements may alter chronology, information framing, and content contracts only; product implementation remains a later separate work unit.

--- a/tests/test_frostbloom_internal_vertical_slice_contract.py
+++ b/tests/test_frostbloom_internal_vertical_slice_contract.py
@@ -230,7 +230,7 @@ class FrostbloomInternalVerticalSliceContractTests(unittest.TestCase):
             "FESTIVAL_PREVIEW_ONLY",
             "NO_MENTOR_GRADE",
             "NO_RESULT_RESCORING",
-            "NO_NEXT_QUEST_CHOICE",
+            "next_quest_choice: false",
             "NO_SECOND_INCIDENT",
             "NO_LORE_DUMP",
             "NO_NEW_GAMEPLAY_DECISION",

--- a/tests/test_frostbloom_internal_vertical_slice_contract.py
+++ b/tests/test_frostbloom_internal_vertical_slice_contract.py
@@ -11,6 +11,8 @@ W7_CANON = ROOT / "docs/planning/FROSTBLOOM_W7_PRESERVED_FACT_CONTEXT_DELTA_01_A
 W7_FIXTURE = ROOT / "data/testing/frostbloom_w7_context_delta_v1.json"
 RESULT_CANON = ROOT / "docs/planning/FROSTBLOOM_RESULT_GRIMOIRE_CAUSAL_DEBRIEF_01_APPROVAL_2026-08-20.md"
 RESULT_FIXTURE = ROOT / "data/testing/frostbloom_result_grimoire_debrief_v1.json"
+PORTFOLIO_CANON = ROOT / "docs/planning/FROSTBLOOM_PORTFOLIO_PREVIEW_EVIDENCE_ECHO_01_APPROVAL_2026-08-20.md"
+PORTFOLIO_FIXTURE = ROOT / "data/testing/frostbloom_portfolio_preview_v1.json"
 WALK = ROOT / "docs/testing/frostbloom_graybox/01_46_MINUTE_WALKTHROUGH.md"
 CURRENT = ROOT / "docs/planning/CURRENT_CONFIRMED_DECISIONS.md"
 BENCH = ROOT / "docs/planning/FROSTBLOOM_INTERNAL_VERTICAL_SLICE_IMPLEMENTATION_BENCHMARK_2026-08-11.md"
@@ -20,7 +22,23 @@ README = ROOT / "README.md"
 
 class FrostbloomInternalVerticalSliceContractTests(unittest.TestCase):
     def test_required_planning_artifacts_exist(self):
-        for path in (CANON, FIRST10, W6_CANON, W6_FIXTURE, W7_CANON, W7_FIXTURE, RESULT_CANON, RESULT_FIXTURE, WALK, CURRENT, BENCH, PLAN, README):
+        for path in (
+            CANON,
+            FIRST10,
+            W6_CANON,
+            W6_FIXTURE,
+            W7_CANON,
+            W7_FIXTURE,
+            RESULT_CANON,
+            RESULT_FIXTURE,
+            PORTFOLIO_CANON,
+            PORTFOLIO_FIXTURE,
+            WALK,
+            CURRENT,
+            BENCH,
+            PLAN,
+            README,
+        ):
             self.assertTrue(path.is_file(), path)
 
     def test_approved_slice_contract_tokens(self):
@@ -197,6 +215,50 @@ class FrostbloomInternalVerticalSliceContractTests(unittest.TestCase):
         self.assertFalse(data["player_principle"]["system_authors_principle"])
         self.assertFalse(data["player_principle"]["graded"])
         self.assertFalse(data["player_principle"]["immediate_stat_bonus"])
+        self.assertEqual("NOT_RUN", data["human_validation"])
+
+    def test_portfolio_preview_evidence_echo_refinement(self):
+        self.assertTrue(PORTFOLIO_CANON.is_file(), PORTFOLIO_CANON)
+        self.assertTrue(PORTFOLIO_FIXTURE.is_file(), PORTFOLIO_FIXTURE)
+        text = PORTFOLIO_CANON.read_text(encoding="utf-8")
+        for token in (
+            "GM-FROSTBLOOM-PORTFOLIO-PREVIEW-EVIDENCE-ECHO-01",
+            "EVIDENCE_ECHO_ONE_OPEN_QUESTION",
+            "MENTOR_RESPONSE_DESCRIPTIVE_NOT_VERDICT",
+            "PORTFOLIO_RECEIPT",
+            "OPEN_QUESTION_NOT_OBJECTIVE",
+            "FESTIVAL_PREVIEW_ONLY",
+            "NO_MENTOR_GRADE",
+            "NO_RESULT_RESCORING",
+            "NO_NEXT_QUEST_CHOICE",
+            "NO_SECOND_INCIDENT",
+            "NO_LORE_DUMP",
+            "NO_NEW_GAMEPLAY_DECISION",
+        ):
+            self.assertIn(token, text)
+        current = CURRENT.read_text(encoding="utf-8")
+        self.assertIn("GM-FROSTBLOOM-PORTFOLIO-PREVIEW-EVIDENCE-ECHO-01", current)
+
+        data = json.loads(PORTFOLIO_FIXTURE.read_text(encoding="utf-8"))
+        self.assertEqual({"start_minute": 44, "end_minute": 46}, data["segment"])
+        self.assertEqual("MENTOR_RESPONSE_DESCRIPTIVE_NOT_VERDICT", data["mentor_echo"]["contract"])
+        self.assertLessEqual(data["mentor_echo"]["max_echo_elements"], 3)
+        self.assertTrue(data["mentor_echo"]["actual_receipts_only"])
+        self.assertFalse(data["mentor_echo"]["can_grade"])
+        self.assertFalse(data["mentor_echo"]["can_rescore_result"])
+        self.assertEqual(
+            ["principle_saved", "causal_evidence_linked", "unresolved_tension_carried"],
+            data["portfolio_receipt"]["fields"],
+        )
+        self.assertEqual("OPEN_QUESTION_NOT_OBJECTIVE", data["open_question"]["contract"])
+        self.assertFalse(data["open_question"]["quest_marker"])
+        self.assertFalse(data["open_question"]["reward"])
+        self.assertFalse(data["open_question"]["required_tracking"])
+        self.assertFalse(data["open_question"]["choice_branch"])
+        self.assertEqual("FESTIVAL_PREVIEW_ONLY", data["festival"]["contract"])
+        self.assertFalse(data["festival"]["playable"])
+        self.assertFalse(data["festival"]["starts_second_incident"])
+        self.assertFalse(data["session_end"]["new_gameplay_decision"])
         self.assertEqual("NOT_RUN", data["human_validation"])
 
     def test_walkthrough_transfers_class_learning_to_field_by_minute_10(self):


### PR DESCRIPTION
## Goal

Promote the user-approved 44–46 minute Portfolio/Preview option A: echo only actual player evidence without grading, confirm the portfolio receipt without replaying the whole Result/Grimoire, then end on one open question plus a Festival PREVIEW_ONLY glimpse.

## Protected canon

- predecessor `GM-FROSTBLOOM-RESULT-GRIMOIRE-CAUSAL-DEBRIEF-01`
- `NO_GLOBAL_SUCCESS_GRADE` remains intact
- mentor response is descriptive, not verdict/grade/rescore
- portfolio receipt only confirms saved principle/evidence/unresolved tension
- open question is curiosity, not objective/quest/reward/branch
- Festival remains PREVIEW_ONLY and non-playable
- no second incident, lore dump, new tutorial, or new gameplay decision
- Human / Device / Performance / Full Slice remain NOT_RUN

## TDD

First commit is intentionally RED. The vertical-slice contract now requires new Portfolio/Preview canon + fixture with:
- `EVIDENCE_ECHO_ONE_OPEN_QUESTION`
- `MENTOR_RESPONSE_DESCRIPTIVE_NOT_VERDICT`
- `PORTFOLIO_RECEIPT`
- `OPEN_QUESTION_NOT_OBJECTIVE`
- `FESTIVAL_PREVIEW_ONLY`
- `NO_MENTOR_GRADE`
- `NO_RESULT_RESCORING`
- `NO_NEXT_QUEST_CHOICE`
- `NO_SECOND_INCIDENT`
- `NO_LORE_DUMP`
- `NO_NEW_GAMEPLAY_DECISION`

## Research

Same work-unit research scope is unchanged from the approved proposal, so the fresh benchmark receipt is reused: Hades reactive acknowledgement, Outer Wilds curiosity/knowledge-driven progression, Heaven's Vault remembered/reactive choices, and Pentiment lasting consequences. Pattern-level adaptation only; no expression/content copying.

## Scope

Planning/docs/test-data/tests/Notion only. No product src, Scene, Resource, addon, asset, project.godot, Task8, balance, or runtime behavior mutation.