### PR TITLE
docs(planning): remove duplicate first-session recaps

### DIFF
--- a/.github/workflows/validate-base-v9-adoption.yml
+++ b/.github/workflows/validate-base-v9-adoption.yml
@@ -19,6 +19,7 @@ jobs:
       - run: python -m unittest tests.test_world_character_three_year_story_contract -v
       - run: python -m unittest tests.test_year_one_growth_economy_test_values_contract -v
       - run: python -m unittest tests.test_frostbloom_internal_vertical_slice_contract -v
+      - run: python -m unittest tests.test_frostbloom_first_session_handoff_buffer_contract -v
       - run: python -m unittest tests.test_prework_benchmark_industry_research_contract -v
       - run: python -m unittest tests.test_frostbloom_internal_graybox_pack_contract -v
       - name: Validate JSON

--- a/data/testing/frostbloom_first_session_handoff_buffer_v1.json
+++ b/data/testing/frostbloom_first_session_handoff_buffer_v1.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": 1,
+  "fixture_id": "FROSTBLOOM_FIRST_SESSION_HANDOFF_BUFFER_V1",
+  "decision_id": "GM-FROSTBLOOM-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER-01",
+  "parent_decision": "GM-FROSTBLOOM-INTERNAL-VERTICAL-SLICE-01",
+  "predecessor_refinement": "GM-FROSTBLOOM-PORTFOLIO-PREVIEW-EVIDENCE-ECHO-01",
+  "contract": "PERSISTENT_HANDOFF_ELASTIC_BUFFER",
+  "session_target_minutes": 46,
+  "investigation_to_w6": {
+    "source_summary": "KNOWN_2_UNKNOWN_2_LENS_1",
+    "summary_persists_into_w6": true,
+    "duplicate_decision_brief_screen": false,
+    "handoff_window": "ELASTIC_HANDOFF_WINDOW",
+    "elastic_buffer_max_seconds_test_value": 60,
+    "fixed_pause_required": false,
+    "stage2_can_begin_early_if_ready": true
+  },
+  "w6_to_w7": {
+    "source_receipt": "W6_ACTUAL_CONSEQUENCE_RECEIPT",
+    "w6_receipt_pins_as_anchor": true,
+    "anchor_semantic": "W6_RESULT_ANCHOR",
+    "duplicate_result_anchor_screen": false,
+    "handoff_window": "ELASTIC_W6_TO_W7_HANDOFF",
+    "elastic_buffer_max_seconds_test_value": 60,
+    "fixed_pause_required": false,
+    "deeper_reveal_can_begin_early_if_ready": true
+  },
+  "elastic_buffer": {
+    "contract": "ELASTIC_BUFFER_NOT_CONTENT",
+    "must_be_filled": false,
+    "new_content_allowed": false,
+    "allowed_absorption": [
+      "TRANSITION_LATENCY",
+      "INPUT_LATENCY",
+      "READING_VARIANCE",
+      "EXISTING_SHORT_ANIMATION_VARIANCE",
+      "ACCESSIBILITY_PACING_VARIANCE"
+    ],
+    "forbidden_fill": [
+      "NEW_TUTORIAL",
+      "NEW_LORE",
+      "NEW_REWARD",
+      "NEW_GAMEPLAY_CHOICE",
+      "SECOND_INCIDENT",
+      "EXTRA_MANDATORY_DIALOGUE"
+    ]
+  },
+  "hard_guards": [
+    "INVESTIGATION_SUMMARY_PERSISTS_INTO_W6",
+    "NO_DUPLICATE_W6_DECISION_BRIEF",
+    "W6_RECEIPT_PINS_AS_W7_ANCHOR",
+    "NO_DUPLICATE_W7_RESULT_ANCHOR_SCREEN",
+    "ELASTIC_BUFFER_NOT_CONTENT",
+    "NO_NEW_CONTENT_FROM_RECOVERED_TIME",
+    "FIRST_ACCEPTED_W6_RESULT_REMAINS_TRUE",
+    "TARGET_46_UNCHANGED"
+  ],
+  "human_validation": "NOT_RUN",
+  "device_validation": "NOT_RUN",
+  "performance_validation": "NOT_RUN",
+  "full_slice_validation": "NOT_RUN"
+}

