### PR TITLE
docs(planning): finalize Frostbloom planning completion

### DIFF
--- a/docs/planning/CURRENT_CONFIRMED_DECISIONS.md
+++ b/docs/planning/CURRENT_CONFIRMED_DECISIONS.md
@@ -44,7 +44,8 @@ result_grimoire_refinement_sync: GR-SYNC-20260820-27-RESULT-GRIMOIRE-CAUSAL-DEBR
 current_planning_refinement: GM-FROSTBLOOM-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER-01
 current_planning_refinement_sync: GR-SYNC-20260820-29-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER
 planning_pointer_closeout_sync: GR-SYNC-20260820-30-FIRST-SESSION-PLANNING-POINTER-CLOSEOUT
-planning_completion_state: READY_PENDING_USER_EXPLICIT_DECLARATION
+planning_completion_sync: GR-SYNC-20260820-31-FIRST-SESSION-PLANNING-COMPLETION
+planning_completion_state: USER_DECLARED_COMPLETE
 frostbloom_first_10_minute_contract: FIRST_10_MIN_CLASS_TO_GUIDED_PRACTICUM
 frostbloom_first_10_minute_target_minutes: 10
 frostbloom_10_23_contract: FREE_SCHEDULE_LENS_ONLY_SEQUENTIAL_PICK_2_OF_4
@@ -83,7 +84,7 @@ frostbloom_implementation_plan: docs/superpowers/plans/2026-08-11-frostbloom-int
 frostbloom_graybox_pack: docs/testing/frostbloom_graybox/README.md
 frostbloom_graybox_status: INTERNAL_PACK_PASS
 frostbloom_runtime_implementation: BLOCKED_BY_TASK8_DEPENDENCY
-next_planning_axis: NONE_PENDING_USER_EXPLICIT_PLANNING_COMPLETION_DECLARATION
+next_planning_axis: NONE_PLANNING_COMPLETE
 current_process_axis: PREWORK_BENCHMARK_INDUSTRY_RESEARCH_ACTIVE
 github_actions_decision: GM-PUBLIC-REPO-FREE-GITHUB-ACTIONS-01
 repo_wide_actions_full_sha: PASS

--- a/docs/planning/sync/GR-SYNC-20260820-31-FIRST-SESSION-PLANNING-COMPLETION.md
+++ b/docs/planning/sync/GR-SYNC-20260820-31-FIRST-SESSION-PLANNING-COMPLETION.md
@@ -1,0 +1,22 @@
+# GR-SYNC-20260820-31-FIRST-SESSION-PLANNING-COMPLETION
+
+```yaml
+sync_id: GR-SYNC-20260820-31-FIRST-SESSION-PLANNING-COMPLETION
+date: 2026-08-20
+scope: FIRST_SESSION_PLANNING_COMPLETION_STATUS_ONLY
+USER_EXPLICIT_PLANNING_COMPLETION: DECLARED
+TASK2_CLOSE_ALLOWED: true
+NO_NEW_PRODUCT_DECISION: true
+NO_RUNTIME_IMPLEMENTATION: true
+planning_pointer_predecessor: GR-SYNC-20260820-30-FIRST-SESSION-PLANNING-POINTER-CLOSEOUT
+current_planning_refinement: GM-FROSTBLOOM-FIRST-SESSION-PERSISTENT-HANDOFF-ELASTIC-BUFFER-01
+next_planning_axis: NONE_PLANNING_COMPLETE
+Human: NOT_RUN
+Device: NOT_RUN
+Performance: NOT_RUN
+Full Slice: NOT_RUN
+```
+
+사용자가 2026-08-20에 GRIMOIRE Frostbloom 첫 세션의 기획 완료를 명시적으로 선언했다. 이 선언은 이미 승인·병합·동기화된 00~46분 설계와 Persistent Handoff + Elastic Buffer refinement를 완료 상태로 닫는 작업이며 새로운 제품 규칙이나 콘텐츠를 추가하지 않는다.
+
+이 완료는 구조 기획의 종료를 의미한다. Human playtest, 실제 기기, 성능, 전체 Vertical Slice 검증은 실행되지 않았으므로 계속 `NOT_RUN`이며, 이후 이미지·UI Component·화면 제작과 구현/검증 workstream에서 별도로 다룬다.

