### PR TITLE
docs(planning): close Frostbloom current planning pointer

### DIFF
--- a/.github/workflows/validate-base-v9-adoption.yml
+++ b/.github/workflows/validate-base-v9-adoption.yml
@@ -20,6 +20,7 @@ jobs:
       - run: python -m unittest tests.test_year_one_growth_economy_test_values_contract -v
       - run: python -m unittest tests.test_frostbloom_internal_vertical_slice_contract -v
       - run: python -m unittest tests.test_frostbloom_first_session_handoff_buffer_contract -v
+      - run: python -m unittest tests.test_frostbloom_planning_pointer_closeout_contract -v
       - run: python -m unittest tests.test_prework_benchmark_industry_research_contract -v
       - run: python -m unittest tests.test_frostbloom_internal_graybox_pack_contract -v
       - name: Validate JSON

--- a/docs/planning/CURRENT_CONFIRMED_DECISIONS.md
+++ b/docs/planning/CURRENT_CONFIRMED_DECISIONS.md
@@ -14,7 +14,7 @@ prework_research_decision: GM-PREWORK-BENCHMARK-INDUSTRY-RESEARCH-01
 prework_research_sync: GR-SYNC-20260811-13-PREWORK-BENCHMARK-INDUSTRY-RESEARCH
 prework_research_gate: REQUIRED_BEFORE_NEW_SUBSTANTIVE_WORK_UNIT
 prework_research_same_work_unit_receipt_reuse: ALLOWED_IF_SCOPE_AND_KEY_ASSUMPTIONS_UNCHANGED
-base_current_main_observed: 3cdb82f94af402fedcc9c1e80902d1d01b8d3ab3
+base_current_main_observed: 369e7173c6a21ec2c7e70cef5e11f799a5d7dbc0
 base_project_pin: v9.4.3
 base_pin_update: NOT_APPROVED_NOT_PERFORMED
 current_state_sync: GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT
@@ -41,8 +41,10 @@ w7_refinement: GM-FROSTBLOOM-W7-PRESERVED-FACT-CONTEXT-DELTA-01
 w7_refinement_sync: GR-SYNC-20260820-26-W7-PRESERVED-FACT-CONTEXT-DELTA
 result_grimoire_refinement: GM-FROSTBLOOM-RESULT-GRIMOIRE-CAUSAL-DEBRIEF-01
 result_grimoire_refinement_sync: GR-SYNC-20260820-27-RESULT-GRIMOIRE-CAUSAL-DEBRIEF
-current_planning_refinement: GM-FROSTBLOOM-PORTFOLIO-PREVIEW-EVIDENCE-ECHO-01
-current_planning_refinement_sync: GR-SYNC-20260820-28-PORTFOLIO-PREVIEW-EVIDENCE-ECHO
+current_planning_refinement: GM-FROSTBLOOM-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER-01
+current_planning_refinement_sync: GR-SYNC-20260820-29-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER
+planning_pointer_closeout_sync: GR-SYNC-20260820-30-FIRST-SESSION-PLANNING-POINTER-CLOSEOUT
+planning_completion_state: READY_PENDING_USER_EXPLICIT_DECLARATION
 frostbloom_first_10_minute_contract: FIRST_10_MIN_CLASS_TO_GUIDED_PRACTICUM
 frostbloom_first_10_minute_target_minutes: 10
 frostbloom_10_23_contract: FREE_SCHEDULE_LENS_ONLY_SEQUENTIAL_PICK_2_OF_4
@@ -60,6 +62,9 @@ frostbloom_portfolio_preview_contract: EVIDENCE_ECHO_ONE_OPEN_QUESTION
 frostbloom_mentor_echo: MENTOR_RESPONSE_DESCRIPTIVE_NOT_VERDICT
 frostbloom_open_question: OPEN_QUESTION_NOT_OBJECTIVE
 frostbloom_festival_close: FESTIVAL_PREVIEW_ONLY