--- a/data/testing/frostbloom_w6_bounded_forecast_v1.json
+++ b/data/testing/frostbloom_w6_bounded_forecast_v1.json
@@ -12,9 +12,12 @@
   "entry_summary": {
     "known": 2,
     "unknown": 2,
-    "lens": 1,
+    "lens": 1
+  },
+  "entry_handoff": {
     "persists_from_investigation": true,
-    "duplicate_decision_brief_required": false
+    "duplicate_decision_brief_required": false,
+    "contract": "INVESTIGATION_SUMMARY_PERSISTS_INTO_W6"
   },
   "stage2": {
     "contract": "CIRCUIT_PREPARATION_BASE_PREVIEW_NO_TARGET",

--- a/data/testing/frostbloom_w6_bounded_forecast_v1.json
+++ b/data/testing/frostbloom_w6_bounded_forecast_v1.json
@@ -4,6 +4,7 @@
   "decision_id": "GM-FROSTBLOOM-W6-BOUNDED-CONSEQUENCE-FORECAST-01",
   "parent_decision": "GM-FROSTBLOOM-INTERNAL-VERTICAL-SLICE-01",
   "predecessor_refinement": "GM-FROSTBLOOM-10-23-LENS-INVESTIGATION-01",
+  "current_transition_refinement": "GM-FROSTBLOOM-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER-01",
   "segment": {
     "start_minute": 23,
     "end_minute": 30
@@ -11,7 +12,9 @@
   "entry_summary": {
     "known": 2,
     "unknown": 2,
-    "lens": 1
+    "lens": 1,
+    "persists_from_investigation": true,
+    "duplicate_decision_brief_required": false
   },
   "stage2": {
     "contract": "CIRCUIT_PREPARATION_BASE_PREVIEW_NO_TARGET",
@@ -61,14 +64,17 @@
   },
   "timing_test_values": [
     {
-      "phase": "DECISION_BRIEF",
+      "phase": "ELASTIC_HANDOFF_WINDOW",
       "start": "23:00",
-      "end": "24:00"
+      "end": "24:00",
+      "must_be_filled": false,
+      "new_content_allowed": false
     },
     {
       "phase": "STAGE2_CIRCUIT",
       "start": "24:00",
-      "end": "26:00"
+      "end": "26:00",
+      "may_begin_early_if_handoff_buffer_unused": true
     },
     {
       "phase": "STAGE3_TARGET_AND_FORECAST",
@@ -96,7 +102,10 @@
     "NO_AUTO_CAST",
     "NO_HIDDEN_EXTRA_MANA",
     "FIRST_ACCEPTED_W6_RESULT_REMAINS_TRUE",
-    "DOES_NOT_REPLACE_W7"
+    "DOES_NOT_REPLACE_W7",
+    "INVESTIGATION_SUMMARY_PERSISTS_INTO_W6",
+    "NO_DUPLICATE_W6_DECISION_BRIEF",
+    "ELASTIC_BUFFER_NOT_CONTENT"
   ],
   "human_validation": "NOT_RUN",
   "device_validation": "NOT_RUN",

--- a/data/testing/frostbloom_w7_context_delta_v1.json
+++ b/data/testing/frostbloom_w7_context_delta_v1.json
@@ -4,6 +4,7 @@
   "decision_id": "GM-FROSTBLOOM-W7-PRESERVED-FACT-CONTEXT-DELTA-01",
   "parent_decision": "GM-FROSTBLOOM-INTERNAL-VERTICAL-SLICE-01",
   "predecessor_refinement": "GM-FROSTBLOOM-W6-BOUNDED-CONSEQUENCE-FORECAST-01",
+  "current_transition_refinement": "GM-FROSTBLOOM-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER-01",
   "segment": {
     "start_minute": 30,
     "end_minute": 39
@@ -11,6 +12,7 @@
   "reveal": {
     "contract": "PRESERVED_FACT_CONTEXT_DELTA",
     "first_phase": "W6_RESULT_ANCHOR",
+    "anchor_presentation": "PERSISTENT_W6_RECEIPT_PIN_NO_RECAP_SCREEN",
     "w6_improvement_remains_true": true,
     "new_context_source": "POST_W6_DEEPER_REVISION_COUPLING",
     "replays_old_repair_record_node": false,
@@ -56,14 +58,18 @@
   },
   "timing_test_values": [
     {
-      "phase": "W6_RESULT_ANCHOR",
+      "phase": "ELASTIC_W6_TO_W7_HANDOFF",
       "start": "30:00",
-      "end": "31:00"
+      "end": "31:00",
+      "must_be_filled": false,
+      "new_content_allowed": false,
+      "anchor_is_persistent_w6_receipt": true
     },
     {
       "phase": "DEEPER_REVISION_REVEAL",
       "start": "31:00",
-      "end": "33:00"
+      "end": "33:00",
+      "may_begin_early_if_handoff_buffer_unused": true
     },
     {
       "phase": "CONTEXT_DELTA_SUMMARY",
@@ -91,7 +97,10 @@
     "NO_NUMBER_ONLY_AMPLIFICATION",
     "NO_NAMED_CORRECT_ROUTE",
     "NO_MOB_WAVE_ESCALATION",
-    "NO_HP_SPONGE_ESCALATION"
+    "NO_HP_SPONGE_ESCALATION",
+    "W6_RECEIPT_PINS_AS_W7_ANCHOR",
+    "NO_DUPLICATE_W7_RESULT_ANCHOR_SCREEN",
+    "ELASTIC_BUFFER_NOT_CONTENT"
   ],
   "human_validation": "NOT_RUN",
   "device_validation": "NOT_RUN",

--- a/docs/planning/FROSTBLOOM_FIRST_SESSION_PERSISTENT_HANDOFF_ELASTIC_BUFFER_01_APPROVAL_2026-08-20.md
+++ b/docs/planning/FROSTBLOOM_FIRST_SESSION_PERSISTENT_HANDOFF_ELASTIC_BUFFER_01_APPROVAL_2026-08-20.md
@@ -1,0 +1,204 @@
+# GM-FROSTBLOOM-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER-01
+
+## 1. 상태
+
+```yaml
+decision_id: GM-FROSTBLOOM-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER-01
+parent_decision: GM-FROSTBLOOM-INTERNAL-VERTICAL-SLICE-01
+predecessor_refinement: GM-FROSTBLOOM-PORTFOLIO-PREVIEW-EVIDENCE-ECHO-01
+sync_id: GR-SYNC-20260820-29-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER
+approval: USER_APPROVED_RECOMMENDED_OPTION_A
+work_mode: PLAN
+contract: PERSISTENT_HANDOFF_ELASTIC_BUFFER
+session_target: TARGET_46_UNCHANGED
+human_validation: NOT_RUN
+device_validation: NOT_RUN
+performance_validation: NOT_RUN
+full_slice_validation: NOT_RUN
+```
+
+2026-08-20 KST의 00~46분 end-to-end 검토에서 연속 recap 두 곳이 발견되었고, 사용자는 권장 A안 **Persistent Handoff + Elastic Buffer**를 승인했다.
+
+이 결정은 새 콘텐츠를 추가하거나 W6/W7의 의미를 바꾸지 않는다. 이미 읽은 정보를 다음 단계가 다시 설명하지 않도록 **직전 상태를 다음 단계에 지속 표시**하고, 그 결과 생기는 시간 여유는 실제 Human pacing·입력·가독성 편차를 흡수하는 가변 buffer로만 보존한다.
+
+## 2. 첫 번째 handoff · Investigation → W6
+
+기존 의미:
+
+```text
+22~23 Known 2 / Unknown 2 / Lens 1
+→ 23~24 같은 정보의 Decision Brief
+→ 24~26 W6 Stage 2
+```
+
+현재 의미:
+
+```text
+22~23 Known 2 / Unknown 2 / Lens 1
+→ 같은 summary가 W6 화면에 그대로 pin
+→ ELASTIC_HANDOFF_WINDOW (0~60초 TEST_VALUE, 별도 recap 콘텐츠 없음)
+→ W6 Stage 2
+```
+
+고정 계약:
+
+```text
+INVESTIGATION_SUMMARY_PERSISTS_INTO_W6
+NO_DUPLICATE_W6_DECISION_BRIEF
+ELASTIC_BUFFER_NOT_CONTENT
+```
+
+- `Known 2 / Unknown 2 / Lens 1`은 W6 진입 정보로 그대로 남는다.
+- W6는 같은 내용을 새 modal/page/mentor line으로 다시 읽히지 않는다.
+- 플레이어가 즉시 준비되면 Stage 2를 더 일찍 시작할 수 있다.
+- 터치 입력, 읽기, 화면 전환, 짧은 애니메이션 때문에 시간이 필요하면 최대 60초의 기존 여유를 사용할 수 있다.
+- buffer가 남았다고 tutorial, dialogue, lore, reward, 새 choice를 채워 넣지 않는다.
+
+## 3. 두 번째 handoff · W6 → W7
+
+기존 의미:
+
+```text
+29~30 W6 Actual Consequence Receipt
+→ 30~31 W6 Result Anchor 재읽기
+→ 31~33 post-W6 deeper coupling
+```
+
+현재 의미:
+
+```text
+29~30 W6 Actual Consequence Receipt
+→ 실제 개선 receipt를 W7의 W6_RESULT_ANCHOR로 그대로 pin
+→ ELASTIC_W6_TO_W7_HANDOFF (0~60초 TEST_VALUE, 별도 recap 화면 없음)
+→ post-W6 deeper coupling
+```
+
+고정 계약:
+
+```text
+W6_RECEIPT_PINS_AS_W7_ANCHOR
+NO_DUPLICATE_W7_RESULT_ANCHOR_SCREEN
+FIRST_ACCEPTED_W6_RESULT_REMAINS_TRUE
+```
+
+`W6_RESULT_ANCHOR`라는 의미는 삭제하지 않는다. W7이 새 coupling을 보여주기 전에 “W6에서 실제로 좋아진 것은 여전히 사실”이라는 기준점이 반드시 있어야 한다. 다만 그 기준점은 바로 직전 W6 receipt의 **persistent pin state**로 충족한다.
+
+## 4. Elastic Buffer 규칙
+
+```yaml
+contract: ELASTIC_BUFFER_NOT_CONTENT
+must_be_filled: false
+new_content_allowed: false
+fixed_pause_required: false
+may_absorb:
+  - transition_latency
+  - input_latency
+  - reading_variance
+  - short_existing_animation_variance
+  - accessibility_pacing_variance
+may_not_absorb:
+  - new_tutorial
+  - new_lore
+  - new_reward
+  - new_gameplay_choice
+  - second_incident
+  - extra_mandatory_dialogue
+```
+
+두 window는 각각 `0~60초`의 Human Slice용 TEST_VALUE다. 둘 다 반드시 60초를 소비해야 하는 것이 아니다. 실제 플레이가 빠르면 세션이 46분보다 짧아질 수 있으며, 남은 시간을 인위적으로 채우지 않는다.
+
+따라서:
+
+```text
+NO_NEW_CONTENT_FROM_RECOVERED_TIME
+TARGET_46_UNCHANGED
+REWORK_53_UNCHANGED
+HARD_STOP_60_UNCHANGED
+```
+
+## 5. Existing Solution First
+
+재사용:
+
+```text
+Known 2 / Unknown 2 / Lens 1 summary
+W6 Stage 2/3
+W6 Actual Consequence Receipt
+W6_RESULT_ANCHOR semantic invariant
+W7 post-W6 deeper coupling
+existing 46 / 53 / 60 timing contract
+```
+
+새로 만들지 않음:
+
+```text
+new decision-brief system
+new result-anchor transaction
+buffer event system
+new tutorial step
+new story beat
+new reward/currency
+new gameplay decision
+```
+
+## 6. 선택 대안 기록
+
+### A · Persistent Handoff + Elastic Buffer — 승인
+동일 정보의 연속 재복기를 제거하고 남는 시간은 비콘텐츠 buffer로 둔다.
+
+### B · 회수 시간을 W6/W7 판단 시간에 고정 재배분 — 기각
+실제 Human evidence 없이 새 고정 배분을 확정하면 또 다른 pacing 가정을 만든다.
+
+### C · 15~20초 micro-recap 유지 — 기각
+중복은 줄지만 직전 화면을 곧바로 다시 요약할 이유가 아직 없다.
+
+### D · 현행 1분 recap 유지 — 기각
+end-to-end 검토에서 이미 연속 반복으로 확인됐다.
+
+## 7. Benchmark disposition
+
+본 결정은 직전 `FROSTBLOOM_FIRST_SESSION_END_TO_END_REVIEW`와 같은 work unit이다. 범위와 핵심 가정이 바뀌지 않았으므로 같은 work-unit research를 재사용한다.
+
+- Nintendo Game Builder Garage — 작은 점진적 완료 단위와 recall-only 진행 의존 회피 패턴을 ADAPT.
+- GDC Mushroom 11 — 실제 gameplay 안에서 점진적이고 집중적으로 학습시키는 패턴을 ADAPT.
+
+표현·콘텐츠는 복제하지 않는다.
+
+## 8. 5회 적대적 검토
+
+### Pass 1 · 정보 삭제 공격
+요약을 없애면서 W6가 어떤 Known/Unknown/Lens를 받았는지 사라지는가?
+
+가드: summary는 삭제가 아니라 persistent pin. **PASS**.
+
+### Pass 2 · W6 성취 삭제 공격
+Result Anchor 화면을 없애면서 W6 개선 보존도 없어지는가?
+
+가드: actual W6 receipt 자체가 anchor로 pin되고 `FIRST_ACCEPTED_W6_RESULT_REMAINS_TRUE` 유지. **PASS**.
+
+### Pass 3 · 빈 시간 content-creep 공격
+회수 시간을 새 tutorial/lore/reward로 채우는가?
+
+가드: `ELASTIC_BUFFER_NOT_CONTENT`, `NO_NEW_CONTENT_FROM_RECOVERED_TIME`. **PASS**.
+
+### Pass 4 · 무조건 대기 공격
+buffer가 60초 강제 pause가 되는가?
+
+가드: `must_be_filled=false`, `fixed_pause_required=false`. **PASS**.
+
+### Pass 5 · 46분 계약 붕괴 공격
+buffer를 제거하면서 46분 target 자체를 44분으로 재정의하는가?
+
+가드: `TARGET_46_UNCHANGED`; 46은 Human target hypothesis이며 빠른 플레이가 더 짧아지는 것은 허용. **PASS**.
+
+## 9. 재검토 조건
+
+Human/Device test에서 다음이 발생하면 buffer cap과 persistent presentation을 다시 본다.
+
+- summary pin이 지나치게 화면을 점유함.
+- W6 receipt pin이 W7 reveal의 주목도를 방해함.
+- 실제 전환 지연이 반복적으로 60초를 초과함.
+- 빠른 플레이어가 갑작스러운 전환으로 느낀다고 보고함.
+- mobile에서 pin + active UI가 동시에 보이기 어려움.
+
+그 전까지 구조적 결정만 PASS이며 실제 pacing, 피로, comprehension, mobile readability는 `NOT_RUN`이다.

--- a/docs/planning/research/2026-08-20-first-session-persistent-handoff-elastic-buffer-research-receipt.md
+++ b/docs/planning/research/2026-08-20-first-session-persistent-handoff-elastic-buffer-research-receipt.md
@@ -1,0 +1,58 @@
+# Research Receipt — First-Session Persistent Handoff + Elastic Buffer
+
+```yaml
+work_unit: FROSTBLOOM_FIRST_SESSION_END_TO_END_REVIEW
+refinement: GM-FROSTBLOOM-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER-01
+research_reuse: SAME_WORK_UNIT_SCOPE_AND_ASSUMPTIONS_UNCHANGED
+fresh_research_performed_in_parent_review: true
+```
+
+## Question
+
+How should the 00–46 Frostbloom slice remove two adjacent recap repetitions without deleting decision context or inventing replacement content before Human/Device evidence exists?
+
+## Reused fresh benchmark evidence
+
+### Nintendo · Game Builder Garage developer interview
+
+Source: https://www.nintendo.com/us/whatsnew/ask-the-developer-vol-1-game-builder-garage/
+
+Pattern used:
+- small, incremental learning/completion units;
+- avoid progression that depends only on the player recalling previously presented information;
+- keep the next actionable context available rather than turning memory into an unnecessary test.
+
+Disposition: **ADAPT**.
+
+### GDC · Mushroom 11 tutorial/onboarding design
+
+Source: GDC Vault / Mushroom 11 tutorial design material reviewed in the parent end-to-end work unit.
+
+Pattern used:
+- teach progressively through actual play;
+- keep instruction focused on the current action;
+- avoid adding explanation after the player has already demonstrated the relevant understanding.
+
+Disposition: **ADAPT**.
+
+## Existing Solution First
+
+Existing GRIMOIRE authorities already contain every required datum:
+
+- `Known 2 / Unknown 2 / Lens 1` before W6;
+- W6 `ACTUAL_IMPROVEMENT / COST_OR_FORGONE_VALUE / REMAINING_UNCERTAINTY` receipt;
+- W7 `W6_RESULT_ANCHOR` semantic guard;
+- 46 / 53 / 60 session timing hypotheses.
+
+Therefore a new recap system, buffer event system, tutorial beat, or story beat is unnecessary.
+
+## Alternatives
+
+A. **Persistent Handoff + Elastic Buffer** — approved/adopted.
+B. Reallocate recovered time to fixed W6/W7 thinking time — rejected until Human evidence.
+C. Keep 15–20 second micro-recaps — rejected because no need is demonstrated yet.
+D. Keep existing one-minute recaps — rejected by end-to-end duplicate-transition finding.
+
+## Boundary
+
+This receipt supports transition-presentation refinement only. It does not establish actual completion time, comprehension, fatigue, accessibility, mobile readability, or fun. Those remain `NOT_RUN`.

--- a/docs/planning/sync/GR-SYNC-20260820-29-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER.md
+++ b/docs/planning/sync/GR-SYNC-20260820-29-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER.md
@@ -1,0 +1,71 @@
+# GR-SYNC-20260820-29-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER
+
+```yaml
+sync_id: GR-SYNC-20260820-29-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER
+decision_id: GM-FROSTBLOOM-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER-01
+approval: USER_APPROVED_RECOMMENDED_OPTION_A
+parent_main: 48e99d54ebc6925a8c9181d88bfe3b3dc165b721
+base_main_observed: 3cdb82f94af402fedcc9c1e80902d1d01b8d3ab3
+mode: PLAN
+human_validation: NOT_RUN
+device_validation: NOT_RUN
+performance_validation: NOT_RUN
+full_slice_validation: NOT_RUN
+```
+
+## User-approved refinement
+
+The 00–46 end-to-end review found two adjacent recap repetitions. The approved correction is:
+
+```text
+PERSISTENT_HANDOFF_ELASTIC_BUFFER
+INVESTIGATION_SUMMARY_PERSISTS_INTO_W6
+NO_DUPLICATE_W6_DECISION_BRIEF
+W6_RECEIPT_PINS_AS_W7_ANCHOR
+NO_DUPLICATE_W7_RESULT_ANCHOR_SCREEN
+ELASTIC_BUFFER_NOT_CONTENT
+NO_NEW_CONTENT_FROM_RECOVERED_TIME
+TARGET_46_UNCHANGED
+```
+
+## TDD receipt
+
+RED branch commits added a dedicated persistent contract test and registered it in planning CI before canon/fixture implementation.
+
+Expected RED failures were confined to:
+
+- missing handoff canon/fixture;
+- missing persistent W6 entry-summary fields;
+- missing persistent W7 anchor-presentation field;
+- missing current handoff overlay registration.
+
+Existing Frostbloom and runtime contracts remained green before the new test step failed.
+
+GREEN artifacts:
+
+- `docs/planning/FROSTBLOOM_FIRST_SESSION_PERSISTENT_HANDOFF_ELASTIC_BUFFER_01_APPROVAL_2026-08-20.md`
+- `data/testing/frostbloom_first_session_handoff_buffer_v1.json`
+- `docs/testing/frostbloom_graybox/08_FIRST_SESSION_HANDOFF_BUFFER_OVERLAY.md`
+- W6/W7 machine fixtures updated as current consumers
+- Graybox README updated with active refinement 7
+- `tests/test_frostbloom_first_session_handoff_buffer_contract.py`
+- planning CI permanently runs the new contract
+- same-work-unit research receipt preserved
+
+## Meaning boundary
+
+No product implementation is added. No new Scene, Resource, addon, asset, gameplay system, reward, quest, or story beat is authorized.
+
+`W6_RESULT_ANCHOR` still exists semantically; only its duplicate recap screen is removed. `Known 2 / Unknown 2 / Lens 1` still exists semantically; only the duplicate W6 Decision Brief is removed.
+
+The two former one-minute recap slots are now elastic Human-test capacity, not guaranteed pause or content allocation.
+
+## Adversarial review
+
+1. Information deletion — blocked by persistent investigation summary.
+2. W6 result rollback — blocked by persistent W6 receipt anchor.
+3. Buffer content creep — blocked by `ELASTIC_BUFFER_NOT_CONTENT`.
+4. Forced one-minute waiting — blocked by `must_be_filled=false`.
+5. Session target drift — blocked by `TARGET_46_UNCHANGED`.
+
+Structural verdict: PASS pending exact-head CI.

--- a/docs/testing/frostbloom_graybox/08_FIRST_SESSION_HANDOFF_BUFFER_OVERLAY.md
+++ b/docs/testing/frostbloom_graybox/08_FIRST_SESSION_HANDOFF_BUFFER_OVERLAY.md
@@ -1,0 +1,69 @@
+# Frostbloom Internal Graybox — 08 First-Session Handoff Buffer Overlay
+
+```yaml
+decision_id: GM-FROSTBLOOM-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER-01
+contract: PERSISTENT_HANDOFF_ELASTIC_BUFFER
+status: CURRENT_CHILD_OVERLAY
+human_validation: NOT_RUN
+device_validation: NOT_RUN
+```
+
+This overlay supersedes only the duplicated transition presentation in the base 46-minute walkthrough. It does not replace W6/W7 causal or gameplay authority.
+
+## Investigation → W6
+
+```text
+22~23 Known 2 / Unknown 2 / Lens 1
+→ persist the same summary into W6
+→ optional 0~60s ELASTIC_HANDOFF_WINDOW
+→ W6 Stage 2
+```
+
+Hard guards:
+
+```text
+INVESTIGATION_SUMMARY_PERSISTS_INTO_W6
+NO_DUPLICATE_W6_DECISION_BRIEF
+ELASTIC_BUFFER_NOT_CONTENT
+```
+
+The summary remains visible/available as the entry state. No second recap modal/page/mentor explanation is required.
+
+## W6 → W7
+
+```text
+29~30 W6 Actual Consequence Receipt
+→ pin the same receipt as W6_RESULT_ANCHOR
+→ optional 0~60s ELASTIC_W6_TO_W7_HANDOFF
+→ post-W6 deeper revision coupling
+```
+
+Hard guards:
+
+```text
+W6_RECEIPT_PINS_AS_W7_ANCHOR
+NO_DUPLICATE_W7_RESULT_ANCHOR_SCREEN
+FIRST_ACCEPTED_W6_RESULT_REMAINS_TRUE
+```
+
+The anchor semantic remains mandatory. Only the duplicated re-reading screen is removed.
+
+## Buffer behavior
+
+```text
+ELASTIC_BUFFER_NOT_CONTENT
+NO_NEW_CONTENT_FROM_RECOVERED_TIME
+TARGET_46_UNCHANGED
+```
+
+Unused buffer may collapse to zero. It can absorb transition/input/reading/accessibility variance, but cannot become new tutorial, lore, reward, gameplay choice, second incident, or mandatory dialogue.
+
+## Adversarial result
+
+1. Information deletion — PASS; summary persists.
+2. W6 rollback — PASS; actual receipt remains anchor.
+3. Content creep — PASS; buffer is not fill space.
+4. Forced waiting — PASS; buffer may collapse to zero.
+5. Target drift — PASS; 46-minute target remains a Human-test hypothesis.
+
+Actual pacing and device readability remain NOT_RUN.

--- a/docs/testing/frostbloom_graybox/README.md
+++ b/docs/testing/frostbloom_graybox/README.md
@@ -9,8 +9,9 @@ ACTIVE_REFINEMENT_3: GM-FROSTBLOOM-W6-BOUNDED-CONSEQUENCE-FORECAST-01
 ACTIVE_REFINEMENT_4: GM-FROSTBLOOM-W7-PRESERVED-FACT-CONTEXT-DELTA-01
 ACTIVE_REFINEMENT_5: GM-FROSTBLOOM-RESULT-GRIMOIRE-CAUSAL-DEBRIEF-01
 ACTIVE_REFINEMENT_6: GM-FROSTBLOOM-PORTFOLIO-PREVIEW-EVIDENCE-ECHO-01
+ACTIVE_REFINEMENT_7: GM-FROSTBLOOM-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER-01
 SCOPE: INTERNAL_DESIGN_VALIDATION_ONLY
-EXECUTION_ORDER: 01 -> 02 -> 03 -> 04 -> 05 -> 06 -> 07
+EXECUTION_ORDER: 01 -> 02 -> 03 -> 04 -> 05 -> 06 -> 07 -> 08
 HUMAN_VALIDATION: NOT_RUN
 DEVICE_VALIDATION: NOT_RUN
 PERFORMANCE_VALIDATION: NOT_RUN
@@ -22,7 +23,7 @@ TASK8: SEPARATE_PRODUCT_WORKSTREAM_UNCHANGED_BY_PLANNING_OVERLAYS
 
 ## Purpose
 
-This pack attacks the approved Frostbloom Single-Incident Spiral before release-near runtime integration. It checks chronology, information leakage, writing-event distinctness, all six 2-of-4 investigation pairs, four free-schedule choices, W6 bounded forecast/consequence preservation, W7 preserved-fact/context-delta redesign distinctness, five-axis results, layered Grimoire causality/player-principle authorship, Portfolio/Preview evidence acknowledgement and non-objective curiosity close, and fourteen parent-pack adversarial regressions.
+This pack attacks the approved Frostbloom Single-Incident Spiral before release-near runtime integration. It checks chronology, information leakage, writing-event distinctness, all six 2-of-4 investigation pairs, four free-schedule choices, W6 bounded forecast/consequence preservation, W7 preserved-fact/context-delta redesign distinctness, five-axis results, layered Grimoire causality/player-principle authorship, Portfolio/Preview evidence acknowledgement and non-objective curiosity close, first-session transition handoffs, and fourteen parent-pack adversarial regressions.
 
 Active child refinements additionally require:
 
@@ -37,9 +38,12 @@ Active child refinements additionally require:
 - minutes 39–44: `FIVE_AXIS_RESULT_SNAPSHOT` → `CAUSAL_THREAD_ACTUAL_RECEIPTS_ONLY` → separate Cost/Forgone/Discovery → `SHORT_PLAYER_PRINCIPLE_NAMING`;
 - Result/Grimoire has no global success grade, may not invent an unobserved cause, and may not system-author/grade/reward the principle wording;
 - minutes 44–46: `MENTOR_RESPONSE_DESCRIPTIVE_NOT_VERDICT` → `PORTFOLIO_RECEIPT` → `OPEN_QUESTION_NOT_OBJECTIVE` + `FESTIVAL_PREVIEW_ONLY` → close;
-- Portfolio/Preview may not add mentor grade/result rescore/hidden best answer, next-quest choice, second incident, lore dump, or any new gameplay decision.
+- Portfolio/Preview may not add mentor grade/result rescore/hidden best answer, next-quest choice, second incident, lore dump, or any new gameplay decision;
+- transition overlay: `PERSISTENT_HANDOFF_ELASTIC_BUFFER` keeps the 22–23 investigation summary pinned into W6 and the W6 actual receipt pinned as W7 anchor;
+- transition overlay forbids `NO_DUPLICATE_W6_DECISION_BRIEF` and `NO_DUPLICATE_W7_RESULT_ANCHOR_SCREEN` violations;
+- any recovered transition time follows `ELASTIC_BUFFER_NOT_CONTENT` and cannot be filled with new tutorial/lore/reward/gameplay content.
 
-It does **not** prove fun, human comprehension, real 10/23/30/39/44/46-minute completion, forecast fairness, W7 emotional acceptance, Result/Grimoire causal comprehension, principle-entry comfort, Portfolio/Preview emotional closure, open-question interpretation, accessibility, device behavior, performance, export quality, or Task8 runtime behavior.
+It does **not** prove fun, human comprehension, real 10/23/30/39/44/46-minute completion, forecast fairness, W7 emotional acceptance, Result/Grimoire causal comprehension, principle-entry comfort, Portfolio/Preview emotional closure, open-question interpretation, transition pacing, elastic-buffer sufficiency, accessibility, device behavior, performance, export quality, or Task8 runtime behavior.
 
 ## Pack surfaces
 
@@ -50,6 +54,7 @@ It does **not** prove fun, human comprehension, real 10/23/30/39/44/46-minute co
 5. `05_W6_REVEAL_W7_CONSEQUENCE_CASES.md`
 6. `06_RESULT_AND_GRIMOIRE_CASES.md`
 7. `07_ADVERSARIAL_WALKTHROUGH.md`
+8. `08_FIRST_SESSION_HANDOFF_BUFFER_OVERLAY.md`
 
 Machine-readable parent authority: `data/testing/frostbloom_internal_graybox_pack_v1.json`.
 Machine-readable 10–23 child overlay: `data/testing/frostbloom_10_23_lens_v1.json`.
@@ -57,7 +62,8 @@ Machine-readable W6 child overlay: `data/testing/frostbloom_w6_bounded_forecast_
 Machine-readable W7 child overlay: `data/testing/frostbloom_w7_context_delta_v1.json`.
 Machine-readable Result/Grimoire child overlay: `data/testing/frostbloom_result_grimoire_debrief_v1.json`.
 Machine-readable Portfolio/Preview child overlay: `data/testing/frostbloom_portfolio_preview_v1.json`.
-Automated structure contracts: `tests/test_frostbloom_internal_vertical_slice_contract.py` and `tests/test_frostbloom_internal_graybox_pack_contract.py`.
+Machine-readable first-session handoff overlay: `data/testing/frostbloom_first_session_handoff_buffer_v1.json`.
+Automated structure contracts: `tests/test_frostbloom_internal_vertical_slice_contract.py`, `tests/test_frostbloom_first_session_handoff_buffer_contract.py`, and `tests/test_frostbloom_internal_graybox_pack_contract.py`.
 
 ## Rollup
 
@@ -67,8 +73,8 @@ READY_WITH_RISKS = zero FAIL and one-or-more in-scope design RISK
 INTERNAL_PACK_PASS = zero FAIL; NOT_TESTABLE_YET may remain only on out-of-scope human/runtime/device/performance questions
 ```
 
-Current internal rollup is `INTERNAL_PACK_PASS`: parent design-structural hard invariants pass and active child overlays add no structural FAIL. Actual elapsed time, comprehension, Lens desirability, investigation-choice reasoning, W6 forecast fairness/readability, W7 reveal acceptance/redesign reasoning, Result/Grimoire comprehension, player-principle input burden, Portfolio/Preview closure/mentor-tone/open-question interpretation, handwriting fatigue, and device behavior remain `NOT_TESTABLE_YET` or `NOT_RUN`.
+Current internal rollup is `INTERNAL_PACK_PASS`: parent design-structural hard invariants pass and active child overlays add no structural FAIL. Actual elapsed time, comprehension, Lens desirability, investigation-choice reasoning, W6 forecast fairness/readability, W7 reveal acceptance/redesign reasoning, Result/Grimoire comprehension, player-principle input burden, Portfolio/Preview closure/mentor-tone/open-question interpretation, first-session transition pacing, handwriting fatigue, and device behavior remain `NOT_TESTABLE_YET` or `NOT_RUN`.
 
 ## Ownership boundary
 
-This pack validates approved Frostbloom content assumptions. It does not own glyph recognition, FIVE_POINT_STAR math, mana, prepared-spell inventory, atomic spell use, result-ledger semantics, generic save I/O, Task8 Spell Use Screen UI, grading, morality scoring, quest-generation authority, or long-term principle-reward systems. Planning refinements may alter chronology, information framing, and content contracts only; product implementation remains a later separate work unit.
+This pack validates approved Frostbloom content assumptions. It does not own glyph recognition, FIVE_POINT_STAR math, mana, prepared-spell inventory, atomic spell use, result-ledger semantics, generic save I/O, Task8 Spell Use Screen UI, grading, morality scoring, quest-generation authority, or long-term principle-reward systems. Planning refinements may alter chronology, information framing, transition presentation, and content contracts only; product implementation remains a later separate work unit.

--- a/tests/test_frostbloom_first_session_handoff_buffer_contract.py
+++ b/tests/test_frostbloom_first_session_handoff_buffer_contract.py
@@ -49,8 +49,9 @@ class FrostbloomFirstSessionHandoffBufferContractTests(unittest.TestCase):
 
     def test_existing_w6_w7_fixtures_consume_handoff_without_recap(self):
         w6 = json.loads(W6_FIXTURE.read_text(encoding="utf-8"))
-        self.assertTrue(w6["entry_summary"]["persists_from_investigation"])
-        self.assertFalse(w6["entry_summary"]["duplicate_decision_brief_required"])
+        self.assertEqual({"known": 2, "unknown": 2, "lens": 1}, w6["entry_summary"])
+        self.assertTrue(w6["entry_handoff"]["persists_from_investigation"])
+        self.assertFalse(w6["entry_handoff"]["duplicate_decision_brief_required"])
         self.assertEqual("ELASTIC_HANDOFF_WINDOW", w6["timing_test_values"][0]["phase"])
 
         w7 = json.loads(W7_FIXTURE.read_text(encoding="utf-8"))

--- a/tests/test_frostbloom_first_session_handoff_buffer_contract.py
+++ b/tests/test_frostbloom_first_session_handoff_buffer_contract.py
@@ -7,13 +7,13 @@ CANON = ROOT / "docs/planning/FROSTBLOOM_FIRST_SESSION_PERSISTENT_HANDOFF_ELASTI
 FIXTURE = ROOT / "data/testing/frostbloom_first_session_handoff_buffer_v1.json"
 W6_FIXTURE = ROOT / "data/testing/frostbloom_w6_bounded_forecast_v1.json"
 W7_FIXTURE = ROOT / "data/testing/frostbloom_w7_context_delta_v1.json"
-WALK = ROOT / "docs/testing/frostbloom_graybox/01_46_MINUTE_WALKTHROUGH.md"
-CURRENT = ROOT / "docs/planning/CURRENT_CONFIRMED_DECISIONS.md"
+OVERLAY = ROOT / "docs/testing/frostbloom_graybox/08_FIRST_SESSION_HANDOFF_BUFFER_OVERLAY.md"
+README = ROOT / "docs/testing/frostbloom_graybox/README.md"
 
 
 class FrostbloomFirstSessionHandoffBufferContractTests(unittest.TestCase):
     def test_required_artifacts_exist(self):
-        for path in (CANON, FIXTURE, W6_FIXTURE, W7_FIXTURE, WALK, CURRENT):
+        for path in (CANON, FIXTURE, W6_FIXTURE, W7_FIXTURE, OVERLAY, README):
             self.assertTrue(path.is_file(), path)
 
     def test_persistent_handoff_elastic_buffer_contract(self):
@@ -58,16 +58,18 @@ class FrostbloomFirstSessionHandoffBufferContractTests(unittest.TestCase):
         self.assertEqual("PERSISTENT_W6_RECEIPT_PIN_NO_RECAP_SCREEN", w7["reveal"]["anchor_presentation"])
         self.assertEqual("ELASTIC_W6_TO_W7_HANDOFF", w7["timing_test_values"][0]["phase"])
 
-    def test_walkthrough_and_current_snapshot_are_updated(self):
-        walk = WALK.read_text(encoding="utf-8")
-        current = CURRENT.read_text(encoding="utf-8")
+    def test_graybox_overlay_is_current_consumer(self):
+        overlay = OVERLAY.read_text(encoding="utf-8")
+        readme = README.read_text(encoding="utf-8")
         for token in (
             "PERSISTENT_HANDOFF_ELASTIC_BUFFER",
             "NO_DUPLICATE_W6_DECISION_BRIEF",
             "NO_DUPLICATE_W7_RESULT_ANCHOR_SCREEN",
+            "ELASTIC_BUFFER_NOT_CONTENT",
         ):
-            self.assertIn(token, walk)
-            self.assertIn(token, current)
+            self.assertIn(token, overlay)
+        self.assertIn("ACTIVE_REFINEMENT_7: GM-FROSTBLOOM-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER-01", readme)
+        self.assertIn("08_FIRST_SESSION_HANDOFF_BUFFER_OVERLAY.md", readme)
 
 
 if __name__ == "__main__":

--- a/tests/test_frostbloom_first_session_handoff_buffer_contract.py
+++ b/tests/test_frostbloom_first_session_handoff_buffer_contract.py
@@ -1,0 +1,74 @@
+import json
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+CANON = ROOT / "docs/planning/FROSTBLOOM_FIRST_SESSION_PERSISTENT_HANDOFF_ELASTIC_BUFFER_01_APPROVAL_2026-08-20.md"
+FIXTURE = ROOT / "data/testing/frostbloom_first_session_handoff_buffer_v1.json"
+W6_FIXTURE = ROOT / "data/testing/frostbloom_w6_bounded_forecast_v1.json"
+W7_FIXTURE = ROOT / "data/testing/frostbloom_w7_context_delta_v1.json"
+WALK = ROOT / "docs/testing/frostbloom_graybox/01_46_MINUTE_WALKTHROUGH.md"
+CURRENT = ROOT / "docs/planning/CURRENT_CONFIRMED_DECISIONS.md"
+
+
+class FrostbloomFirstSessionHandoffBufferContractTests(unittest.TestCase):
+    def test_required_artifacts_exist(self):
+        for path in (CANON, FIXTURE, W6_FIXTURE, W7_FIXTURE, WALK, CURRENT):
+            self.assertTrue(path.is_file(), path)
+
+    def test_persistent_handoff_elastic_buffer_contract(self):
+        text = CANON.read_text(encoding="utf-8")
+        for token in (
+            "GM-FROSTBLOOM-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER-01",
+            "PERSISTENT_HANDOFF_ELASTIC_BUFFER",
+            "INVESTIGATION_SUMMARY_PERSISTS_INTO_W6",
+            "NO_DUPLICATE_W6_DECISION_BRIEF",
+            "W6_RECEIPT_PINS_AS_W7_ANCHOR",
+            "NO_DUPLICATE_W7_RESULT_ANCHOR_SCREEN",
+            "ELASTIC_BUFFER_NOT_CONTENT",
+            "NO_NEW_CONTENT_FROM_RECOVERED_TIME",
+            "TARGET_46_UNCHANGED",
+            "human_validation: NOT_RUN",
+            "device_validation: NOT_RUN",
+            "full_slice_validation: NOT_RUN",
+        ):
+            self.assertIn(token, text)
+
+        data = json.loads(FIXTURE.read_text(encoding="utf-8"))
+        self.assertEqual("PERSISTENT_HANDOFF_ELASTIC_BUFFER", data["contract"])
+        self.assertTrue(data["investigation_to_w6"]["summary_persists_into_w6"])
+        self.assertFalse(data["investigation_to_w6"]["duplicate_decision_brief_screen"])
+        self.assertEqual(60, data["investigation_to_w6"]["elastic_buffer_max_seconds_test_value"])
+        self.assertTrue(data["w6_to_w7"]["w6_receipt_pins_as_anchor"])
+        self.assertFalse(data["w6_to_w7"]["duplicate_result_anchor_screen"])
+        self.assertEqual(60, data["w6_to_w7"]["elastic_buffer_max_seconds_test_value"])
+        self.assertFalse(data["elastic_buffer"]["must_be_filled"])
+        self.assertFalse(data["elastic_buffer"]["new_content_allowed"])
+        self.assertEqual(46, data["session_target_minutes"])
+        self.assertEqual("NOT_RUN", data["human_validation"])
+
+    def test_existing_w6_w7_fixtures_consume_handoff_without_recap(self):
+        w6 = json.loads(W6_FIXTURE.read_text(encoding="utf-8"))
+        self.assertTrue(w6["entry_summary"]["persists_from_investigation"])
+        self.assertFalse(w6["entry_summary"]["duplicate_decision_brief_required"])
+        self.assertEqual("ELASTIC_HANDOFF_WINDOW", w6["timing_test_values"][0]["phase"])
+
+        w7 = json.loads(W7_FIXTURE.read_text(encoding="utf-8"))
+        self.assertEqual("W6_RESULT_ANCHOR", w7["reveal"]["first_phase"])
+        self.assertEqual("PERSISTENT_W6_RECEIPT_PIN_NO_RECAP_SCREEN", w7["reveal"]["anchor_presentation"])
+        self.assertEqual("ELASTIC_W6_TO_W7_HANDOFF", w7["timing_test_values"][0]["phase"])
+
+    def test_walkthrough_and_current_snapshot_are_updated(self):
+        walk = WALK.read_text(encoding="utf-8")
+        current = CURRENT.read_text(encoding="utf-8")
+        for token in (
+            "PERSISTENT_HANDOFF_ELASTIC_BUFFER",
+            "NO_DUPLICATE_W6_DECISION_BRIEF",
+            "NO_DUPLICATE_W7_RESULT_ANCHOR_SCREEN",
+        ):
+            self.assertIn(token, walk)
+            self.assertIn(token, current)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Goal

Promote the user-approved `Persistent Handoff + Elastic Buffer` refinement found by the 00–46 minute end-to-end review.

## Protected meaning

- `22~23 Known 2 / Unknown 2 / Lens 1` remains the W6 entry state, but persists into W6 instead of being repeated as a separate 23~24 Decision Brief screen.
- W6 actual consequence receipt remains the factual W7 anchor, but stays pinned instead of being repeated as a separate 30~31 Result Anchor recap screen.
- the recovered transition capacity is elastic pacing/input/readability buffer, not new content.
- W6 real improvement preservation, W7 post-W6 coupling, FIVE_POINT_STAR/Stage2/3 ownership, 46-minute target, and Human/Device evidence ceilings remain unchanged.

## TDD

First commits are intentionally RED. `tests.test_frostbloom_first_session_handoff_buffer_contract` requires:
- `PERSISTENT_HANDOFF_ELASTIC_BUFFER`
- `INVESTIGATION_SUMMARY_PERSISTS_INTO_W6`
- `NO_DUPLICATE_W6_DECISION_BRIEF`
- `W6_RECEIPT_PINS_AS_W7_ANCHOR`
- `NO_DUPLICATE_W7_RESULT_ANCHOR_SCREEN`
- `ELASTIC_BUFFER_NOT_CONTENT`
- `NO_NEW_CONTENT_FROM_RECOVERED_TIME`
- `TARGET_46_UNCHANGED`

## Research

The approved end-to-end review work unit already performed fresh onboarding/tutorial benchmarking (Nintendo Game Builder Garage and GDC Mushroom 11). Scope and assumptions are unchanged, so that receipt is reused under the project same-work-unit rule.

## Scope

Planning/docs/test-data/tests/CI registration/Notion only. No product src, Scene, Resource, addon, asset, project.godot, Task8, balance, or runtime behavior mutation.