--- a/tests/test_frostbloom_planning_pointer_closeout_contract.py
+++ b/tests/test_frostbloom_planning_pointer_closeout_contract.py
@@ -4,6 +4,7 @@ import unittest
 ROOT = Path(__file__).resolve().parents[1]
 CURRENT = ROOT / "docs/planning/CURRENT_CONFIRMED_DECISIONS.md"
 SYNC = ROOT / "docs/planning/sync/GR-SYNC-20260820-30-FIRST-SESSION-PLANNING-POINTER-CLOSEOUT.md"
+COMPLETION_SYNC = ROOT / "docs/planning/sync/GR-SYNC-20260820-31-FIRST-SESSION-PLANNING-COMPLETION.md"
 
 
 class FrostbloomPlanningPointerCloseoutContractTests(unittest.TestCase):
@@ -21,15 +22,17 @@ class FrostbloomPlanningPointerCloseoutContractTests(unittest.TestCase):
             "planning_pointer_closeout_sync: GR-SYNC-20260820-30-FIRST-SESSION-PLANNING-POINTER-CLOSEOUT",
             text,
         )
-        self.assertIn("planning_completion_state: READY_PENDING_USER_EXPLICIT_DECLARATION", text)
         self.assertIn(
-            "next_planning_axis: NONE_PENDING_USER_EXPLICIT_PLANNING_COMPLETION_DECLARATION",
+            "planning_completion_sync: GR-SYNC-20260820-31-FIRST-SESSION-PLANNING-COMPLETION",
             text,
         )
+        self.assertIn("planning_completion_state: USER_DECLARED_COMPLETE", text)
+        self.assertIn("next_planning_axis: NONE_PLANNING_COMPLETE", text)
         self.assertNotIn(
             "next_planning_axis: FROSTBLOOM_FIRST_SESSION_END_TO_END_REVIEW",
             text,
         )
+        self.assertNotIn("READY_PENDING_USER_EXPLICIT_DECLARATION", text)
         self.assertIn(
             "base_current_main_observed: 369e7173c6a21ec2c7e70cef5e11f799a5d7dbc0",
             text,
@@ -44,6 +47,22 @@ class FrostbloomPlanningPointerCloseoutContractTests(unittest.TestCase):
             "NO_NEW_PRODUCT_DECISION",
             "USER_EXPLICIT_PLANNING_COMPLETION: NOT_DECLARED",
             "TASK2_CLOSE_ALLOWED: false",
+            "Human: NOT_RUN",
+            "Device: NOT_RUN",
+            "Performance: NOT_RUN",
+            "Full Slice: NOT_RUN",
+        ):
+            self.assertIn(token, text)
+
+    def test_user_declared_planning_completion_is_recorded_without_runtime_overclaim(self):
+        self.assertTrue(COMPLETION_SYNC.is_file(), COMPLETION_SYNC)
+        text = COMPLETION_SYNC.read_text(encoding="utf-8")
+        for token in (
+            "GR-SYNC-20260820-31-FIRST-SESSION-PLANNING-COMPLETION",
+            "USER_EXPLICIT_PLANNING_COMPLETION: DECLARED",
+            "TASK2_CLOSE_ALLOWED: true",
+            "NO_NEW_PRODUCT_DECISION",
+            "NO_RUNTIME_IMPLEMENTATION",
             "Human: NOT_RUN",
             "Device: NOT_RUN",
             "Performance: NOT_RUN",


### PR DESCRIPTION
## Goal
Record the user's explicit planning-completion declaration after the already-merged Frostbloom first-session planning closeout.

## Scope
Planning status metadata only. No new product decision, no runtime implementation, no Human/Device/Performance/Full Slice PASS claim.

## TDD
First commit intentionally updates the closeout contract to require a new completion receipt and completed current-state markers; it should fail until the completion receipt and current snapshot are updated.