+frostbloom_transition_refinement: PERSISTENT_HANDOFF_ELASTIC_BUFFER
+frostbloom_investigation_to_w6: INVESTIGATION_SUMMARY_PERSISTS_INTO_W6_NO_DUPLICATE_W6_DECISION_BRIEF
+frostbloom_w6_to_w7: W6_RECEIPT_PINS_AS_W7_ANCHOR_NO_DUPLICATE_W7_RESULT_ANCHOR_SCREEN
 year_one_chapters: 7
 year_one_term_distribution: 2_2_3
 world_model: PRECEDENT_CONTEXT_REVISION
@@ -78,7 +83,7 @@ frostbloom_implementation_plan: docs/superpowers/plans/2026-08-11-frostbloom-int
 frostbloom_graybox_pack: docs/testing/frostbloom_graybox/README.md
 frostbloom_graybox_status: INTERNAL_PACK_PASS
 frostbloom_runtime_implementation: BLOCKED_BY_TASK8_DEPENDENCY
-next_planning_axis: FROSTBLOOM_FIRST_SESSION_END_TO_END_REVIEW
+next_planning_axis: NONE_PENDING_USER_EXPLICIT_PLANNING_COMPLETION_DECLARATION
 current_process_axis: PREWORK_BENCHMARK_INDUSTRY_RESEARCH_ACTIVE
 github_actions_decision: GM-PUBLIC-REPO-FREE-GITHUB-ACTIONS-01
 repo_wide_actions_full_sha: PASS
@@ -545,6 +550,31 @@ full_slice_validation: NOT_RUN
 Portfolio Receipt는 `principle_saved / causal_evidence_linked / unresolved_tension_carried`만 확인하며 5축 Result나 Causal Thread를 다시 펼치거나 새 점수/보상 트랙으로 환산하지 않는다. 마지막 질문은 실제 Discovery 또는 Remaining Uncertainty에서 파생된 1개 질문이며 `OPEN_QUESTION_NOT_OBJECTIVE`를 따른다. quest marker, reward, required tracking, branch 선택이 아니다.
 
 Festival은 `PREVIEW_ONLY`로 한 개의 짧은 visual/audio/dialogue glimpse만 허용한다. playable second incident, 새 tutorial/system intro, lore dump를 시작하지 않는다. 세션 종료 입력은 close confirmation 역할만 가지며 새 gameplay decision을 요구하지 않는다. 실제 2분 달성, mentor tone 수용성, curiosity hook 이해도는 Human/Device test 전까지 `NOT_RUN`이다.
+
+## GM-FROSTBLOOM-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER-01 — active child refinement
+
+```yaml
+decision_id: GM-FROSTBLOOM-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER-01
+parent_decision: GM-FROSTBLOOM-INTERNAL-VERTICAL-SLICE-01
+predecessor_refinement: GM-FROSTBLOOM-PORTFOLIO-PREVIEW-EVIDENCE-ECHO-01
+sync_id: GR-SYNC-20260820-29-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER
+approval: USER_APPROVED_RECOMMENDED_OPTION_A
+canon_document: docs/planning/FROSTBLOOM_FIRST_SESSION_PERSISTENT_HANDOFF_ELASTIC_BUFFER_01_APPROVAL_2026-08-20.md
+fixture: data/testing/frostbloom_first_session_handoff_buffer_v1.json
+contract: PERSISTENT_HANDOFF_ELASTIC_BUFFER
+investigation_to_w6: INVESTIGATION_SUMMARY_PERSISTS_INTO_W6_NO_DUPLICATE_W6_DECISION_BRIEF
+w6_to_w7: W6_RECEIPT_PINS_AS_W7_ANCHOR_NO_DUPLICATE_W7_RESULT_ANCHOR_SCREEN
+buffer_contract: ELASTIC_BUFFER_NOT_CONTENT
+session_target: TARGET_46_UNCHANGED
+human_validation: NOT_RUN
+device_validation: NOT_RUN
+performance_validation: NOT_RUN
+full_slice_validation: NOT_RUN
+```
+
+00~46분 end-to-end 검토에서 발견된 두 연속 recap을 새 콘텐츠 없이 제거한다. `Known 2 / Unknown 2 / Lens 1`은 W6 진입 시 다시 설명하는 별도 Decision Brief가 아니라 기존 summary를 persistent pin으로 이어받는다. W6 actual consequence receipt 역시 별도 W7 Result Anchor 재복기 화면으로 반복하지 않고 그대로 `W6_RESULT_ANCHOR`가 된다.
+
+두 전환의 최대 60초 TEST_VALUE는 강제 pause가 아니라 읽기·입력·전환·접근성 편차를 흡수하는 가변 여유다. 남는 시간을 새 tutorial, lore, reward, gameplay choice로 채우지 않는다. `FIRST_ACCEPTED_W6_RESULT_REMAINS_TRUE`, `POST_W6_DEEPER_REVISION_COUPLING`, 46/53/60 시간 계약은 그대로 유지한다. Human/Device evidence 전까지 실제 pacing·가독성·수용성은 `NOT_RUN`이다.
 
 ## GM-SPELL-WORKFLOW-UI-V2-01 — current implementation state
 

--- a/docs/planning/sync/GR-SYNC-20260820-30-FIRST-SESSION-PLANNING-POINTER-CLOSEOUT.md
+++ b/docs/planning/sync/GR-SYNC-20260820-30-FIRST-SESSION-PLANNING-POINTER-CLOSEOUT.md
@@ -1,0 +1,60 @@
+# GR-SYNC-20260820-30-FIRST-SESSION-PLANNING-POINTER-CLOSEOUT
+
+```yaml
+sync_id: GR-SYNC-20260820-30-FIRST-SESSION-PLANNING-POINTER-CLOSEOUT
+sync_type: CURRENT_POINTER_CLOSEOUT_ONLY
+project: GRIMOIRE
+source_main_before_change: 526d5140d604d073528e3b12f12ead3ecb787e84
+base_main_observed: 369e7173c6a21ec2c7e70cef5e11f799a5d7dbc0
+base_project_pin: v9.4.3
+base_pin_changed: false
+latest_approved_refinement: GM-FROSTBLOOM-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER-01
+latest_approved_refinement_sync: GR-SYNC-20260820-29-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER
+completed_review_axis: FROSTBLOOM_FIRST_SESSION_END_TO_END_REVIEW
+planning_completion_state: READY_PENDING_USER_EXPLICIT_DECLARATION
+USER_EXPLICIT_PLANNING_COMPLETION: NOT_DECLARED
+TASK2_CLOSE_ALLOWED: false
+NO_NEW_PRODUCT_DECISION: true
+product_scope_change: NONE
+runtime_mutation: NONE
+Human: NOT_RUN
+Device: NOT_RUN
+Performance: NOT_RUN
+Full Slice: NOT_RUN
+```
+
+## 목적
+
+PR #146 병합 이후 실제 최신 기획 refinement와 `CURRENT_CONFIRMED_DECISIONS.md` 상단 pointer 사이에 남아 있던 정본 지연을 닫는다. 이 sync는 게임 규칙·콘텐츠·밸런스·UI 동작을 새로 결정하지 않는다.
+
+## 반영 범위
+
+- `current_planning_refinement`를 `GM-FROSTBLOOM-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER-01`로 승격한다.
+- `current_planning_refinement_sync`를 Sync29로 승격한다.
+- 이미 수행 완료된 `FROSTBLOOM_FIRST_SESSION_END_TO_END_REVIEW`를 `next_planning_axis`에서 제거한다.
+- 새 기획축을 발명하지 않고 `NONE_PENDING_USER_EXPLICIT_PLANNING_COMPLETION_DECLARATION`으로 둔다.
+- 사용자의 명시적 “기획 완료” 선언이 아직 없으므로 `planning_completion_state`는 `READY_PENDING_USER_EXPLICIT_DECLARATION`이며 TASK-2는 닫지 않는다.
+- 이번 작업에서 관측한 Base main SHA만 갱신하고 `base_project_pin: v9.4.3`은 변경하지 않는다.
+
+## 변경하지 않는 것
+
+```text
+NO_NEW_PRODUCT_DECISION
+NO_NEW_GAMEPLAY_CONTENT
+NO_RUNTIME_IMPLEMENTATION_CHANGE
+NO_TASK8_CHANGE
+NO_BALANCE_CHANGE
+NO_HUMAN_EVIDENCE_PROMOTION
+NO_DEVICE_EVIDENCE_PROMOTION
+NO_PERFORMANCE_EVIDENCE_PROMOTION
+NO_FULL_SLICE_EVIDENCE_PROMOTION
+```
+
+## 완료 조건
+
+1. dedicated pointer closeout regression GREEN.
+2. 기존 planning/runtime/current-state 회귀 GREEN.
+3. exact-head main concurrency 확인.
+4. PR squash merge.
+5. 병합 SHA를 Notion Project Home / TASK-2에 동기화하고 readback.
+6. TASK-2는 사용자 명시 완료 선언 전까지 `진행 중` 유지.

--- a/tests/test_frostbloom_planning_pointer_closeout_contract.py
+++ b/tests/test_frostbloom_planning_pointer_closeout_contract.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+CURRENT = ROOT / "docs/planning/CURRENT_CONFIRMED_DECISIONS.md"
+SYNC = ROOT / "docs/planning/sync/GR-SYNC-20260820-30-FIRST-SESSION-PLANNING-POINTER-CLOSEOUT.md"
+
+
+class FrostbloomPlanningPointerCloseoutContractTests(unittest.TestCase):
+    def test_current_pointer_promotes_latest_approved_refinement(self):
+        text = CURRENT.read_text(encoding="utf-8")
+        self.assertIn(
+            "current_planning_refinement: GM-FROSTBLOOM-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER-01",
+            text,
+        )
+        self.assertIn(
+            "current_planning_refinement_sync: GR-SYNC-20260820-29-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER",
+            text,
+        )
+        self.assertIn(
+            "planning_pointer_closeout_sync: GR-SYNC-20260820-30-FIRST-SESSION-PLANNING-POINTER-CLOSEOUT",
+            text,
+        )
+        self.assertIn("planning_completion_state: READY_PENDING_USER_EXPLICIT_DECLARATION", text)
+        self.assertIn(
+            "next_planning_axis: NONE_PENDING_USER_EXPLICIT_PLANNING_COMPLETION_DECLARATION",
+            text,
+        )
+        self.assertNotIn(
+            "next_planning_axis: FROSTBLOOM_FIRST_SESSION_END_TO_END_REVIEW",
+            text,
+        )
+        self.assertIn(
+            "base_current_main_observed: 369e7173c6a21ec2c7e70cef5e11f799a5d7dbc0",
+            text,
+        )
+
+    def test_closeout_receipt_preserves_completion_authority_and_evidence_ceiling(self):
+        self.assertTrue(SYNC.is_file(), SYNC)
+        text = SYNC.read_text(encoding="utf-8")
+        for token in (
+            "GR-SYNC-20260820-30-FIRST-SESSION-PLANNING-POINTER-CLOSEOUT",
+            "CURRENT_POINTER_CLOSEOUT_ONLY",
+            "NO_NEW_PRODUCT_DECISION",
+            "USER_EXPLICIT_PLANNING_COMPLETION: NOT_DECLARED",
+            "TASK2_CLOSE_ALLOWED: false",
+            "Human: NOT_RUN",
+            "Device: NOT_RUN",
+            "Performance: NOT_RUN",
+            "Full Slice: NOT_RUN",
+        ):
+            self.assertIn(token, text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Goal

Close the final planning-canon pointer gap after the merged Persistent Handoff + Elastic Buffer refinement.

## Scope

Pointer/sync metadata only. No new product decision, no new content, no runtime/Scene/Resource/data behavior change, and no TASK-2 completion without an explicit user planning-complete declaration.

## Required final state

- `current_planning_refinement` -> `GM-FROSTBLOOM-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER-01`
- `current_planning_refinement_sync` -> `GR-SYNC-20260820-29-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER`
- `next_planning_axis` no longer points at the already-completed end-to-end review
- planning completion state is ready but pending explicit user declaration
- Base observed SHA refreshed only; Base pin remains unchanged
- Human/Device/Performance/Full Slice evidence remains NOT_RUN

## TDD

Initial commits intentionally RED via `tests.test_frostbloom_planning_pointer_closeout_contract`.