### PR TITLE
docs(visual): plan component sheets and first-session assets

### DIFF
--- a/docs/superpowers/plans/2026-08-20-component-sheets-semantic-ui.md
+++ b/docs/superpowers/plans/2026-08-20-component-sheets-semantic-ui.md
@@ -1,0 +1,750 @@
+# GRIMOIRE Component Sheets A–D & Semantic UI Components Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the approved Component Pack 1A/1B as reusable Godot semantic UI components and four rendered Component Sheets without changing gameplay, resource mutation, or Spell Workflow ownership.
+
+**Architecture:** Extend the existing `GrimoireThemeFactory` and `StarCircuitBoard` rather than introducing a second UI/token or FIVE_POINT_STAR system. Add small read-only semantic composites under `src/ui/components/`, deterministic showcase sheets under `src/ui/component_sheets/`, and one dedicated contract/integration/capture pipeline that proves 1920×1080 visual-master assembly and 1280×720 minimum-regression behavior.
+
+**Tech Stack:** Godot 4.7.1 GDScript, Godot Theme/Control/Container APIs, SVG assets already in the repository, Python 3.12 `unittest`, existing custom Godot test runner, GitHub Actions with Xvfb + GL Compatibility rendering.
+
+**Spec:** `docs/superpowers/specs/2026-08-20-component-sheet-image-production-contract-design.md`
+
+## Global Constraints
+
+- Current project authority at plan creation: GRIMOIRE `main` `4c2f23c4bb8b7487559b113a5d41deab815fb62d`.
+- Current Base observation at plan creation: Base `main` `e222e93e79e95364dca668eaaf0f156676123342`; reuse handoff says GRIMOIRE owns `FIVE_POINT_STAR`, composition, explicit Commit, lesson pacing, and field-practice experience.
+- Reuse Base `RM-VIS-001 SEMANTIC_UI_SKIN_KIT` and `RM-VIS-002 GAMEPLAY_SYMBOL_ATLAS` only as structural contracts; project-specific Navy/Gold academy skin remains GRIMOIRE-owned.
+- Visual authoring master: `1920×1080`, 16:9; safe margins at that reference are 64 px horizontal / 48 px vertical.
+- Minimum PC readability regression: `1280×720`; no critical overlap, clipping, or sub-48×48 interactive controls.
+- Shipping mobile battle/writing orientation remains landscape; narrow/portrait-width cases are component stress tests only, not a shipping orientation change.
+- Reuse `src/ui/theme/grimoire_theme_factory.gd`; do not create a second token/theme authority.
+- Reuse `src/ui/components/star_circuit_board.gd`; do not create a second FIVE_POINT_STAR renderer, validator, stock owner, or commit owner.
+- Stage 2 remains circuit/base-preview authority with no Target/Mana mutation; Stage 3 remains explicit Target/final-preview/confirmation/atomic-use authority.
+- `FOCUS != SELECTED`; color is never the only state channel; mobile cannot depend on Hover; Reduced Motion must permit immediate state replacement.
+- Runtime copy remains `ENGLISH_SAFE_COPY_UNTIL_LICENSED_KOREAN_FONT`; Component Sheet documentation may explain Korean copy but runtime scenes introduced by this plan use English-safe sample strings only.
+- Functional UI text, counts, success %, Mana, Focus/Selected/Disabled truth, Forecast wording, and Causal Thread content remain live UI—not baked imagery.
+- Human visual validation, physical-device validation, performance validation, and Full Vertical Slice validation remain `NOT_RUN` throughout this plan.
+- No Task8 mutation. If an active Task8 PR/path overlaps a planned file at execution time, stop and re-scope rather than editing the active work.
+
+---
+
+## File Structure
+
+### Existing files to modify
+
+- `src/ui/theme/grimoire_theme_factory.gd` — add only bounded variants needed by the approved component states; keep existing token constants as the sole color authority.
+- `tests/test_runner.gd` — register the new Godot integration suite.
+
+### New component files
+
+- `src/ui/components/academy_panel.tscn` — reusable PanelContainer base scene using existing Theme variations.
+- `src/ui/components/five_point_star_composer.gd`
+- `src/ui/components/five_point_star_composer.tscn`
+- `src/ui/components/context_header.gd`
+- `src/ui/components/context_header.tscn`
+- `src/ui/components/context_target_selector.gd`
+- `src/ui/components/context_target_selector.tscn`
+- `src/ui/components/commit_bar.gd`
+- `src/ui/components/commit_bar.tscn`
+- `src/ui/components/evidence_pin.gd`
+- `src/ui/components/evidence_pin.tscn`
+- `src/ui/components/forecast_card.gd`
+- `src/ui/components/forecast_card.tscn`
+- `src/ui/components/context_delta_card.gd`
+- `src/ui/components/context_delta_card.tscn`
+- `src/ui/components/result_axis_card.gd`
+- `src/ui/components/result_axis_card.tscn`
+- `src/ui/components/causal_thread.gd`
+- `src/ui/components/causal_thread.tscn`
+
+### New deterministic showcase/capture files
+
+- `data/testing/component_sheet_samples_v1.json` — English-safe deterministic sample values for A–D.
+- `src/ui/component_sheets/component_sheet_a_foundations.gd`
+- `src/ui/component_sheets/component_sheet_a_foundations.tscn`
+- `src/ui/component_sheets/component_sheet_b_spell_workflow.gd`
+- `src/ui/component_sheets/component_sheet_b_spell_workflow.tscn`
+- `src/ui/component_sheets/component_sheet_c_frostbloom_decision.gd`
+- `src/ui/component_sheets/component_sheet_c_frostbloom_decision.tscn`
+- `src/ui/component_sheets/component_sheet_d_result_grimoire.gd`
+- `src/ui/component_sheets/component_sheet_d_result_grimoire.tscn`
+- `tools/capture_component_sheets.gd` — deterministic 1920×1080 and 1280×720 captures for all four sheets.
+
+### New tests/workflow/evidence files
+
+- `tests/test_component_sheet_pack_contract.py`
+- `tests/integration/test_component_sheet_pack.gd`
+- `.github/workflows/validate-component-sheet-pack.yml`
+- `docs/planning/COMPONENT_SHEET_PACK_01_ADVERSARIAL_REVIEW_2026-08-20.md`
+- `docs/planning/sync/GR-SYNC-20260820-33-COMPONENT-SHEET-PACK-IMPLEMENTATION.md`
+
+---
+
+### Task 1: Contract RED and deterministic sample fixture
+
+**Files:**
+- Create: `tests/test_component_sheet_pack_contract.py`
+- Create: `tests/integration/test_component_sheet_pack.gd`
+- Create: `data/testing/component_sheet_samples_v1.json`
+- Modify: `tests/test_runner.gd`
+
+**Interfaces:**
+- Consumes: approved written spec, existing `GrimoireThemeFactory`, existing `StarCircuitBoard`.
+- Produces: hard file/API/semantic requirements that every later task must satisfy.
+
+- [ ] **Step 1: Write the Python RED contract**
+
+Create `tests/test_component_sheet_pack_contract.py` with path checks for all new component/sheet files and these semantic guards:
+
+```python
+from pathlib import Path
+import json
+import re
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+THEME = ROOT / "src/ui/theme/grimoire_theme_factory.gd"
+SPEC = ROOT / "docs/superpowers/specs/2026-08-20-component-sheet-image-production-contract-design.md"
+FIXTURE = ROOT / "data/testing/component_sheet_samples_v1.json"
+
+COMPONENTS = [
+    "academy_panel.tscn",
+    "five_point_star_composer.tscn",
+    "context_header.tscn",
+    "context_target_selector.tscn",
+    "commit_bar.tscn",
+    "evidence_pin.tscn",
+    "forecast_card.tscn",
+    "context_delta_card.tscn",
+    "result_axis_card.tscn",
+    "causal_thread.tscn",
+]
+SHEETS = [
+    "component_sheet_a_foundations.tscn",
+    "component_sheet_b_spell_workflow.tscn",
+    "component_sheet_c_frostbloom_decision.tscn",
+    "component_sheet_d_result_grimoire.tscn",
+]
+
+class ComponentSheetPackContractTests(unittest.TestCase):
+    def test_required_component_and_sheet_files_exist(self):
+        for name in COMPONENTS:
+            self.assertTrue((ROOT / "src/ui/components" / name).is_file(), name)
+        for name in SHEETS:
+            self.assertTrue((ROOT / "src/ui/component_sheets" / name).is_file(), name)
+
+    def test_existing_theme_remains_single_token_authority(self):
+        theme = THEME.read_text(encoding="utf-8")
+        self.assertIn('SURFACE_CANVAS := Color("071524")', theme)
+        self.assertIn('LINE_GOLD_ACTIVE := Color("e2bd68")', theme)
+        for path in (ROOT / "src/ui/components").glob("*.gd"):
+            if path.name == "star_circuit_board.gd":
+                continue
+            text = path.read_text(encoding="utf-8")
+            self.assertNotRegex(text, re.compile(r'Color\("(?:071524|0d2033|e2bd68|72d9e8)"\)', re.I), path.name)
+
+    def test_fixture_preserves_frostbloom_semantics(self):
+        data = json.loads(FIXTURE.read_text(encoding="utf-8"))
+        self.assertEqual({"known": 2, "unknown": 2, "lens": "FIELD_HANDLING"}, data["evidence_pin"])
+        self.assertEqual(
+            ["KNOWN_IMPROVEMENT", "UNCERTAIN_CONSEQUENCE", "FINAL_TARGET_SUCCESS_BREAKDOWN", "MANA_COST"],
+            list(data["forecast"].keys()),
+        )
+        self.assertEqual(["STILL_TRUE", "NEWLY_LEARNED", "NEW_TENSION"], list(data["context_delta"].keys()))
+        self.assertEqual(["FACILITY", "LIFE", "SPIRIT", "RELATIONSHIP", "DISCOVERY"], list(data["result_axes"].keys()))
+        self.assertEqual(
+            ["OBSERVATION", "W6_CIRCUIT", "W6_TARGET", "W6_RESULT", "CONTEXT_DELTA", "W7_JUDGMENT", "W7_RESULT"],
+            [item["kind"] for item in data["causal_thread"]],
+        )
+
+    def test_no_named_correct_route_or_global_grade_copy(self):
+        text = FIXTURE.read_text(encoding="utf-8").lower()
+        for forbidden in ("recommended", "best route", "correct route", "perfect", "s-rank", "a-rank"):
+            self.assertNotIn(forbidden, text)
+
+    def test_runtime_sample_copy_stays_english_safe_until_font_gate(self):
+        for folder in (ROOT / "src/ui/components", ROOT / "src/ui/component_sheets"):
+            for path in folder.glob("*.tscn"):
+                self.assertNotRegex(path.read_text(encoding="utf-8"), re.compile(r"[가-힣]"), path.name)
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Write the deterministic fixture**
+
+Create `data/testing/component_sheet_samples_v1.json` exactly with this shape so visual captures and tests never invent hidden answers:
+
+```json
+{
+  "schema_version": 1,
+  "context": {"location": "FROSTBLOOM GREENHOUSE", "phase": "FIELD PRACTICUM", "task": "Read the live context before rewriting it."},
+  "targets": [
+    {"id": "irrigation_valve", "label": "Irrigation Valve", "hint": "Pressure path currently observed."},
+    {"id": "root_layer", "label": "Root Layer", "hint": "Living structure carrying the damage."},
+    {"id": "spirit_channel", "label": "Spirit Channel", "hint": "Response remains partly unknown."}
+  ],
+  "evidence_pin": {"known": 2, "unknown": 2, "lens": "FIELD_HANDLING"},
+  "forecast": {
+    "KNOWN_IMPROVEMENT": "Pressure can be reduced at the selected target.",
+    "UNCERTAIN_CONSEQUENCE": "Spirit response remains unresolved.",
+    "FINAL_TARGET_SUCCESS_BREAKDOWN": {"percent": 72, "rows": [{"label": "Circuit", "value": "+18"}, {"label": "Observed context", "value": "+9"}]},
+    "MANA_COST": 18
+  },
+  "context_delta": {
+    "STILL_TRUE": "The accepted W6 pressure reduction remains real.",
+    "NEWLY_LEARNED": "The revised flow exposed a deeper coupling.",
+    "NEW_TENSION": "The spirit channel now shares the redirected load."
+  },
+  "result_axes": {
+    "FACILITY": "Pressure stabilized.",
+    "LIFE": "Root damage remains mixed.",
+    "SPIRIT": "Response changed, not erased.",
+    "RELATIONSHIP": "Field trust preserved.",
+    "DISCOVERY": "A deeper revision coupling was revealed."
+  },
+  "causal_thread": [
+    {"kind": "OBSERVATION", "text": "Two field observations were confirmed."},
+    {"kind": "W6_CIRCUIT", "text": "FLOW was shaped with a bounded auxiliary choice."},
+    {"kind": "W6_TARGET", "text": "Root Layer was selected."},
+    {"kind": "W6_RESULT", "text": "Pressure reduction was accepted and persisted."},
+    {"kind": "CONTEXT_DELTA", "text": "A deeper coupling became observable."},
+    {"kind": "W7_JUDGMENT", "text": "The redesign changed target/tradeoff reasoning."},
+    {"kind": "W7_RESULT", "text": "The new tension was addressed without deleting the W6 gain."}
+  ]
+}
+```
+
+- [ ] **Step 3: Write the Godot integration RED suite**
+
+Create `tests/integration/test_component_sheet_pack.gd` with file-load and API assertions that intentionally fail until Tasks 2–5 create the components:
+
+```gdscript
+extends RefCounted
+
+const COMPONENTS := {
+    "composer": "res://src/ui/components/five_point_star_composer.tscn",
+    "header": "res://src/ui/components/context_header.tscn",
+    "targets": "res://src/ui/components/context_target_selector.tscn",
+    "commit": "res://src/ui/components/commit_bar.tscn",
+    "evidence": "res://src/ui/components/evidence_pin.tscn",
+    "forecast": "res://src/ui/components/forecast_card.tscn",
+    "delta": "res://src/ui/components/context_delta_card.tscn",
+    "result": "res://src/ui/components/result_axis_card.tscn",
+    "causal": "res://src/ui/components/causal_thread.tscn",
+}
+
+func run(case) -> void:
+    for key in COMPONENTS:
+        case.assert_true(FileAccess.file_exists(COMPONENTS[key]), "%s component scene exists" % key)
+    case.assert_true(FileAccess.file_exists("res://src/ui/components/star_circuit_board.tscn"), "Existing StarCircuitBoard is preserved")
+```
+
+- [ ] **Step 4: Register the suite in the existing runner**
+
+Add exactly one entry to `tests/test_runner.gd` after `test_star_ui_kit_scene.gd`:
+
+```gdscript
+"res://tests/integration/test_component_sheet_pack.gd",
+```
+
+- [ ] **Step 5: Run RED**
+
+Run:
+
+```bash
+python -m unittest tests.test_component_sheet_pack_contract -v
+.tooling/godot/4.7.1-stable/linux/Godot_v4.7.1-stable_linux.x86_64 --headless --path . --script res://tests/test_runner.gd
+```
+
+Expected: Python and Godot suites fail only on the not-yet-created component/sheet files; all pre-existing suites remain green.
+
+- [ ] **Step 6: Commit RED evidence**
+
+```bash
+git add tests/test_component_sheet_pack_contract.py tests/integration/test_component_sheet_pack.gd tests/test_runner.gd data/testing/component_sheet_samples_v1.json
+git commit -m "test(ui): define component sheet pack contract"
+```
+
+---
+
+### Task 2: Extend the existing Theme and build Sheet A foundations
+
+**Files:**
+- Modify: `src/ui/theme/grimoire_theme_factory.gd`
+- Create: `src/ui/components/academy_panel.tscn`
+- Create: `src/ui/component_sheets/component_sheet_a_foundations.gd`
+- Create: `src/ui/component_sheets/component_sheet_a_foundations.tscn`
+- Modify: `tests/integration/test_component_sheet_pack.gd`
+
+**Interfaces:**
+- Consumes: existing constants and `GrimoireThemeFactory.create_theme()`.
+- Produces: bounded type variations `AcademyPanelPinned`, `AcademyPanelModal`, `AcademyButtonCaution`, `AcademyButtonQuiet`, `AcademyBadgeSelected`, `AcademyBadgeUnknown` while preserving all predecessor variations.
+
+- [ ] **Step 1: Extend the integration test before Theme work**
+
+Add assertions that `GrimoireThemeFactory.create_theme()` exposes the new variations and still exposes predecessor variations:
+
+```gdscript
+var theme_factory = load("res://src/ui/theme/grimoire_theme_factory.gd")
+var theme: Theme = theme_factory.create_theme()
+for variation in [
+    &"AcademyPanel", &"AcademyPanelEmphasis", &"AcademyPanelPinned", &"AcademyPanelModal",
+    &"AcademyButton", &"AcademyButtonPrimary", &"AcademyButtonCaution", &"AcademyButtonQuiet",
+    &"AcademyBadge", &"AcademyBadgeSelected", &"AcademyBadgeUnknown"
+]:
+    case.assert_true(theme.get_type_variation_base(variation) != &"", "%s theme variation exists" % variation)
+```
+
+- [ ] **Step 2: Run focused Godot RED**
+
+Run the full custom runner. Expected: only the new variation assertions fail.
+
+- [ ] **Step 3: Add bounded variations using existing constants only**
+
+In `grimoire_theme_factory.gd`, add registrations inside the existing panel/button/badge configuration functions. Do not add new color literals; derive styles from existing constants. The intended mappings are:
+
+```text
+AcademyPanelPinned  = SURFACE_INSET + PLAYER_CYAN border + PANEL_RADIUS
+AcademyPanelModal   = SURFACE_PANEL_EMPHASIS + LINE_GOLD_ACTIVE 2px border
+AcademyButtonCaution= SURFACE_PANEL + WARNING_AMBER 2px border + existing focus box
+AcademyButtonQuiet  = SURFACE_INSET + LINE_BRASS 1px border + existing focus box
+AcademyBadgeSelected= SURFACE_INSET + PLAYER_CYAN 2px border
+AcademyBadgeUnknown = SURFACE_INSET + WARNING_AMBER 1px dashed-equivalent semantic marker via icon/label; no failure/red semantics
+```
+
+Use `_style_box()` and `_set_button_set()` rather than duplicating StyleBox construction.
+
+- [ ] **Step 4: Create the base Academy Panel scene**
+
+Create `academy_panel.tscn` with a `PanelContainer` root, `theme_type_variation = &"AcademyPanel"`, and a single `MarginContainer/Content` child slot. No baked copy and no local color overrides.
+
+- [ ] **Step 5: Build deterministic Sheet A**
+
+`component_sheet_a_foundations.gd` must call `GrimoireThemeFactory.create_theme()` in `_ready()` and expose `initialize_demo()` so the capture tool can reset it. Sheet A displays:
+
+```text
+Panel row: STANDARD / ELEVATED / PINNED / MODAL
+Button row: PRIMARY / SECONDARY / CAUTION / QUIET / DISABLED
+Badge row: DEFAULT / SELECTED / UNKNOWN
+State comparison: FOCUS vs SELECTED vs CAUTION vs DISABLED
+Context Header placeholder block reserved for Task 3
+```
+
+Use English-safe labels only and a neutral Navy canvas.
+
+- [ ] **Step 6: Run Python + Godot tests**
+
+Expected: Theme/foundation assertions green; failures remain only for Tasks 3–5 missing components/sheets.
+
+- [ ] **Step 7: Commit foundations**
+
+```bash
+git add src/ui/theme/grimoire_theme_factory.gd src/ui/components/academy_panel.tscn src/ui/component_sheets/component_sheet_a_foundations.* tests/integration/test_component_sheet_pack.gd
+git commit -m "feat(ui): add component sheet foundations"
+```
+
+---
+
+### Task 3: Build Spell Workflow semantic composites and Sheet B
+
+**Files:**
+- Create: `src/ui/components/five_point_star_composer.gd`
+- Create: `src/ui/components/five_point_star_composer.tscn`
+- Create: `src/ui/components/context_header.gd`
+- Create: `src/ui/components/context_header.tscn`
+- Create: `src/ui/components/context_target_selector.gd`
+- Create: `src/ui/components/context_target_selector.tscn`
+- Create: `src/ui/components/commit_bar.gd`
+- Create: `src/ui/components/commit_bar.tscn`
+- Create: `src/ui/component_sheets/component_sheet_b_spell_workflow.gd`
+- Create: `src/ui/component_sheets/component_sheet_b_spell_workflow.tscn`
+- Modify: `tests/integration/test_component_sheet_pack.gd`
+
+**Interfaces:**
+- Produces: read-only/view-input APIs; no stock, Mana, validator, or commit transaction calls.
+
+`FivePointStarComposer`:
+
+```gdscript
+signal slot_requested(role: StringName, index: int)
+func set_visual_state(state: StringName, active_vertices: int, cause_vertex: int = -1) -> void
+func visual_snapshot() -> Dictionary
+```
+
+`ContextHeader`:
+
+```gdscript
+func configure(location_text: String, phase_text: String, task_text: String) -> void
+func visual_snapshot() -> Dictionary
+```
+
+`ContextTargetSelector`:
+
+```gdscript
+signal target_selected(target_id: StringName)
+func configure_targets(targets: Array[Dictionary], selected_id: StringName = &"") -> void
+func visual_snapshot() -> Dictionary
+```
+
+`CommitBar`:
+
+```gdscript
+signal edit_requested
+signal commit_requested
+func configure(target_label: String, mana_cost: int, can_commit: bool, confirmation_required: bool) -> void
+func visual_snapshot() -> Dictionary
+```
+
+- [ ] **Step 1: Expand integration tests for the exact APIs and ownership boundary**
+
+Instantiate each scene, call the setters, and assert snapshots. Also inspect scripts as text in the Python contract and forbid these tokens in the four new scripts:
+
+```text
+consume_mana
+reserve_for_spell
+confirm_commit
+AtomicSpellUseService
+TypedGlyphStockPool
+StarCircuitValidator
+```
+
+- [ ] **Step 2: Run RED**
+
+Expected: API assertions fail because the scripts/scenes do not yet exist.
+
+- [ ] **Step 3: Implement `FivePointStarComposer` as a wrapper, not a fork**
+
+The scene must instance `res://src/ui/components/star_circuit_board.tscn` as `StarCircuitBoard` and create one main + five auxiliary `Button` controls using `GlyphSlotMain` / `GlyphSlot`. `set_visual_state()` delegates directly to the existing board:
+
+```gdscript
+func set_visual_state(state: StringName, active_vertices: int, cause_vertex: int = -1) -> void:
+    $StarCircuitBoard.set_visual_state(state, active_vertices, cause_vertex)
+
+func visual_snapshot() -> Dictionary:
+    var board: Dictionary = $StarCircuitBoard.visual_snapshot()
+    return {
+        "state": board.state,
+        "active_vertices": board.active_vertices,
+        "cause_vertex": board.cause_vertex,
+        "main_slot_role": &"MAIN",
+        "aux_slot_count": 5,
+    }
+```
+
+Button presses emit `slot_requested` only; they do not mutate inventory/circuit validity.
+
+- [ ] **Step 4: Implement `ContextHeader`**
+
+Use Panel/Label/Badge primitives. `configure()` updates only live Label text and returns the same three strings from `visual_snapshot()`.
+
+- [ ] **Step 5: Implement `ContextTargetSelector`**
+
+Create one Button per supplied dictionary with required keys `id`, `label`, `hint`. Set button metadata `target_id`; emit `target_selected(StringName(id))` on press. Selection styling uses `AcademyBadgeSelected` or Button focus/selected treatment; do not add recommendation/best-route logic.
+
+- [ ] **Step 6: Implement `CommitBar`**
+
+Use a target summary Label, Mana Label, Edit Button, Commit Button. `configure()` sets Commit disabled when `can_commit == false`; confirmation changes copy/state only. Emit signals only.
+
+- [ ] **Step 7: Build Sheet B**
+
+Load `component_sheet_samples_v1.json`; compose Context Header + Five Point Star Composer + Target Selector + Commit Bar and show four labeled demonstration states:
+
+```text
+EDIT → TARGET → FINAL → CONFIRM
+```
+
+The same Composer instance changes visual state; do not render four unrelated frame families.
+
+- [ ] **Step 8: Run tests and predecessor regressions**
+
+Run Python contract and full Godot runner. Expected: all Spell Workflow component assertions green and all predecessor Star Circuit suites unchanged.
+
+- [ ] **Step 9: Commit Spell Workflow composites**
+
+```bash
+git add src/ui/components/five_point_star_composer.* src/ui/components/context_header.* src/ui/components/context_target_selector.* src/ui/components/commit_bar.* src/ui/component_sheets/component_sheet_b_spell_workflow.* tests/integration/test_component_sheet_pack.gd tests/test_component_sheet_pack_contract.py
+git commit -m "feat(ui): add spell workflow semantic components"
+```
+
+---
+
+### Task 4: Build Persistent Evidence, W6 Forecast, W7 Delta, and Sheet C
+
+**Files:**
+- Create: `src/ui/components/evidence_pin.gd`
+- Create: `src/ui/components/evidence_pin.tscn`
+- Create: `src/ui/components/forecast_card.gd`
+- Create: `src/ui/components/forecast_card.tscn`
+- Create: `src/ui/components/context_delta_card.gd`
+- Create: `src/ui/components/context_delta_card.tscn`
+- Create: `src/ui/component_sheets/component_sheet_c_frostbloom_decision.gd`
+- Create: `src/ui/component_sheets/component_sheet_c_frostbloom_decision.tscn`
+- Modify: `tests/integration/test_component_sheet_pack.gd`
+
+**Interfaces:**
+
+`EvidencePin`:
+
+```gdscript
+func configure(known_count: int, unknown_count: int, lens_label: String, compact: bool = false) -> void
+func visual_snapshot() -> Dictionary
+```
+
+`ForecastCard`:
+
+```gdscript
+func configure(known_improvement: String, uncertain_consequence: String, success_percent: int, breakdown_rows: Array[Dictionary], mana_cost: int) -> void
+func visual_snapshot() -> Dictionary
+```
+
+`ContextDeltaCard`:
+
+```gdscript
+func configure(still_true: String, newly_learned: String, new_tension: String) -> void
+func visual_snapshot() -> Dictionary
+```
+
+- [ ] **Step 1: Add RED assertions for exact semantic fields**
+
+Assert `EvidencePin.visual_snapshot()` returns `known=2`, `unknown=2`, `lens="FIELD_HANDLING"`; `ForecastCard` snapshot keys are exactly the approved four semantic fields; `ContextDeltaCard` keys are exactly `STILL_TRUE`, `NEWLY_LEARNED`, `NEW_TENSION`.
+
+- [ ] **Step 2: Run RED**
+
+Expected: only these new APIs fail.
+
+- [ ] **Step 3: Implement `EvidencePin`**
+
+Use `AcademyPanelPinned` with three Badge/Label regions. Unknown uses amber/diamond-or-unknown icon plus `UNKNOWN` wording, never danger-red/failure styling. `compact=true` changes Container visibility/layout only; it does not drop Unknown or Lens.
+
+- [ ] **Step 4: Implement `ForecastCard`**
+
+Render sections in this order and preserve all four simultaneously:
+
+```text
+KNOWN IMPROVEMENT
+UNCERTAIN CONSEQUENCE
+SUCCESS BREAKDOWN
+MANA COST
+```
+
+Clamp display percentage to `0..100` for rendering safety, but do not calculate it. Breakdown rows are display-only label/value pairs. No hidden facts, target recommendation, or best-route copy is introduced.
+
+- [ ] **Step 5: Implement `ContextDeltaCard`**
+
+Use three stable blocks. `STILL_TRUE` receives preserved/steady iconography; `NEW_TENSION` uses caution semantics, not failure semantics. No action buttons exist inside the card.
+
+- [ ] **Step 6: Build Sheet C with persistent handoff**
+
+Show:
+
+```text
+Evidence Pin (same instance identity)
+→ W6 Forecast
+→ pinned W6 result anchor strip
+→ W7 Context Delta
+```
+
+The Sheet must visibly demonstrate there is no duplicate “Decision Brief” and no second “Result Anchor recap screen”.
+
+- [ ] **Step 7: Run tests and commit**
+
+```bash
+git add src/ui/components/evidence_pin.* src/ui/components/forecast_card.* src/ui/components/context_delta_card.* src/ui/component_sheets/component_sheet_c_frostbloom_decision.* tests/integration/test_component_sheet_pack.gd
+git commit -m "feat(ui): add frostbloom decision components"
+```
+
+---
+
+### Task 5: Build Result/Causal components and Sheet D
+
+**Files:**
+- Create: `src/ui/components/result_axis_card.gd`
+- Create: `src/ui/components/result_axis_card.tscn`
+- Create: `src/ui/components/causal_thread.gd`
+- Create: `src/ui/components/causal_thread.tscn`
+- Create: `src/ui/component_sheets/component_sheet_d_result_grimoire.gd`
+- Create: `src/ui/component_sheets/component_sheet_d_result_grimoire.tscn`
+- Modify: `tests/integration/test_component_sheet_pack.gd`
+
+**Interfaces:**
+
+`ResultAxisCard`:
+
+```gdscript
+const ALLOWED_AXES := [&"FACILITY", &"LIFE", &"SPIRIT", &"RELATIONSHIP", &"DISCOVERY"]
+func configure(axis_id: StringName, summary: String, detail: String = "") -> void
+func visual_snapshot() -> Dictionary
+```
+
+`CausalThread`:
+
+```gdscript
+const ALLOWED_KINDS := [&"OBSERVATION", &"W6_CIRCUIT", &"W6_TARGET", &"W6_RESULT", &"CONTEXT_DELTA", &"W7_JUDGMENT", &"W7_RESULT"]
+func configure(receipts: Array[Dictionary]) -> void
+func visual_snapshot() -> Dictionary
+```
+
+- [ ] **Step 1: Write RED assertions**
+
+Assert five axis cards accept only the approved axis IDs; invalid axis IDs leave the card in an explicit `INVALID_AXIS` snapshot state instead of silently becoming a sixth axis. Assert Causal Thread preserves all seven receipt kinds in supplied order and does not add a summary grade.
+
+- [ ] **Step 2: Run RED**
+
+Expected: new Result/Causal assertions fail.
+
+- [ ] **Step 3: Implement `ResultAxisCard`**
+
+Use Academy Panel + icon slot + title + live summary/detail. No score, grade, star count, or aggregate result property exists in script or scene.
+
+- [ ] **Step 4: Implement `CausalThread`**
+
+Create one node row per receipt with kind label, live text, and connector. Use a vertical `VBoxContainer` as the canonical constrained layout. At wide widths, the parent Sheet may arrange nodes into a stepped flow; the component's data order remains unchanged. Unsupported kinds set `status=&"INVALID_RECEIPT_KIND"` and do not invent replacement content.
+
+- [ ] **Step 5: Build Sheet D**
+
+Show the five Result axes as `3 + 2` at 1920×1080 and stacked at constrained width. Below or beside them, render the seven-step Causal Thread. Add one “Portfolio Receipt” mini composition using existing Panel/Badge/Label primitives only; do not create a thirteenth core component.
+
+- [ ] **Step 6: Run tests and commit**
+
+```bash
+git add src/ui/components/result_axis_card.* src/ui/components/causal_thread.* src/ui/component_sheets/component_sheet_d_result_grimoire.* tests/integration/test_component_sheet_pack.gd
+git commit -m "feat(ui): add result and causal components"
+```
+
+---
+
+### Task 6: Responsive layout, deterministic captures, and dedicated CI
+
+**Files:**
+- Create: `tools/capture_component_sheets.gd`
+- Create: `.github/workflows/validate-component-sheet-pack.yml`
+- Modify: `tests/test_component_sheet_pack_contract.py`
+- Modify: `tests/integration/test_component_sheet_pack.gd`
+
+**Interfaces:**
+- Consumes: four Sheet scenes and existing Godot 4.7.1 setup tool.
+- Produces: eight deterministic PNG evidence files: A–D at 1920×1080 and 1280×720.
+
+- [ ] **Step 1: Add RED capture/workflow contract**
+
+Python contract requires `tools/capture_component_sheets.gd`, workflow path, and exact artifact filenames:
+
+```python
+CAPTURES = [
+    f"component-sheet-{sheet}-{size}.png"
+    for sheet in "abcd"
+    for size in ("1920x1080", "1280x720")
+]
+```
+
+- [ ] **Step 2: Implement the capture script using the existing snapshot pattern**
+
+Use the same `SubViewport`/`RenderingServer.force_draw` approach as `tools/capture_star_ui_snapshot.gd`. Define exact sheet paths and sizes:
+
+```gdscript
+const SHEETS := {
+    "a": "res://src/ui/component_sheets/component_sheet_a_foundations.tscn",
+    "b": "res://src/ui/component_sheets/component_sheet_b_spell_workflow.tscn",
+    "c": "res://src/ui/component_sheets/component_sheet_c_frostbloom_decision.tscn",
+    "d": "res://src/ui/component_sheets/component_sheet_d_result_grimoire.tscn",
+}
+const SIZES := [Vector2i(1920, 1080), Vector2i(1280, 720)]
+```
+
+For each pair: instantiate fresh scene, full-rect it, call `initialize_demo()` when available, wait five frames, save to `res://build/visual/component-sheet-{id}-{width}x{height}.png`, and fail if file size is under 10 KB.
+
+- [ ] **Step 3: Strengthen integration layout assertions**
+
+Instantiate every Sheet under a 1920×1080 and 1280×720 `SubViewport`. Assert all visible `BaseButton` descendants have `custom_minimum_size.x >= 48` and `.y >= 48` when they are interactive. Assert no Sheet root reports size outside its viewport and no required semantic component is hidden.
+
+- [ ] **Step 4: Create dedicated CI**
+
+`validate-component-sheet-pack.yml` must:
+
+```text
+checkout
+→ setup Python 3.12
+→ python -m unittest tests.test_component_sheet_pack_contract -v
+→ setup Godot 4.7.1 via tools/setup_godot_toolchain.py
+→ Godot --headless --import
+→ Godot custom test_runner.gd
+→ xvfb-run GL compatibility capture_component_sheets.gd
+→ assert all 8 PNGs non-empty
+→ upload build/visual/component-sheet-*.png + logs
+```
+
+Do not remove or weaken `validate-star-runtime-poc.yml`; the predecessor UI kit remains independently validated.
+
+- [ ] **Step 5: Run local/focused verification**
+
+Run Python contract, full Godot runner, import, and capture. Expected: 8 PNGs exist and all pre-existing suites remain green.
+
+- [ ] **Step 6: Commit capture/CI**
+
+```bash
+git add tools/capture_component_sheets.gd .github/workflows/validate-component-sheet-pack.yml tests/test_component_sheet_pack_contract.py tests/integration/test_component_sheet_pack.gd
+git commit -m "test(ui): add component sheet visual evidence pipeline"
+```
+
+---
+
+### Task 7: Five-pass adversarial closure, PR, merge, and Notion readback
+
+**Files:**
+- Create: `docs/planning/COMPONENT_SHEET_PACK_01_ADVERSARIAL_REVIEW_2026-08-20.md`
+- Create: `docs/planning/sync/GR-SYNC-20260820-33-COMPONENT-SHEET-PACK-IMPLEMENTATION.md`
+- Modify only current pointers/Notion records after exact-head success; do not mutate unrelated runtime canon.
+
+**Interfaces:**
+- Produces: review evidence, exact-head workflow receipt, merged main SHA, TASK-13 revision/readback.
+
+- [ ] **Step 1: Run whole-state adversarial pass 1 — duplicate authority attack**
+
+Verify only `GrimoireThemeFactory` owns the approved token literals and only the existing `StarCircuitBoard` draws the FIVE_POINT_STAR. Record PASS/FAIL and exact paths.
+
+- [ ] **Step 2: Run pass 2 — semantic dishonesty attack**
+
+Inspect W6/W7/Result sample and component APIs for recommendation, hidden-known modifiers, W6 rollback, global score/grade, or retrospective correct-answer nodes. Record findings.
+
+- [ ] **Step 3: Run pass 3 — responsive/accessibility structural attack**
+
+Review 1920×1080 and 1280×720 captures plus automated hit-target checks; verify Focus and Selected differ, Unknown is not failure-red, and no hover-only critical information exists. Keep physical/device/human evidence `NOT_RUN`.
+
+- [ ] **Step 4: Run pass 4 — Task8/product ownership attack**
+
+Compare changed paths against any current open PRs and protected Spell Workflow files. If active Task8 owns an overlapping path, stop and rebase/re-scope; otherwise record `TASK8_SOURCE_DELTA: NONE` for this UI pack.
+
+- [ ] **Step 5: Run pass 5 — scope/art creep attack**
+
+Verify no background/portrait/full Festival art, no font package, no new gameplay engine, and no thirteenth component family was smuggled into this plan.
+
+- [ ] **Step 6: Create the review and sync receipt**
+
+The sync must explicitly record:
+
+```yaml
+decision_id: GM-COMPONENT-SHEET-IMAGE-PRODUCTION-CONTRACT-01
+component_sheet_pack: A_B_C_D
+existing_theme_reused: true
+existing_star_circuit_board_reused: true
+visual_master: 1920x1080
+minimum_regression: 1280x720
+human_visual_validation: NOT_RUN
+physical_device_validation: NOT_RUN
+performance_validation: NOT_RUN
+full_vertical_slice_validation: NOT_RUN
+```
+
+- [ ] **Step 7: Open PR and inspect exact-head checks/review threads**
+
+Require the new Component Sheet workflow plus all applicable existing Planning/Spell/Star/Godot workflows to finish successfully. GUT Formal Adoption may be path-filter skipped when applicable; do not relabel a skip as PASS.
+
+- [ ] **Step 8: Squash merge only after clean exact-head readback**
+
+Confirm `main` did not move into a conflicting owner path; then squash merge with expected head SHA.
+
+- [ ] **Step 9: Update Notion TASK-13 after merge**
+
+Increase Revision, keep area `비주얼`, record merged SHA and Sheet A–D artifact evidence. Mark the component-sheet implementation substage complete, but keep TASK-13 overall `진행 중` because image production is Plan 2. Human/Device/Performance/Full Slice remain `NOT_RUN`.

--- a/docs/superpowers/plans/2026-08-20-first-session-image-asset-production.md
+++ b/docs/superpowers/plans/2026-08-20-first-session-image-asset-production.md
@@ -1,0 +1,774 @@
+# GRIMOIRE First-Session Image Asset Production Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Produce, review, decompose, register, and import the approved first-session image asset batch while keeping all functional UI live, preserving GRIMOIRE’s locked visual authority, and preventing generated candidates from becoming runtime assets without provenance and user approval.
+
+**Architecture:** Treat image generation as candidate-source production, not direct runtime export. Recover approved references and briefs, generate bounded alternatives, keep candidates in the persistent Library, obtain explicit visual selection, classify reusable layers/variants using Base RM-VIS modules, then create deterministic runtime exports/manifests and a Godot asset-gallery evidence scene only for approved candidates.
+
+**Tech Stack:** ChatGPT image generation surface, ChatGPT Files/Library, Python 3.12 for SHA/conversion/manifest validation, Pillow only for deterministic format/crop/export operations if needed, text-free SVG for glyph/Lens/Result symbols, Godot 4.7.1 import/render verification, Python `unittest`, existing `ASSET_MANIFEST_SCHEMA.json`, Notion `ASSET LIBRARY · Master`.
+
+**Spec:** `docs/superpowers/specs/2026-08-20-component-sheet-image-production-contract-design.md`
+
+## Global Constraints
+
+- Current project authority at plan creation: GRIMOIRE `main` `4c2f23c4bb8b7487559b113a5d41deab815fb62d`.
+- Current Base observation: `e222e93e79e95364dca668eaaf0f156676123342`; use `RM-VIS-002 GAMEPLAY_SYMBOL_ATLAS`, `RM-VIS-003 MODULAR_BACKGROUND_LAYER_KIT`, `RM-VIS-004 COMBAT_TELEGRAPH_VFX_KIT`, and `RM-VIS-005 PORTRAIT_STATE_VARIANT_KIT` as structural/reuse contracts only.
+- Locked visual authority remains `/GRIMOIRE/Visual Authority/GRIMOIRE_ART_STYLE_01_LOCKED_REFERENCE.png`, SHA-256 `b55ce1dec6c2521668602d1ce6547526e7f40b8c7c9b6f5276d9289a67f14f7a`; do not edit, regenerate, crop-replace, recolor, or overwrite it.
+- Approved Board A/B remain composition/checkpoint references; their embedded UI text/numbers are noncanonical placeholders and must never be extracted as runtime UI sprites.
+- Visual style remains `SOFT_STORYBOOK_ENVIRONMENT + CLEAN_ANIME_CEL_CHARACTER_OVER_STORYBOOK_BACKGROUND + NAVY_GOLD_MAGIC_ACADEMY_FRAME`.
+- AI-generated-look reduction, style consistency/readability, and world/core-system fit remain mandatory review axes.
+- Background source master target: `2560×1440`; runtime opaque background export: WebP Lossless; no alpha.
+- Half-body portrait runtime canvas: `1024×1536 RGBA`; Maren uses the professor family and does not create a new costume family.
+- Main companion runtime frame target: `256×256 RGBA`; generate higher-resolution source, then crop/export deterministically.
+- Base glyph count for this first session remains exactly `FLOW / FOCUS / DISPERSE`; glyph source target is `512×512`, SVG preferred for final runtime symbol.
+- Base icon hard cap remains 24. The new Lens 4 + Result Axis 5 must reuse existing common icons where semantically valid and keep total active base icons under the cap.
+- Text/labels/numbers are live UI. No Korean/English functional text, success %, Mana, count, grade, or button label may be baked into images.
+- Generated asset existence does not imply approval. Candidate → visual review → selected candidate → export → manifest → import → runtime verification are distinct states.
+- Every runtime asset must conform to `docs/planning/ASSET_MANIFEST_SCHEMA.json`; source File ID/path + SHA, tool, owner, export SHA/format/dimensions, license status/evidence, screen consumers, approval, and runtime validation are mandatory.
+- Source layers live in ChatGPT Library/external source storage or `.gdignore` source root; GitHub product paths receive only approved runtime exports/manifests, not uncontrolled layered masters.
+- Human visual approval is required before any generated raster candidate can become `APPROVED_RUNTIME_CANDIDATE`.
+- Physical-device validation, performance validation, accessibility/device validation, and Full Vertical Slice validation remain `NOT_RUN` unless actually executed later.
+- No Festival full-content batch, all-NPC portrait batch, Year-One full asset set, companion growth stages, guardian battlefield body, or second incident art is authorized.
+
+---
+
+## File Structure
+
+### Planning/brief/contract files
+
+- `docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_BRIEF.md` — exact asset groups, alternatives, generation constraints, rejection criteria.
+- `docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_PLAN.json` — machine-readable planned groups and state ceilings.
+- `docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_LAYER_REUSE_REVIEW.md` — selected candidates classified as `REUSE_AS_IS / VARIANT_SEED / STRUCTURE_PATTERN / STYLE_DNA / REBUILD_FOR_REUSE / ONE_OFF_KEEP / REJECT_REUSE`.
+- `tests/test_first_session_image_batch_contract.py` — planning/runtime manifest guard.
+
+### Runtime export targets after explicit visual approval
+
+- `assets/art/backgrounds/greenhouse/bg_greenhouse_field_base.webp`
+- `assets/art/backgrounds/school/bg_school_common.webp`
+- `assets/art/characters/professor/chr_maren_portrait_instructive.png`
+- `assets/art/characters/companion/chr_nea_field_neutral.png`
+- `assets/art/ui/glyphs/glyph_flow.svg`
+- `assets/art/ui/glyphs/glyph_focus.svg`
+- `assets/art/ui/glyphs/glyph_disperse.svg`
+- `assets/art/ui/lens/icon_lens_rest.svg`
+- `assets/art/ui/lens/icon_lens_prepare.svg`
+- `assets/art/ui/lens/icon_lens_social.svg`
+- `assets/art/ui/lens/icon_lens_practicum.svg`
+- `assets/art/ui/result/icon_result_facility.svg`
+- `assets/art/ui/result/icon_result_life.svg`
+- `assets/art/ui/result/icon_result_spirit.svg`
+- `assets/art/ui/result/icon_result_relationship.svg`
+- `assets/art/ui/result/icon_result_discovery.svg`
+
+### Runtime manifests after explicit visual approval
+
+- `assets/manifests/bg_greenhouse_field_base.json`
+- `assets/manifests/bg_school_common.json`
+- `assets/manifests/chr_maren_portrait_instructive.json`
+- `assets/manifests/chr_nea_field_neutral.json`
+- `assets/manifests/glyph_flow.json`
+- `assets/manifests/glyph_focus.json`
+- `assets/manifests/glyph_disperse.json`
+- `assets/manifests/icon_lens_rest.json`
+- `assets/manifests/icon_lens_prepare.json`
+- `assets/manifests/icon_lens_social.json`
+- `assets/manifests/icon_lens_practicum.json`
+- `assets/manifests/icon_result_facility.json`
+- `assets/manifests/icon_result_life.json`
+- `assets/manifests/icon_result_spirit.json`
+- `assets/manifests/icon_result_relationship.json`
+- `assets/manifests/icon_result_discovery.json`
+
+### Runtime gallery/verification files
+
+- `src/ui/asset_gallery/first_session_asset_gallery.gd`
+- `src/ui/asset_gallery/first_session_asset_gallery.tscn`
+- `tools/capture_first_session_asset_gallery.gd`
+- `.github/workflows/validate-first-session-image-assets.yml`
+- `docs/planning/FIRST_SESSION_IMAGE_BATCH_01_ADVERSARIAL_REVIEW_2026-08-20.md`
+- `docs/planning/sync/GR-SYNC-20260820-34-FIRST-SESSION-IMAGE-ASSETS.md`
+
+### Persistent Library candidate roots
+
+```text
+/GRIMOIRE/Production Candidates/first_session_01/backgrounds/greenhouse/
+/GRIMOIRE/Production Candidates/first_session_01/backgrounds/classroom/
+/GRIMOIRE/Production Candidates/first_session_01/characters/maren/
+/GRIMOIRE/Production Candidates/first_session_01/characters/nea/
+/GRIMOIRE/Production Candidates/first_session_01/symbol_concepts/glyphs/
+/GRIMOIRE/Production Candidates/first_session_01/symbol_concepts/lens/
+/GRIMOIRE/Production Candidates/first_session_01/symbol_concepts/result/
+/GRIMOIRE/Production Candidates/first_session_01/ornament_vfx/
+```
+
+---
+
+### Task 1: Asset-batch contract RED and exact generation briefs
+
+**Files:**
+- Create: `tests/test_first_session_image_batch_contract.py`
+- Create: `docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_BRIEF.md`
+- Create: `docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_PLAN.json`
+
+**Interfaces:**
+- Consumes: Art Bible, Asset Spec, approved Board A/B manifests, Component production spec, Base RM-VIS contracts.
+- Produces: exactly seven mandatory production groups plus one conditional ornament/VFX sufficiency group; no generated asset yet.
+
+- [ ] **Step 1: Write the RED contract first**
+
+Create `tests/test_first_session_image_batch_contract.py`:
+
+```python
+from pathlib import Path
+import json
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+PLAN = ROOT / "docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_PLAN.json"
+BRIEF = ROOT / "docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_BRIEF.md"
+SCHEMA = ROOT / "docs/planning/ASSET_MANIFEST_SCHEMA.json"
+
+EXPECTED_GROUPS = [
+    "GREENHOUSE_BACKGROUND",
+    "CLASSROOM_BACKGROUND",
+    "MAREN_PORTRAIT",
+    "NEA_SOURCE",
+    "GLYPH_SYMBOLS",
+    "LENS_SYMBOLS",
+    "RESULT_AXIS_SYMBOLS",
+    "ORNAMENT_VFX_SUFFICIENCY",
+]
+
+class FirstSessionImageBatchContractTests(unittest.TestCase):
+    def test_plan_and_brief_exist(self):
+        self.assertTrue(PLAN.is_file())
+        self.assertTrue(BRIEF.is_file())
+
+    def test_plan_is_candidate_only_before_human_review(self):
+        data = json.loads(PLAN.read_text(encoding="utf-8"))
+        self.assertEqual(EXPECTED_GROUPS, [g["group_id"] for g in data["groups"]])
+        self.assertTrue(all(g["status"] == "PLANNED" for g in data["groups"]))
+        self.assertTrue(all(g["runtime_validation"] == "NOT_RUN" for g in data["groups"]))
+        self.assertFalse(data["mass_generation_authorized"])
+
+    def test_locked_authority_and_text_boundary_are_explicit(self):
+        text = BRIEF.read_text(encoding="utf-8")
+        self.assertIn("b55ce1dec6c2521668602d1ce6547526e7f40b8c7c9b6f5276d9289a67f14f7a", text)
+        self.assertIn("NO_FUNCTIONAL_TEXT_BAKED_INTO_IMAGE", text)
+        self.assertIn("USER_VISUAL_APPROVAL_REQUIRED", text)
+
+    def test_runtime_schema_still_requires_traceability(self):
+        schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+        for key in ("asset_id", "source", "export", "license", "status", "used_in_screens", "runtime_validation"):
+            self.assertIn(key, schema["required"])
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run RED**
+
+Run:
+
+```bash
+python -m unittest tests.test_first_session_image_batch_contract -v
+```
+
+Expected: fail because BRIEF/PLAN do not yet exist.
+
+- [ ] **Step 3: Create the machine plan**
+
+`FIRST_SESSION_IMAGE_BATCH_01_PLAN.json` uses this exact outer shape:
+
+```json
+{
+  "schema_version": 1,
+  "decision_id": "GM-COMPONENT-SHEET-IMAGE-PRODUCTION-CONTRACT-01",
+  "status": "IMPLEMENTATION_PLAN_APPROVED_CANDIDATE_PRODUCTION_NOT_STARTED",
+  "mass_generation_authorized": false,
+  "locked_visual_sha256": "b55ce1dec6c2521668602d1ce6547526e7f40b8c7c9b6f5276d9289a67f14f7a",
+  "groups": [
+    {"group_id": "GREENHOUSE_BACKGROUND", "candidate_count": 3, "status": "PLANNED", "runtime_validation": "NOT_RUN"},
+    {"group_id": "CLASSROOM_BACKGROUND", "candidate_count": 3, "status": "PLANNED", "runtime_validation": "NOT_RUN"},
+    {"group_id": "MAREN_PORTRAIT", "candidate_count": 3, "status": "PLANNED", "runtime_validation": "NOT_RUN"},
+    {"group_id": "NEA_SOURCE", "candidate_count": 3, "status": "PLANNED", "runtime_validation": "NOT_RUN"},
+    {"group_id": "GLYPH_SYMBOLS", "candidate_count": 3, "status": "PLANNED", "runtime_validation": "NOT_RUN"},
+    {"group_id": "LENS_SYMBOLS", "candidate_count": 3, "status": "PLANNED", "runtime_validation": "NOT_RUN"},
+    {"group_id": "RESULT_AXIS_SYMBOLS", "candidate_count": 3, "status": "PLANNED", "runtime_validation": "NOT_RUN"},
+    {"group_id": "ORNAMENT_VFX_SUFFICIENCY", "candidate_count": 0, "status": "PLANNED", "runtime_validation": "NOT_RUN"}
+  ]
+}
+```
+
+- [ ] **Step 4: Write exact visual briefs and rejection criteria**
+
+The Markdown brief must define these immutable requirements:
+
+```text
+GLOBAL:
+- no UI frame, button, number, logo, watermark, or functional text in generated raster art
+- no copy of a competitor's character/layout/trade dress
+- preserve Soft Storybook environment + clean cel characters + restrained Navy/Gold academy language
+- playable/reading region has lower detail density than focal framing
+- AI artifacts in hands, architecture, repeated motifs, edge tangencies, pseudo-text, or inconsistent costume = reject
+- USER_VISUAL_APPROVAL_REQUIRED before export/import
+```
+
+Then define per-group briefs:
+
+**Greenhouse:** 2560×1440 source target, fixed 3/4 environment, damaged frostbloom greenhouse, readable irrigation/root/spirit-channel landmarks, no character/UI, three materially different camera/composition candidates while preserving the same location identity.
+
+**Classroom:** 2560×1440 source target, same academy world, practical glyph-learning space, visible practice surface and supervised field-maintenance preparation cues, no baked tutorial text, three composition alternatives.
+
+**Maren:** half-body source with transparent-friendly/simple background, same professor identity family, neutral-to-instructive expression, Navy/Gold academic authority without villain coding, no costume variants; three candidates differ in expression/gesture/framing only.
+
+**Nea:** small wolf-like companion, white/pale-blue, rounded face, large ears/tail, small elemental glow, no growth form; three candidates differ only in pose/energy emphasis.
+
+**Glyph concept directions:** FLOW = directional curved stream, FOCUS = compressed core/convergence, DISPERSE = expanding/diverging wave. Three style-direction sheets; final runtime glyphs will be manually rebuilt as text-free SVG.
+
+**Lens concept directions:** REST = recovery/quiet state, PREPARE = tool/readiness, SOCIAL = people/context, PRACTICUM = field handling/comparison. Three style-direction sheets; final runtime icons rebuilt as SVG.
+
+**Result concept directions:** FACILITY = structure, LIFE = living growth, SPIRIT = spirit resonance, RELATIONSHIP = linked people/records, DISCOVERY = revealed knowledge. Three style-direction sheets; final runtime icons rebuilt as SVG.
+
+**Ornament/VFX:** inspect existing `academy_corner_ornament.svg`, phase/warning icons, and existing glyph/VFX assets first. Generate nothing if they satisfy Sheet A–D needs; if insufficient, authorize at most one ornament motif concept sheet and one transparent VFX-mask concept sheet in a later bounded revision.
+
+- [ ] **Step 5: Run GREEN and commit**
+
+```bash
+python -m unittest tests.test_first_session_image_batch_contract -v
+git add tests/test_first_session_image_batch_contract.py docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_BRIEF.md docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_PLAN.json
+git commit -m "test(art): define first-session image batch contract"
+```
+
+---
+
+### Task 2: Recover references and generate three Greenhouse/Classroom candidates each
+
+**Files/Library:**
+- Read only: locked Art Style reference and approved Board A/B Library files.
+- Write candidates to the two background Library roots; do not write runtime `assets/` yet.
+- Create: `docs/planning/visual/first_session_image_batch_01_background_candidates.json`
+
+**Interfaces:**
+- Consumes: visual authority + exact background briefs.
+- Produces: six candidate source records with File IDs/generation IDs/SHA where available, all status `IN_VISUAL_REVIEW` or `SOURCE_READY`, never runtime-approved.
+
+- [ ] **Step 1: Recover and inspect the exact approved references**
+
+Use Files/Library search for the locked visual authority and Board A/B. Verify locked SHA/name against the brief. If the locked source cannot be recovered exactly, stop background generation rather than substituting an unknown reference.
+
+- [ ] **Step 2: Generate three Greenhouse alternatives with image generation**
+
+Generate exactly 3 images in one bounded request when the tool supports it. Require:
+
+```text
+same GRIMOIRE visual language
+soft storybook fixed 3/4 greenhouse environment
+frostbloom damage/pressure context
+clear irrigation path + root layer + spirit-channel landmarks
+central playable area quieter than framing
+no characters
+no UI
+no lettering/signage/pseudo-text
+16:9 composition suitable for a 2560×1440 master/export workflow
+```
+
+Alternative axes are camera elevation, foreground framing, and landmark distribution—not different world styles.
+
+- [ ] **Step 3: Persist candidates in Library and record provenance**
+
+Store each as `greenhouse_candidate_01/02/03.png` under the Greenhouse candidate folder. Record actual File ID/library path, generation/tool identifier if surfaced, dimensions, and SHA-256 after materialization. Status remains `IN_VISUAL_REVIEW`.
+
+- [ ] **Step 4: Generate three Classroom alternatives**
+
+Use the same process with exact brief constraints. Candidate axes are room orientation, practice-surface location, and professor/student staging space; no actual characters are baked into the background source.
+
+- [ ] **Step 5: Create the background candidate receipt**
+
+The JSON receipt records six candidates and explicitly says:
+
+```yaml
+selected_candidate: NONE_PENDING_USER_VISUAL_REVIEW
+runtime_export: NOT_CREATED
+runtime_validation: NOT_RUN
+```
+
+- [ ] **Step 6: Present candidates to the user for visual selection**
+
+Show all three per group with concise A/B/C differences. Do not pick on the user's behalf. Ask for one selected candidate per group or a specific bounded revision request.
+
+- [ ] **Step 7: Commit provenance receipt only**
+
+Do not commit candidate PNGs to runtime paths before selection.
+
+```bash
+git add docs/planning/visual/first_session_image_batch_01_background_candidates.json
+git commit -m "docs(art): record first-session background candidates"
+```
+
+---
+
+### Task 3: Generate Maren and Nea identity-safe candidates and select base families
+
+**Files/Library:**
+- Candidate roots: Maren and Nea Library folders.
+- Create: `docs/planning/visual/first_session_image_batch_01_character_candidates.json`
+
+**Interfaces:**
+- Consumes: Board A/B character continuity, Art Bible character keys, Base `RM-VIS-005 PORTRAIT_STATE_VARIANT_KIT`.
+- Produces: one selected Maren base family and one selected Nea base family after explicit user review; no runtime export before selection.
+
+- [ ] **Step 1: Define identity locks from approved references before generation**
+
+Record the observed/approved identity constraints, not invented detail:
+
+```yaml
+maren:
+  role: mentor_professor
+  costume_family: navy_gold_academy
+  variation_axes: expression_gaze_small_gesture_framing_only
+  new_costume: forbidden
+nea:
+  body_family: small_wolf_spirit
+  palette: white_pale_blue
+  face: rounded
+  ears_tail: large_readable_silhouette
+  glow: small_elemental
+  growth_form: forbidden
+```
+
+If an exact face/costume feature is not supported by the approved reference, leave it unspecified in the brief rather than hallucinating it.
+
+- [ ] **Step 2: Generate exactly three Maren half-body candidates**
+
+Request transparent background when supported. Keep clothing/palette/light family constant; vary only instructive expression, small hand gesture, and framing. Reject pseudo-text, extra accessories, costume redesign, or face drift.
+
+- [ ] **Step 3: Generate exactly three Nea candidates**
+
+Request transparent background. Keep body/palette/silhouette family fixed; vary only neutral pose vs alert pose vs gentle field-attention pose. Reject growth/evolution armor, mount scale, extra tails/wings, or mascot redesign.
+
+- [ ] **Step 4: Persist and hash candidates; record them as `IN_VISUAL_REVIEW`**
+
+Create the character candidate receipt with actual source IDs and no runtime export fields.
+
+- [ ] **Step 5: User selects one Maren and one Nea family**
+
+Selection promotes only the source family to `SOURCE_READY`. It does not yet mean Runtime Verified/Project Asset Approved.
+
+- [ ] **Step 6: Commit the character candidate/selection receipt**
+
+```bash
+git add docs/planning/visual/first_session_image_batch_01_character_candidates.json
+git commit -m "docs(art): record first-session character candidates"
+```
+
+---
+
+### Task 4: Generate symbol directions, choose one, then rebuild final glyph/Lens/Result icons as SVG
+
+**Files:**
+- Candidate concept sheets live in Library only.
+- Create final SVGs at the 12 runtime paths listed above.
+- Create: `docs/planning/visual/first_session_image_batch_01_symbol_direction_review.md`
+- Modify: `tests/test_first_session_image_batch_contract.py`
+
+**Interfaces:**
+- Consumes: Base `RM-VIS-002`, selected GRIMOIRE visual language, existing text-free SVG conventions.
+- Produces: 3 glyph SVGs + 4 Lens SVGs + 5 Result SVGs; simple path geometry, no text/raster/filter/font.
+
+- [ ] **Step 1: Generate three concept-direction sheets for each symbol family**
+
+Use image generation for visual exploration only. Each sheet must show all semantic members of its family and no readable text. Concept sheets are `REFERENCE_ONLY` and never runtime imports.
+
+- [ ] **Step 2: Present the three directions and obtain one user-selected direction per family**
+
+Decision axes: 16/24/32/48px legibility, GRIMOIRE identity, shape distinctness, AI-look reduction, and no semantic collision with existing Mana/Warning/Phase icons.
+
+- [ ] **Step 3: Write SVG RED assertions before rebuilding**
+
+Extend Python contract:
+
+```python
+SVG_PATHS = [
+    "assets/art/ui/glyphs/glyph_flow.svg",
+    "assets/art/ui/glyphs/glyph_focus.svg",
+    "assets/art/ui/glyphs/glyph_disperse.svg",
+    "assets/art/ui/lens/icon_lens_rest.svg",
+    "assets/art/ui/lens/icon_lens_prepare.svg",
+    "assets/art/ui/lens/icon_lens_social.svg",
+    "assets/art/ui/lens/icon_lens_practicum.svg",
+    "assets/art/ui/result/icon_result_facility.svg",
+    "assets/art/ui/result/icon_result_life.svg",
+    "assets/art/ui/result/icon_result_spirit.svg",
+    "assets/art/ui/result/icon_result_relationship.svg",
+    "assets/art/ui/result/icon_result_discovery.svg",
+]
+for relative in SVG_PATHS:
+    text = (ROOT / relative).read_text(encoding="utf-8").lower()
+    self.assertIn("<svg", text)
+    self.assertRegex(text, r"<(path|circle|polygon|line|rect)\b")
+    for forbidden in ("<text", "<image", "<filter", "data:image", "font-family"):
+        self.assertNotIn(forbidden, text)
+```
+
+Run RED; expected: missing SVGs.
+
+- [ ] **Step 4: Rebuild glyphs as simple project-authored SVG**
+
+Semantic geometry, independent of concept-sheet pixels:
+
+```text
+FLOW      = one continuous curved stream path + one secondary parallel accent; directional continuity, no arrow label
+FOCUS     = outer ring/diamond converging to a small central core
+DISPERSE  = central origin with three expanding/diverging arcs
+```
+
+Use existing Navy/Gold/Cyan token-compatible flat fills/strokes and no filters.
+
+- [ ] **Step 5: Rebuild Lens SVGs**
+
+```text
+REST      = quiet crescent/settled pulse motif
+PREPARE   = compact tool/readiness diamond + handle motif
+SOCIAL    = two linked nodes with dialogue/context bridge shape, no text bubble lettering
+PRACTICUM = field marker + handling/compare split motif
+```
+
+- [ ] **Step 6: Rebuild Result SVGs**
+
+```text
+FACILITY      = structural arch/beam
+LIFE          = sprout/leaf growth
+SPIRIT        = resonance spiral/core
+RELATIONSHIP  = two linked rings/nodes
+DISCOVERY     = opened-page/eye-reveal hybrid silhouette without letters
+```
+
+- [ ] **Step 7: Run SVG contract and commit**
+
+```bash
+python -m unittest tests.test_first_session_image_batch_contract -v
+git add assets/art/ui/glyphs assets/art/ui/lens assets/art/ui/result tests/test_first_session_image_batch_contract.py docs/planning/visual/first_session_image_batch_01_symbol_direction_review.md
+git commit -m "feat(art): add first-session semantic symbols"
+```
+
+---
+
+### Task 5: Layer/reuse classification and ornament/VFX sufficiency decision
+
+**Files:**
+- Create: `docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_LAYER_REUSE_REVIEW.md`
+- Read: existing `assets/art/ui/common/*.svg` and approved raster candidates.
+
+**Interfaces:**
+- Consumes: selected source candidates and Base `RM-VIS-003/004/005` classification rules.
+- Produces: explicit layer provenance and reuse classification; either `NO_NEW_ORNAMENT_VFX_REQUIRED` or a narrowly justified follow-up.
+
+- [ ] **Step 1: Classify both selected backgrounds**
+
+For each, record:
+
+```text
+base_environment
+midground
+foreground_props
+lighting
+story_state_overlay
+atmosphere_fx
+```
+
+Each part receives provenance `SOURCE_LAYER`, `MASK_CUTOUT`, `MANUAL_OR_SEMANTIC_REBUILD`, or `DERIVED_GENERATIVE_RECOVERY`. Never label generated reconstruction of an occluded area as observed source.
+
+- [ ] **Step 2: Classify Maren/Nea**
+
+Maren selected source is `VARIANT_SEED` for future expression-only variants. Nea selected source is `VARIANT_SEED` for bounded pose/reaction variants; growth-form generation remains forbidden.
+
+- [ ] **Step 3: Inspect existing common ornament/icon assets against Component Sheets A–D**
+
+If `academy_corner_ornament.svg`, phase diamond, warning diamond, Mana, and current star/glyph visual primitives cover the required decorative states, record:
+
+```yaml
+ornament_vfx_decision: NO_NEW_ORNAMENT_VFX_REQUIRED
+reason: EXISTING_ASSETS_SUFFICIENT
+```
+
+If and only if a concrete missing semantic exists, create a separate bounded follow-up decision instead of generating speculative ornament/VFX in this task.
+
+- [ ] **Step 4: Run 5-pass visual reuse adversarial review**
+
+1. **Primary-quality attack:** did decomposition pressure make the selected image worse as a primary scene?
+2. **Fake-layer attack:** are generated reconstructions truthfully labeled?
+3. **Identity-drift attack:** would a variant seed allow face/costume/world drift?
+4. **Over-reuse attack:** are one-off focal parts being forced into generic modules?
+5. **Scope-creep attack:** did optional ornament/VFX become a new art batch without a consumer?
+
+- [ ] **Step 5: Commit the layer/reuse review**
+
+```bash
+git add docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_LAYER_REUSE_REVIEW.md
+git commit -m "docs(art): classify first-session asset reuse"
+```
+
+---
+
+### Task 6: Export selected raster sources, compute SHA, and create schema-valid runtime manifests
+
+**Files:**
+- Create selected runtime backgrounds/portraits at the four raster export paths.
+- Create 16 per-asset manifests listed above.
+- Modify: `tests/test_first_session_image_batch_contract.py`
+- Modify: `docs/ASSET_LICENSE_LEDGER.md` only with actual generated/exported records; preserve NOT_RUN ceilings.
+
+**Interfaces:**
+- Consumes: explicit user-selected candidate File IDs and the 12 project-authored SVGs.
+- Produces: runtime candidates with deterministic formats/hashes and `APPROVED_RUNTIME_CANDIDATE` status at most; not `PROJECT_ASSET_APPROVED` until runtime verification and final approval.
+
+- [ ] **Step 1: Materialize the selected source files and verify source hashes**
+
+Use the exact selected Library file IDs. Compute:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+import hashlib
+for p in Path('/mnt/data').rglob('*'):
+    if p.is_file():
+        print(p, hashlib.sha256(p.read_bytes()).hexdigest())
+PY
+```
+
+Match the recorded candidate SHA. Any mismatch blocks export.
+
+- [ ] **Step 2: Export opaque backgrounds losslessly**
+
+Use deterministic image conversion only—no creative retouch at export. Resize/crop only if the approved candidate is not already 2560×1440, preserving 16:9 composition. Export:
+
+```text
+bg_greenhouse_field_base.webp  2560×1440  WebP Lossless  alpha=false
+bg_school_common.webp           2560×1440  WebP Lossless  alpha=false
+```
+
+- [ ] **Step 3: Export Maren portrait**
+
+Create `chr_maren_portrait_instructive.png` at 1024×1536 RGBA. Crop contract is waist/mid-thigh with headroom; do not redraw or costume-change during export. If transparent background generation was imperfect, use deterministic mask cleanup only when the selected source supports it; otherwise send the source back for bounded image edit rather than painting new anatomy with a generic script.
+
+- [ ] **Step 4: Export Nea field source**
+
+Create `chr_nea_field_neutral.png` at 256×256 RGBA from the selected higher-resolution source, preserving silhouette and glow readability.
+
+- [ ] **Step 5: Extend Python manifest tests before creating manifests**
+
+For every `assets/manifests/*.json` created by this plan, load `ASSET_MANIFEST_SCHEMA.json` required fields manually or with available schema validation. Require:
+
+```text
+source.storage in {EXTERNAL_LIBRARY, GENERATED_CANDIDATE}
+license.status in {PROJECT_ORIGINAL, USER_OWNED}
+status in {APPROVED_RUNTIME_CANDIDATE, IMPORTED, RUNTIME_VERIFIED, PROJECT_ASSET_APPROVED}
+runtime_validation initially NOT_RUN
+source.sha256 and export.sha256 are real 64-char lowercase hashes
+```
+
+Run RED; expected: manifests missing.
+
+- [ ] **Step 6: Create each manifest with real values only**
+
+Example shape for the selected Greenhouse export:
+
+```json
+{
+  "schema_version": 1,
+  "asset_id": "bg_greenhouse_field_base",
+  "role": "FROSTBLOOM_FIELD_BACKGROUND",
+  "decision_ids": ["ART-BIBLE-01", "ASSET-SPEC-01", "GM-COMPONENT-SHEET-IMAGE-PRODUCTION-CONTRACT-01"],
+  "source": {
+    "storage": "EXTERNAL_LIBRARY",
+    "file_id_or_path": "ACTUAL_SELECTED_LIBRARY_FILE_ID",
+    "sha256": "ACTUAL_SOURCE_SHA256",
+    "tool": "ChatGPT image generation",
+    "owner": "GRIMOIRE project",
+    "prompt_or_brief_path": "docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_BRIEF.md",
+    "parent_asset_ids": ["REF-ART-STYLE-LOCKED-01", "GR-VISUAL-CHECKPOINT-BOARD-A-01"]
+  },
+  "export": {
+    "file_path": "assets/art/backgrounds/greenhouse/bg_greenhouse_field_base.webp",
+    "sha256": "ACTUAL_EXPORT_SHA256",
+    "format": "WEBP",
+    "width": 2560,
+    "height": 1440,
+    "alpha": false,
+    "import_profile": "BACKGROUND_LOSSLESS_LINEAR_MIPMAP_TRIAL"
+  },
+  "license": {
+    "status": "PROJECT_ORIGINAL",
+    "evidence": "Generated for this project with the user-authorized ChatGPT image-generation workflow; no external asset pack imported.",
+    "credit_required": false,
+    "modification_allowed": true,
+    "redistribution_allowed": true
+  },
+  "status": "APPROVED_RUNTIME_CANDIDATE",
+  "approved_by": "USER_VISUAL_SELECTION",
+  "approved_at": "2026-08-20",
+  "used_in_screens": ["FROSTBLOOM_FIELD", "RESULT_RETURN"],
+  "runtime_validation": "NOT_RUN"
+}
+```
+
+At execution, replace `ACTUAL_*` values with observed values; never commit placeholder strings. The task is not complete until a placeholder scan returns zero hits.
+
+- [ ] **Step 7: Update the Asset License Ledger truthfully**
+
+Record only the assets actually exported. `runtime_asset_records` may increase, but `runtime_verified` and `project_asset_approved` stay at their true values until Task 7.
+
+- [ ] **Step 8: Run manifest tests and commit runtime candidates**
+
+```bash
+python -m unittest tests.test_first_session_image_batch_contract -v
+git add assets/art/backgrounds assets/art/characters assets/art/ui/glyphs assets/art/ui/lens assets/art/ui/result assets/manifests docs/ASSET_LICENSE_LEDGER.md tests/test_first_session_image_batch_contract.py
+git commit -m "feat(art): export first-session runtime asset candidates"
+```
+
+---
+
+### Task 7: Godot import verification and first-session asset gallery evidence
+
+**Files:**
+- Create: `src/ui/asset_gallery/first_session_asset_gallery.gd`
+- Create: `src/ui/asset_gallery/first_session_asset_gallery.tscn`
+- Create: `tools/capture_first_session_asset_gallery.gd`
+- Create: `.github/workflows/validate-first-session-image-assets.yml`
+- Modify per-asset manifests from `runtime_validation: NOT_RUN` to `PASS` / status `RUNTIME_VERIFIED` only after actual import/render checks succeed.
+
+**Interfaces:**
+- Consumes: approved runtime candidate exports.
+- Produces: one deterministic 1920×1080 gallery PNG and import/render evidence; this is asset/runtime evidence, not Human/Device/Full Slice evidence.
+
+- [ ] **Step 1: Add RED tests for Godot importability**
+
+Extend Python contract to require gallery/capture/workflow files. Add a Godot integration suite or script checks that `load()` returns real Texture2D for WebP/PNG/SVG runtime exports after import.
+
+- [ ] **Step 2: Create the asset gallery scene**
+
+Use `GrimoireThemeFactory.create_theme()` and live Labels. Layout:
+
+```text
+left top: greenhouse background crop/fit preview
+right top: classroom background crop/fit preview
+lower left: Maren portrait on neutral checker/navy plate
+lower center: Nea source on neutral plate
+lower right: glyph 3 + Lens 4 + Result 5 icon grid
+```
+
+No functional game UI claim; this is an inspection gallery.
+
+- [ ] **Step 3: Create deterministic capture script**
+
+Reuse the existing SubViewport capture pattern; capture exactly 1920×1080 to `build/visual/first-session-asset-gallery.png`. Fail if texture is missing, dimensions mismatch, or PNG is under 20 KB.
+
+- [ ] **Step 4: Create dedicated CI**
+
+Workflow steps:
+
+```text
+Python manifest/asset contract
+→ Godot 4.7.1 setup
+→ --headless --import
+→ asset load verification
+→ xvfb GL-compatibility gallery capture
+→ upload gallery PNG + import/capture logs
+```
+
+- [ ] **Step 5: Run exact import/render checks**
+
+Only after success, set per-asset `runtime_validation` to `PASS` and `status` to `RUNTIME_VERIFIED`. Do not set `PROJECT_ASSET_APPROVED` yet unless the user separately approves the runtime-rendered evidence.
+
+- [ ] **Step 6: Commit gallery/evidence**
+
+```bash
+git add src/ui/asset_gallery tools/capture_first_session_asset_gallery.gd .github/workflows/validate-first-session-image-assets.yml assets/manifests
+git commit -m "test(art): verify first-session runtime assets"
+```
+
+---
+
+### Task 8: Final user runtime-visual approval, five-pass adversarial closure, merge, and Notion/Asset Library sync
+
+**Files/Systems:**
+- Create: `docs/planning/FIRST_SESSION_IMAGE_BATCH_01_ADVERSARIAL_REVIEW_2026-08-20.md`
+- Create: `docs/planning/sync/GR-SYNC-20260820-34-FIRST-SESSION-IMAGE-ASSETS.md`
+- Update: selected manifests to `PROJECT_ASSET_APPROVED` only after explicit runtime-rendered visual approval.
+- Update: Notion `ASSET LIBRARY · Master` records and TASK-13.
+
+**Interfaces:**
+- Produces: truthfully approved first-session asset set, merged SHA, source/runtime traceability, remaining validation ceilings.
+
+- [ ] **Step 1: Present the real Godot-rendered gallery to the user**
+
+Approval question is about project use of the actual imported exports—not just the original generation candidates. If the user requests revision, return to the owning asset task; do not patch around a bad source by silently editing unrelated assets.
+
+- [ ] **Step 2: Promote only explicitly approved rendered assets**
+
+For each approved manifest:
+
+```text
+status: PROJECT_ASSET_APPROVED
+runtime_validation: PASS
+approved_by: USER_RUNTIME_VISUAL_APPROVAL
+```
+
+If one asset is rejected, keep it `REVISION_REQUIRED` or `REJECTED` independently; do not block unrelated approved assets unless shared style identity is compromised.
+
+- [ ] **Step 3: Adversarial pass 1 — AI artifact/consistency attack**
+
+Review anatomy, pseudo-text, repeated architectural patterns, lighting continuity, perspective, Maren face/costume continuity, Nea silhouette/palette, and cross-scene style cohesion.
+
+- [ ] **Step 4: Pass 2 — gameplay readability attack**
+
+Verify backgrounds leave usable low-detail play/read zones; icons distinguish semantics at 16/24/32/48; glyph Flow/Focus/Disperse remain distinct without relying on hue.
+
+- [ ] **Step 5: Pass 3 — rights/provenance attack**
+
+Every approved asset must trace source File ID/path + SHA + generation brief/tool + export SHA + license evidence. Any missing link blocks `PROJECT_ASSET_APPROVED`.
+
+- [ ] **Step 6: Pass 4 — scope/reuse attack**
+
+Ensure no Festival batch, extra NPC portraits, growth forms, background #3, or speculative VFX was added. Verify layer-reuse labels are truthful and do not convert one-off focal art into forced generic modules.
+
+- [ ] **Step 7: Pass 5 — evidence overclaim attack**
+
+Runtime import/render PASS is not Human playtest, device, performance, accessibility, emotional, or Full Slice PASS. Keep those labels `NOT_RUN`.
+
+- [ ] **Step 8: Open PR and run exact-head workflows**
+
+Require the dedicated image asset workflow and all applicable existing Planning/Visual/Toolchain/Star workflows. Inspect changed files and review threads. Do not touch unrelated active PRs.
+
+- [ ] **Step 9: Squash merge after exact-head success**
+
+Use expected head SHA and re-read `main` after merge.
+
+- [ ] **Step 10: Sync Notion Asset Library**
+
+Create/update one record per approved runtime asset with:
+
+```text
+Name
+Asset ID
+Category
+Record Type = ASSET
+Status = APPROVED
+Approved = checked
+Reuse = MASTER or YES/COMPONENT as appropriate
+Source
+Hash
+Rights / License
+Implementation Path
+Prompt/brief reference
+Project = GRIMOIRE
+Last Synced
+```
+
+Generated concept sheets that are not runtime assets remain `REFERENCE`/`WIP` or are omitted from the primary asset library depending on reuse value.
+
+- [ ] **Step 11: Update TASK-13 and Project Home**
+
+Record Component Sheets merged SHA (from Plan 1), image asset merged SHA, selected asset IDs, and remaining NOT_RUN boundaries. TASK-13 may be marked `완료` only when both Component Sheet implementation and this approved image batch are complete; Human/Device/Performance/Full Slice continue as separate later work.

--- a/docs/superpowers/plans/2026-08-20-first-session-image-asset-production.md
+++ b/docs/superpowers/plans/2026-08-20-first-session-image-asset-production.md
@@ -2,11 +2,11 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Produce, review, decompose, register, and import the approved first-session image asset batch while keeping all functional UI live, preserving GRIMOIRE’s locked visual authority, and preventing generated candidates from becoming runtime assets without provenance and user approval.
+**Goal:** Produce, review, decompose, register, and import the approved first-session image asset batch while keeping all functional UI live, preserving GRIMOIRE’s locked visual authority, and preventing generated candidates from becoming runtime assets without provenance, rights evidence, and user approval.
 
-**Architecture:** Treat image generation as candidate-source production, not direct runtime export. Recover approved references and briefs, generate bounded alternatives, keep candidates in the persistent Library, obtain explicit visual selection, classify reusable layers/variants using Base RM-VIS modules, then create deterministic runtime exports/manifests and a Godot asset-gallery evidence scene only for approved candidates.
+**Architecture:** Treat image generation as candidate-source production, never as direct runtime export. Recover approved references and briefs, generate bounded alternatives, persist each candidate with exact IDs/hashes, obtain explicit visual selection, classify reusable layers/variants using Base RM-VIS modules, then create deterministic runtime exports/manifests and a Godot asset-gallery evidence scene only for selected candidates whose rights evidence is sufficient.
 
-**Tech Stack:** ChatGPT image generation surface, ChatGPT Files/Library, Python 3.12 for SHA/conversion/manifest validation, Pillow only for deterministic format/crop/export operations if needed, text-free SVG for glyph/Lens/Result symbols, Godot 4.7.1 import/render verification, Python `unittest`, existing `ASSET_MANIFEST_SCHEMA.json`, Notion `ASSET LIBRARY · Master`.
+**Tech Stack:** ChatGPT image generation surface, ChatGPT Files/Library, Python 3.12 for SHA/conversion/manifest validation, Pillow only for deterministic format/crop/export operations, text-free SVG for glyph/Lens/Result symbols, Godot 4.7.1 import/render verification, Python `unittest`, existing `ASSET_MANIFEST_SCHEMA.json`, Notion `ASSET LIBRARY · Master`.
 
 **Spec:** `docs/superpowers/specs/2026-08-20-component-sheet-image-production-contract-design.md`
 
@@ -22,27 +22,33 @@
 - Half-body portrait runtime canvas: `1024×1536 RGBA`; Maren uses the professor family and does not create a new costume family.
 - Main companion runtime frame target: `256×256 RGBA`; generate higher-resolution source, then crop/export deterministically.
 - Base glyph count for this first session remains exactly `FLOW / FOCUS / DISPERSE`; glyph source target is `512×512`, SVG preferred for final runtime symbol.
-- Base icon hard cap remains 24. The new Lens 4 + Result Axis 5 must reuse existing common icons where semantically valid and keep total active base icons under the cap.
+- Base icon hard cap remains 24. Lens 4 + Result Axis 5 reuse existing common icons where semantically valid and the execution must count active base icons before adding any new symbol.
 - Text/labels/numbers are live UI. No Korean/English functional text, success %, Mana, count, grade, or button label may be baked into images.
-- Generated asset existence does not imply approval. Candidate → visual review → selected candidate → export → manifest → import → runtime verification are distinct states.
+- Generated asset existence does not imply approval. Candidate → visual review → selected source → rights/provenance review → export → manifest → import → runtime verification → runtime-rendered user approval are distinct states.
 - Every runtime asset must conform to `docs/planning/ASSET_MANIFEST_SCHEMA.json`; source File ID/path + SHA, tool, owner, export SHA/format/dimensions, license status/evidence, screen consumers, approval, and runtime validation are mandatory.
+- Rights status is evidence-driven. Do not assume `PROJECT_ORIGINAL`, `USER_OWNED`, commercial rights, modification rights, or redistribution rights merely because an image was generated. Read the current applicable tool/service terms when the asset is selected and record evidence before runtime promotion.
+- A selected asset with unresolved rights remains `license.status = REVIEW_REQUIRED` and cannot become `APPROVED_RUNTIME_CANDIDATE`, `RUNTIME_VERIFIED`, or `PROJECT_ASSET_APPROVED`.
 - Source layers live in ChatGPT Library/external source storage or `.gdignore` source root; GitHub product paths receive only approved runtime exports/manifests, not uncontrolled layered masters.
-- Human visual approval is required before any generated raster candidate can become `APPROVED_RUNTIME_CANDIDATE`.
-- Physical-device validation, performance validation, accessibility/device validation, and Full Vertical Slice validation remain `NOT_RUN` unless actually executed later.
-- No Festival full-content batch, all-NPC portrait batch, Year-One full asset set, companion growth stages, guardian battlefield body, or second incident art is authorized.
+- Human visual selection is required before any generated raster candidate can enter runtime export work. A second user approval of the real Godot-rendered gallery is required before `PROJECT_ASSET_APPROVED`.
+- Physical-device validation, performance validation, accessibility/device validation, and Full Vertical Slice validation remain `NOT_RUN` unless actually executed.
+- No Festival full-content batch, all-NPC portrait batch, Year-One full asset set, companion growth stages, guardian battlefield body, or second-incident art is authorized.
 
 ---
 
 ## File Structure
 
-### Planning/brief/contract files
+### Planning, candidate, rights, and reuse records
 
-- `docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_BRIEF.md` — exact asset groups, alternatives, generation constraints, rejection criteria.
-- `docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_PLAN.json` — machine-readable planned groups and state ceilings.
-- `docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_LAYER_REUSE_REVIEW.md` — selected candidates classified as `REUSE_AS_IS / VARIANT_SEED / STRUCTURE_PATTERN / STYLE_DNA / REBUILD_FOR_REUSE / ONE_OFF_KEEP / REJECT_REUSE`.
-- `tests/test_first_session_image_batch_contract.py` — planning/runtime manifest guard.
+- `docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_BRIEF.md`
+- `docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_PLAN.json`
+- `docs/planning/visual/first_session_image_batch_01_background_candidates.json`
+- `docs/planning/visual/first_session_image_batch_01_character_candidates.json`
+- `docs/planning/visual/first_session_image_batch_01_symbol_direction_review.md`
+- `docs/planning/visual/first_session_image_batch_01_rights_review.json`
+- `docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_LAYER_REUSE_REVIEW.md`
+- `tests/test_first_session_image_batch_contract.py`
 
-### Runtime export targets after explicit visual approval
+### Runtime export targets after source selection and rights clearance
 
 - `assets/art/backgrounds/greenhouse/bg_greenhouse_field_base.webp`
 - `assets/art/backgrounds/school/bg_school_common.webp`
@@ -61,26 +67,11 @@
 - `assets/art/ui/result/icon_result_relationship.svg`
 - `assets/art/ui/result/icon_result_discovery.svg`
 
-### Runtime manifests after explicit visual approval
+### Runtime manifests
 
-- `assets/manifests/bg_greenhouse_field_base.json`
-- `assets/manifests/bg_school_common.json`
-- `assets/manifests/chr_maren_portrait_instructive.json`
-- `assets/manifests/chr_nea_field_neutral.json`
-- `assets/manifests/glyph_flow.json`
-- `assets/manifests/glyph_focus.json`
-- `assets/manifests/glyph_disperse.json`
-- `assets/manifests/icon_lens_rest.json`
-- `assets/manifests/icon_lens_prepare.json`
-- `assets/manifests/icon_lens_social.json`
-- `assets/manifests/icon_lens_practicum.json`
-- `assets/manifests/icon_result_facility.json`
-- `assets/manifests/icon_result_life.json`
-- `assets/manifests/icon_result_spirit.json`
-- `assets/manifests/icon_result_relationship.json`
-- `assets/manifests/icon_result_discovery.json`
+One JSON file under `assets/manifests/` for every runtime export above, using the export basename as the manifest basename.
 
-### Runtime gallery/verification files
+### Runtime gallery and verification
 
 - `src/ui/asset_gallery/first_session_asset_gallery.gd`
 - `src/ui/asset_gallery/first_session_asset_gallery.tscn`
@@ -99,7 +90,6 @@
 /GRIMOIRE/Production Candidates/first_session_01/symbol_concepts/glyphs/
 /GRIMOIRE/Production Candidates/first_session_01/symbol_concepts/lens/
 /GRIMOIRE/Production Candidates/first_session_01/symbol_concepts/result/
-/GRIMOIRE/Production Candidates/first_session_01/ornament_vfx/
 ```
 
 ---
@@ -113,7 +103,7 @@
 
 **Interfaces:**
 - Consumes: Art Bible, Asset Spec, approved Board A/B manifests, Component production spec, Base RM-VIS contracts.
-- Produces: exactly seven mandatory production groups plus one conditional ornament/VFX sufficiency group; no generated asset yet.
+- Produces: seven mandatory production groups plus one conditional ornament/VFX sufficiency group; no generated asset.
 
 - [ ] **Step 1: Write the RED contract first**
 
@@ -122,6 +112,7 @@ Create `tests/test_first_session_image_batch_contract.py`:
 ```python
 from pathlib import Path
 import json
+import re
 import unittest
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -163,6 +154,14 @@ class FirstSessionImageBatchContractTests(unittest.TestCase):
         for key in ("asset_id", "source", "export", "license", "status", "used_in_screens", "runtime_validation"):
             self.assertIn(key, schema["required"])
 
+    def test_no_unresolved_template_markers_enter_runtime_manifests(self):
+        manifest_root = ROOT / "assets/manifests"
+        if not manifest_root.is_dir():
+            return
+        bad = re.compile(r"(actual_|replace_me|example_sha|example_file_id)", re.I)
+        for path in manifest_root.glob("*.json"):
+            self.assertNotRegex(path.read_text(encoding="utf-8"), bad, path.name)
+
 if __name__ == "__main__":
     unittest.main()
 ```
@@ -179,13 +178,13 @@ Expected: fail because BRIEF/PLAN do not yet exist.
 
 - [ ] **Step 3: Create the machine plan**
 
-`FIRST_SESSION_IMAGE_BATCH_01_PLAN.json` uses this exact outer shape:
+Create `FIRST_SESSION_IMAGE_BATCH_01_PLAN.json` exactly as:
 
 ```json
 {
   "schema_version": 1,
   "decision_id": "GM-COMPONENT-SHEET-IMAGE-PRODUCTION-CONTRACT-01",
-  "status": "IMPLEMENTATION_PLAN_APPROVED_CANDIDATE_PRODUCTION_NOT_STARTED",
+  "status": "CANDIDATE_PRODUCTION_NOT_STARTED",
   "mass_generation_authorized": false,
   "locked_visual_sha256": "b55ce1dec6c2521668602d1ce6547526e7f40b8c7c9b6f5276d9289a67f14f7a",
   "groups": [
@@ -203,35 +202,27 @@ Expected: fail because BRIEF/PLAN do not yet exist.
 
 - [ ] **Step 4: Write exact visual briefs and rejection criteria**
 
-The Markdown brief must define these immutable requirements:
+The Markdown brief must contain:
 
 ```text
-GLOBAL:
-- no UI frame, button, number, logo, watermark, or functional text in generated raster art
-- no copy of a competitor's character/layout/trade dress
-- preserve Soft Storybook environment + clean cel characters + restrained Navy/Gold academy language
-- playable/reading region has lower detail density than focal framing
-- AI artifacts in hands, architecture, repeated motifs, edge tangencies, pseudo-text, or inconsistent costume = reject
-- USER_VISUAL_APPROVAL_REQUIRED before export/import
+NO_FUNCTIONAL_TEXT_BAKED_INTO_IMAGE
+USER_VISUAL_APPROVAL_REQUIRED
+NO_COMPETITOR_TRADE_DRESS_COPY
+LOCKED_REFERENCE_EDIT_FORBIDDEN
 ```
 
-Then define per-group briefs:
+Per-group requirements:
 
-**Greenhouse:** 2560×1440 source target, fixed 3/4 environment, damaged frostbloom greenhouse, readable irrigation/root/spirit-channel landmarks, no character/UI, three materially different camera/composition candidates while preserving the same location identity.
+- **Greenhouse:** 2560×1440 source target; fixed 3/4 storybook environment; damaged frostbloom greenhouse; readable irrigation/root/spirit-channel landmarks; no characters/UI; three alternatives vary camera elevation, foreground framing, and landmark distribution while preserving one location identity.
+- **Classroom:** 2560×1440 source target; same academy world; practical glyph-learning room; visible practice surface and supervised field-maintenance preparation cues; no tutorial text; three alternatives vary room orientation, practice-surface location, and staging space.
+- **Maren:** half-body source; same professor identity family; neutral-to-instructive expression; Navy/Gold academy clothing family; no costume variant; alternatives vary expression, small gesture, and framing only.
+- **Nea:** small wolf-like spirit; white/pale-blue; rounded face; large ears/tail; small elemental glow; no growth form; alternatives vary pose/energy emphasis only.
+- **Glyph directions:** FLOW = directional curved stream; FOCUS = compressed core/convergence; DISPERSE = expanding/diverging wave. Concept sheets are reference-only; runtime glyphs are rebuilt as SVG.
+- **Lens directions:** REST = recovery/quiet; PREPARE = tool/readiness; SOCIAL = people/context; PRACTICUM = field handling/comparison. Runtime icons are rebuilt as SVG.
+- **Result directions:** FACILITY = structure; LIFE = living growth; SPIRIT = resonance; RELATIONSHIP = linked people/records; DISCOVERY = revealed knowledge. Runtime icons are rebuilt as SVG.
+- **Ornament/VFX sufficiency:** inspect existing common ornament/phase/warning/Mana assets first. If sufficient, generate nothing. A new ornament/VFX concept requires a separate bounded revision tied to a concrete consumer.
 
-**Classroom:** 2560×1440 source target, same academy world, practical glyph-learning space, visible practice surface and supervised field-maintenance preparation cues, no baked tutorial text, three composition alternatives.
-
-**Maren:** half-body source with transparent-friendly/simple background, same professor identity family, neutral-to-instructive expression, Navy/Gold academic authority without villain coding, no costume variants; three candidates differ in expression/gesture/framing only.
-
-**Nea:** small wolf-like companion, white/pale-blue, rounded face, large ears/tail, small elemental glow, no growth form; three candidates differ only in pose/energy emphasis.
-
-**Glyph concept directions:** FLOW = directional curved stream, FOCUS = compressed core/convergence, DISPERSE = expanding/diverging wave. Three style-direction sheets; final runtime glyphs will be manually rebuilt as text-free SVG.
-
-**Lens concept directions:** REST = recovery/quiet state, PREPARE = tool/readiness, SOCIAL = people/context, PRACTICUM = field handling/comparison. Three style-direction sheets; final runtime icons rebuilt as SVG.
-
-**Result concept directions:** FACILITY = structure, LIFE = living growth, SPIRIT = spirit resonance, RELATIONSHIP = linked people/records, DISCOVERY = revealed knowledge. Three style-direction sheets; final runtime icons rebuilt as SVG.
-
-**Ornament/VFX:** inspect existing `academy_corner_ornament.svg`, phase/warning icons, and existing glyph/VFX assets first. Generate nothing if they satisfy Sheet A–D needs; if insufficient, authorize at most one ornament motif concept sheet and one transparent VFX-mask concept sheet in a later bounded revision.
+Reject pseudo-text, watermark/logo, malformed anatomy, repeated nonsensical architectural motifs, inconsistent costume/face, crowded gameplay/read zones, or style drift.
 
 - [ ] **Step 5: Run GREEN and commit**
 
@@ -247,60 +238,53 @@ git commit -m "test(art): define first-session image batch contract"
 
 **Files/Library:**
 - Read only: locked Art Style reference and approved Board A/B Library files.
-- Write candidates to the two background Library roots; do not write runtime `assets/` yet.
+- Write candidates only to the background candidate Library roots.
 - Create: `docs/planning/visual/first_session_image_batch_01_background_candidates.json`
 
 **Interfaces:**
-- Consumes: visual authority + exact background briefs.
-- Produces: six candidate source records with File IDs/generation IDs/SHA where available, all status `IN_VISUAL_REVIEW` or `SOURCE_READY`, never runtime-approved.
+- Consumes: exact references + background briefs.
+- Produces: six candidate records containing observed IDs/dimensions/SHA; no runtime export.
 
-- [ ] **Step 1: Recover and inspect the exact approved references**
+- [ ] **Step 1: Recover exact references through Files/Library**
 
-Use Files/Library search for the locked visual authority and Board A/B. Verify locked SHA/name against the brief. If the locked source cannot be recovered exactly, stop background generation rather than substituting an unknown reference.
+Search for the locked reference and Board A/B by exact names. Read native images. Verify the locked reference record names the expected SHA. If the exact locked reference cannot be recovered, stop generation and record the blocker instead of substituting another image.
 
-- [ ] **Step 2: Generate three Greenhouse alternatives with image generation**
+- [ ] **Step 2: Generate exactly three Greenhouse alternatives**
 
-Generate exactly 3 images in one bounded request when the tool supports it. Require:
+Use the image-generation surface with the approved references in context. The request must state: same GRIMOIRE visual language, soft storybook fixed 3/4 greenhouse, frostbloom damage/pressure context, readable irrigation/root/spirit-channel landmarks, quiet gameplay center, no characters, no UI, no text/signage/pseudo-text, 16:9 composition. Candidate axes are camera elevation, foreground framing, and landmark distribution—not world style.
 
-```text
-same GRIMOIRE visual language
-soft storybook fixed 3/4 greenhouse environment
-frostbloom damage/pressure context
-clear irrigation path + root layer + spirit-channel landmarks
-central playable area quieter than framing
-no characters
-no UI
-no lettering/signage/pseudo-text
-16:9 composition suitable for a 2560×1440 master/export workflow
+- [ ] **Step 3: Recover generated file IDs and persist candidates**
+
+After generation, use Files search scoped to the current conversation with `model_generated=true` and identify exactly the three new Greenhouse images. Materialize each once for SHA calculation, then upload/copy each to the Greenhouse Library folder as `greenhouse_candidate_01.png`, `greenhouse_candidate_02.png`, `greenhouse_candidate_03.png`. Record actual returned Library path/file ID, dimensions, byte size, generation identifier if surfaced, and SHA-256.
+
+- [ ] **Step 4: Generate and persist exactly three Classroom alternatives**
+
+Repeat with the Classroom brief and save as `classroom_candidate_01.png` through `03.png`.
+
+- [ ] **Step 5: Write the background candidate receipt from observed metadata**
+
+The receipt uses this schema and receives values directly from tool/read/hash results:
+
+```json
+{
+  "schema_version": 1,
+  "status": "IN_VISUAL_REVIEW",
+  "groups": {
+    "GREENHOUSE_BACKGROUND": {"selected_file_id": null, "candidates": []},
+    "CLASSROOM_BACKGROUND": {"selected_file_id": null, "candidates": []}
+  },
+  "runtime_export_created": false,
+  "runtime_validation": "NOT_RUN"
+}
 ```
 
-Alternative axes are camera elevation, foreground framing, and landmark distribution—not different world styles.
+Each candidate object contains `file_id`, `library_path`, `sha256`, `width`, `height`, and `generation_id` only when that ID is actually surfaced.
 
-- [ ] **Step 3: Persist candidates in Library and record provenance**
+- [ ] **Step 6: Present all six candidates to the user for visual selection**
 
-Store each as `greenhouse_candidate_01/02/03.png` under the Greenhouse candidate folder. Record actual File ID/library path, generation/tool identifier if surfaced, dimensions, and SHA-256 after materialization. Status remains `IN_VISUAL_REVIEW`.
+Show A/B/C for each group with one-line differences. Do not auto-select. Record the exact selected file IDs after the user chooses or requests a bounded revision.
 
-- [ ] **Step 4: Generate three Classroom alternatives**
-
-Use the same process with exact brief constraints. Candidate axes are room orientation, practice-surface location, and professor/student staging space; no actual characters are baked into the background source.
-
-- [ ] **Step 5: Create the background candidate receipt**
-
-The JSON receipt records six candidates and explicitly says:
-
-```yaml
-selected_candidate: NONE_PENDING_USER_VISUAL_REVIEW
-runtime_export: NOT_CREATED
-runtime_validation: NOT_RUN
-```
-
-- [ ] **Step 6: Present candidates to the user for visual selection**
-
-Show all three per group with concise A/B/C differences. Do not pick on the user's behalf. Ask for one selected candidate per group or a specific bounded revision request.
-
-- [ ] **Step 7: Commit provenance receipt only**
-
-Do not commit candidate PNGs to runtime paths before selection.
+- [ ] **Step 7: Commit provenance/selection receipt only**
 
 ```bash
 git add docs/planning/visual/first_session_image_batch_01_background_candidates.json
@@ -309,54 +293,58 @@ git commit -m "docs(art): record first-session background candidates"
 
 ---
 
-### Task 3: Generate Maren and Nea identity-safe candidates and select base families
+### Task 3: Generate Maren and Nea identity-safe candidates and select source families
 
 **Files/Library:**
 - Candidate roots: Maren and Nea Library folders.
 - Create: `docs/planning/visual/first_session_image_batch_01_character_candidates.json`
 
 **Interfaces:**
-- Consumes: Board A/B character continuity, Art Bible character keys, Base `RM-VIS-005 PORTRAIT_STATE_VARIANT_KIT`.
-- Produces: one selected Maren base family and one selected Nea base family after explicit user review; no runtime export before selection.
+- Consumes: Art Bible/Board continuity + Base `RM-VIS-005`.
+- Produces: one user-selected Maren source and one user-selected Nea source; no runtime export.
 
-- [ ] **Step 1: Define identity locks from approved references before generation**
+- [ ] **Step 1: Record only supported identity locks**
 
-Record the observed/approved identity constraints, not invented detail:
+Before generation, write the candidate receipt with immutable axes:
 
-```yaml
-maren:
-  role: mentor_professor
-  costume_family: navy_gold_academy
-  variation_axes: expression_gaze_small_gesture_framing_only
-  new_costume: forbidden
-nea:
-  body_family: small_wolf_spirit
-  palette: white_pale_blue
-  face: rounded
-  ears_tail: large_readable_silhouette
-  glow: small_elemental
-  growth_form: forbidden
+```json
+{
+  "maren": {
+    "role": "mentor_professor",
+    "costume_family": "navy_gold_academy",
+    "allowed_variation_axes": ["expression", "gaze", "small_gesture", "framing"],
+    "new_costume_allowed": false
+  },
+  "nea": {
+    "body_family": "small_wolf_spirit",
+    "palette_family": "white_pale_blue",
+    "rounded_face": true,
+    "large_ears_tail_silhouette": true,
+    "small_elemental_glow": true,
+    "growth_form_allowed": false
+  }
+}
 ```
 
-If an exact face/costume feature is not supported by the approved reference, leave it unspecified in the brief rather than hallucinating it.
+If a facial/costume detail is not supported by the approved reference, do not add it to the lock.
 
-- [ ] **Step 2: Generate exactly three Maren half-body candidates**
+- [ ] **Step 2: Generate exactly three Maren candidates**
 
-Request transparent background when supported. Keep clothing/palette/light family constant; vary only instructive expression, small hand gesture, and framing. Reject pseudo-text, extra accessories, costume redesign, or face drift.
+Use transparent background when supported. Hold costume/palette/light family constant and vary only instructive expression, small gesture, and framing. Reject face drift, costume redesign, extra accessories, pseudo-text, or style drift.
 
 - [ ] **Step 3: Generate exactly three Nea candidates**
 
-Request transparent background. Keep body/palette/silhouette family fixed; vary only neutral pose vs alert pose vs gentle field-attention pose. Reject growth/evolution armor, mount scale, extra tails/wings, or mascot redesign.
+Use transparent background when supported. Hold body/palette/silhouette family fixed; vary neutral, alert, and field-attention poses only. Reject armor/evolution, mount scale, extra tails/wings, or mascot redesign.
 
-- [ ] **Step 4: Persist and hash candidates; record them as `IN_VISUAL_REVIEW`**
+- [ ] **Step 4: Persist, materialize once, hash, and record candidates**
 
-Create the character candidate receipt with actual source IDs and no runtime export fields.
+Use the same Files/Library procedure as Task 2. Every candidate record gets observed file ID/path/SHA/dimensions. Status remains `IN_VISUAL_REVIEW`.
 
-- [ ] **Step 5: User selects one Maren and one Nea family**
+- [ ] **Step 5: User selects one Maren and one Nea source family**
 
-Selection promotes only the source family to `SOURCE_READY`. It does not yet mean Runtime Verified/Project Asset Approved.
+Record selected file IDs. Selection promotes the source family only to `SOURCE_READY`; it does not imply runtime import or rights clearance.
 
-- [ ] **Step 6: Commit the character candidate/selection receipt**
+- [ ] **Step 6: Commit character receipt**
 
 ```bash
 git add docs/planning/visual/first_session_image_batch_01_character_candidates.json
@@ -365,29 +353,29 @@ git commit -m "docs(art): record first-session character candidates"
 
 ---
 
-### Task 4: Generate symbol directions, choose one, then rebuild final glyph/Lens/Result icons as SVG
+### Task 4: Explore symbol directions, select directions, then author final SVG symbols
 
 **Files:**
-- Candidate concept sheets live in Library only.
-- Create final SVGs at the 12 runtime paths listed above.
+- Candidate concept sheets: Library only.
+- Create final 12 SVGs at the runtime paths listed in File Structure.
 - Create: `docs/planning/visual/first_session_image_batch_01_symbol_direction_review.md`
 - Modify: `tests/test_first_session_image_batch_contract.py`
 
 **Interfaces:**
-- Consumes: Base `RM-VIS-002`, selected GRIMOIRE visual language, existing text-free SVG conventions.
-- Produces: 3 glyph SVGs + 4 Lens SVGs + 5 Result SVGs; simple path geometry, no text/raster/filter/font.
+- Consumes: Base `RM-VIS-002`, selected GRIMOIRE visual language, existing simple SVG conventions.
+- Produces: 3 glyph + 4 Lens + 5 Result SVGs; text-free, raster-free, filter-free.
 
 - [ ] **Step 1: Generate three concept-direction sheets for each symbol family**
 
-Use image generation for visual exploration only. Each sheet must show all semantic members of its family and no readable text. Concept sheets are `REFERENCE_ONLY` and never runtime imports.
+Use image generation for visual exploration only. Each sheet contains all members of its family without readable text. Persist concept sheets as `REFERENCE_ONLY`; never import them directly into runtime.
 
-- [ ] **Step 2: Present the three directions and obtain one user-selected direction per family**
+- [ ] **Step 2: Obtain one user-selected direction per family**
 
-Decision axes: 16/24/32/48px legibility, GRIMOIRE identity, shape distinctness, AI-look reduction, and no semantic collision with existing Mana/Warning/Phase icons.
+Review at semantic criteria: 16/24/32/48 px legibility, GRIMOIRE identity, shape distinctness, AI-look reduction, and no collision with existing Mana/Warning/Phase symbols.
 
-- [ ] **Step 3: Write SVG RED assertions before rebuilding**
+- [ ] **Step 3: Write SVG RED assertions**
 
-Extend Python contract:
+Extend the Python contract:
 
 ```python
 SVG_PATHS = [
@@ -405,7 +393,9 @@ SVG_PATHS = [
     "assets/art/ui/result/icon_result_discovery.svg",
 ]
 for relative in SVG_PATHS:
-    text = (ROOT / relative).read_text(encoding="utf-8").lower()
+    path = ROOT / relative
+    self.assertTrue(path.is_file(), relative)
+    text = path.read_text(encoding="utf-8").lower()
     self.assertIn("<svg", text)
     self.assertRegex(text, r"<(path|circle|polygon|line|rect)\b")
     for forbidden in ("<text", "<image", "<filter", "data:image", "font-family"):
@@ -414,35 +404,33 @@ for relative in SVG_PATHS:
 
 Run RED; expected: missing SVGs.
 
-- [ ] **Step 4: Rebuild glyphs as simple project-authored SVG**
+- [ ] **Step 4: Author the three glyph SVGs from semantic geometry**
 
-Semantic geometry, independent of concept-sheet pixels:
-
-```text
-FLOW      = one continuous curved stream path + one secondary parallel accent; directional continuity, no arrow label
-FOCUS     = outer ring/diamond converging to a small central core
-DISPERSE  = central origin with three expanding/diverging arcs
-```
-
-Use existing Navy/Gold/Cyan token-compatible flat fills/strokes and no filters.
-
-- [ ] **Step 5: Rebuild Lens SVGs**
+Use simple project-authored paths, not trace copies of concept-sheet pixels:
 
 ```text
-REST      = quiet crescent/settled pulse motif
-PREPARE   = compact tool/readiness diamond + handle motif
-SOCIAL    = two linked nodes with dialogue/context bridge shape, no text bubble lettering
-PRACTICUM = field marker + handling/compare split motif
+FLOW      = continuous curved stream + secondary parallel accent
+FOCUS     = converging outer geometry + small central core
+DISPERSE  = central origin + three expanding/diverging arcs
 ```
 
-- [ ] **Step 6: Rebuild Result SVGs**
+- [ ] **Step 5: Author Lens SVGs**
+
+```text
+REST      = quiet crescent/settled pulse
+PREPARE   = compact tool/readiness diamond + handle
+SOCIAL    = two linked nodes + context bridge
+PRACTICUM = field marker + handling/compare split
+```
+
+- [ ] **Step 6: Author Result SVGs**
 
 ```text
 FACILITY      = structural arch/beam
-LIFE          = sprout/leaf growth
+LIFE          = sprout/leaf
 SPIRIT        = resonance spiral/core
 RELATIONSHIP  = two linked rings/nodes
-DISCOVERY     = opened-page/eye-reveal hybrid silhouette without letters
+DISCOVERY     = open-page/reveal silhouette without letters
 ```
 
 - [ ] **Step 7: Run SVG contract and commit**
@@ -459,51 +447,32 @@ git commit -m "feat(art): add first-session semantic symbols"
 
 **Files:**
 - Create: `docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_LAYER_REUSE_REVIEW.md`
-- Read: existing `assets/art/ui/common/*.svg` and approved raster candidates.
 
 **Interfaces:**
-- Consumes: selected source candidates and Base `RM-VIS-003/004/005` classification rules.
-- Produces: explicit layer provenance and reuse classification; either `NO_NEW_ORNAMENT_VFX_REQUIRED` or a narrowly justified follow-up.
+- Consumes: selected source candidates + Base `RM-VIS-003/004/005`.
+- Produces: truthful layer provenance/reuse classification and one ornament/VFX sufficiency verdict.
 
-- [ ] **Step 1: Classify both selected backgrounds**
+- [ ] **Step 1: Classify selected backgrounds**
 
-For each, record:
+For each selected background, record `base_environment`, `midground`, `foreground_props`, `lighting`, `story_state_overlay`, `atmosphere_fx`. Each part gets one provenance: `SOURCE_LAYER`, `MASK_CUTOUT`, `MANUAL_OR_SEMANTIC_REBUILD`, or `DERIVED_GENERATIVE_RECOVERY`. Generated recovery of an occluded region is never labeled `SOURCE_LAYER`.
 
-```text
-base_environment
-midground
-foreground_props
-lighting
-story_state_overlay
-atmosphere_fx
-```
+- [ ] **Step 2: Classify selected Maren/Nea families**
 
-Each part receives provenance `SOURCE_LAYER`, `MASK_CUTOUT`, `MANUAL_OR_SEMANTIC_REBUILD`, or `DERIVED_GENERATIVE_RECOVERY`. Never label generated reconstruction of an occluded area as observed source.
+Maren is `VARIANT_SEED` for expression-only variants. Nea is `VARIANT_SEED` for bounded pose/reaction variants. Record growth form and costume-family expansion as outside this batch.
 
-- [ ] **Step 2: Classify Maren/Nea**
+- [ ] **Step 3: Inspect existing ornament/icon assets**
 
-Maren selected source is `VARIANT_SEED` for future expression-only variants. Nea selected source is `VARIANT_SEED` for bounded pose/reaction variants; growth-form generation remains forbidden.
+Check `assets/art/ui/common/academy_corner_ornament.svg`, phase/warning/Mana icons, and existing StarCircuitBoard visuals against Component Sheets A–D. If sufficient, record `NO_NEW_ORNAMENT_VFX_REQUIRED`. If one concrete semantic gap remains, stop and create a separate bounded design before generation; do not add speculative art here.
 
-- [ ] **Step 3: Inspect existing common ornament/icon assets against Component Sheets A–D**
+- [ ] **Step 4: Run five adversarial reuse passes**
 
-If `academy_corner_ornament.svg`, phase diamond, warning diamond, Mana, and current star/glyph visual primitives cover the required decorative states, record:
+1. Primary-quality attack — decomposition must not degrade the selected primary image.
+2. Fake-layer attack — generated reconstruction provenance is truthful.
+3. Identity-drift attack — variant seed boundaries protect face/costume/world identity.
+4. Over-reuse attack — one-off focal parts are not forced into generic modules.
+5. Scope-creep attack — optional ornament/VFX has not become an unowned batch.
 
-```yaml
-ornament_vfx_decision: NO_NEW_ORNAMENT_VFX_REQUIRED
-reason: EXISTING_ASSETS_SUFFICIENT
-```
-
-If and only if a concrete missing semantic exists, create a separate bounded follow-up decision instead of generating speculative ornament/VFX in this task.
-
-- [ ] **Step 4: Run 5-pass visual reuse adversarial review**
-
-1. **Primary-quality attack:** did decomposition pressure make the selected image worse as a primary scene?
-2. **Fake-layer attack:** are generated reconstructions truthfully labeled?
-3. **Identity-drift attack:** would a variant seed allow face/costume/world drift?
-4. **Over-reuse attack:** are one-off focal parts being forced into generic modules?
-5. **Scope-creep attack:** did optional ornament/VFX become a new art batch without a consumer?
-
-- [ ] **Step 5: Commit the layer/reuse review**
+- [ ] **Step 5: Commit reuse review**
 
 ```bash
 git add docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_LAYER_REUSE_REVIEW.md
@@ -512,119 +481,160 @@ git commit -m "docs(art): classify first-session asset reuse"
 
 ---
 
-### Task 6: Export selected raster sources, compute SHA, and create schema-valid runtime manifests
+### Task 6: Rights review, deterministic exports, and schema-valid manifests
 
 **Files:**
-- Create selected runtime backgrounds/portraits at the four raster export paths.
-- Create 16 per-asset manifests listed above.
+- Create: `docs/planning/visual/first_session_image_batch_01_rights_review.json`
+- Create: selected raster runtime exports.
+- Create: one manifest per runtime export/symbol under `assets/manifests/`.
 - Modify: `tests/test_first_session_image_batch_contract.py`
-- Modify: `docs/ASSET_LICENSE_LEDGER.md` only with actual generated/exported records; preserve NOT_RUN ceilings.
+- Modify: `docs/ASSET_LICENSE_LEDGER.md` with observed records only.
 
 **Interfaces:**
-- Consumes: explicit user-selected candidate File IDs and the 12 project-authored SVGs.
-- Produces: runtime candidates with deterministic formats/hashes and `APPROVED_RUNTIME_CANDIDATE` status at most; not `PROJECT_ASSET_APPROVED` until runtime verification and final approval.
+- Consumes: exact selected Library file IDs, computed SHA-256 values, current tool/service rights evidence, selected SVGs.
+- Produces: runtime candidates only when rights status is resolved; otherwise a documented block.
 
-- [ ] **Step 1: Materialize the selected source files and verify source hashes**
+- [ ] **Step 1: Perform current rights review before export promotion**
 
-Use the exact selected Library file IDs. Compute:
+Read the current applicable generation/service terms and any project policy relevant to ownership, commercial use, modification, redistribution, and required credit. Record one entry per selected raster source:
+
+```json
+{
+  "source_file_id": "file_00000000000000000000000000000000",
+  "status": "REVIEW_REQUIRED",
+  "evidence": [],
+  "commercial_use": "UNRESOLVED",
+  "modification": "UNRESOLVED",
+  "redistribution": "UNRESOLVED",
+  "credit_required": "UNRESOLVED"
+}
+```
+
+The literal example file ID above is schema illustration in the planning document only; execution writes the rights-review file from the exact selected file ID returned by Files. It must not be copied into a project record. After checking current evidence, change `status` only to a schema-supported resolved status whose claims are directly supported. If unresolved, stop runtime promotion for that asset.
+
+- [ ] **Step 2: Materialize selected sources by exact file ID and verify source SHA**
+
+For each selected source, materialize it once, compute SHA-256, and compare it to the selected-candidate receipt. Mismatch is a hard block.
+
+- [ ] **Step 3: Export raster assets without creative alteration**
+
+Use deterministic conversion only:
+
+```text
+bg_greenhouse_field_base.webp  2560×1440 WebP lossless alpha=false
+bg_school_common.webp           2560×1440 WebP lossless alpha=false
+chr_maren_portrait_instructive.png 1024×1536 PNG RGBA
+chr_nea_field_neutral.png       256×256 PNG RGBA
+```
+
+If a source requires creative anatomy/background repair rather than deterministic crop/mask cleanup, return to image editing/generation and user review; do not hide creative repair inside export code.
+
+- [ ] **Step 4: Add manifest-validation helpers to the Python contract before writing manifests**
+
+Add:
+
+```python
+import hashlib
+
+SHA_RE = re.compile(r"^[a-f0-9]{64}$")
+ALLOWED_RESOLVED_LICENSE = {"PROJECT_ORIGINAL", "USER_OWNED", "COMMERCIAL_USE_APPROVED"}
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+def assert_runtime_manifest(testcase: unittest.TestCase, manifest: dict, manifest_path: Path):
+    testcase.assertRegex(manifest["source"]["sha256"], SHA_RE, manifest_path.name)
+    testcase.assertRegex(manifest["export"]["sha256"], SHA_RE, manifest_path.name)
+    testcase.assertIn(manifest["license"]["status"], ALLOWED_RESOLVED_LICENSE, manifest_path.name)
+    testcase.assertNotEqual("REVIEW_REQUIRED", manifest["license"]["status"])
+    testcase.assertEqual(sha256_file(ROOT / manifest["export"]["file_path"]), manifest["export"]["sha256"])
+    testcase.assertEqual("NOT_RUN", manifest["runtime_validation"])
+```
+
+Run RED; expected: manifests do not yet exist.
+
+- [ ] **Step 5: Generate manifests from observed records, never from template strings**
+
+Create a local script during execution (or a one-shot Python command) that loads the selected candidate receipt and rights-review record, reads the exported file, computes both hashes, and builds the manifest dictionary. The builder contract is:
+
+```python
+def build_manifest(*, asset_id, role, decision_ids, source_record, rights_record,
+                   export_path, export_format, width, height, alpha,
+                   import_profile, used_in_screens):
+    source_file_id = source_record["file_id"]
+    source_sha = source_record["sha256"]
+    license_status = rights_record["status"]
+    evidence = rights_record["evidence"]
+    assert source_file_id
+    assert SHA_RE.fullmatch(source_sha)
+    assert license_status in ALLOWED_RESOLVED_LICENSE
+    assert evidence
+    export_sha = sha256_file(ROOT / export_path)
+    return {
+        "schema_version": 1,
+        "asset_id": asset_id,
+        "role": role,
+        "decision_ids": decision_ids,
+        "source": {
+            "storage": "EXTERNAL_LIBRARY",
+            "file_id_or_path": source_file_id,
+            "sha256": source_sha,
+            "tool": source_record["tool"],
+            "owner": source_record["owner"],
+            "prompt_or_brief_path": "docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_BRIEF.md",
+            "parent_asset_ids": source_record.get("parent_asset_ids", []),
+        },
+        "export": {
+            "file_path": str(export_path),
+            "sha256": export_sha,
+            "format": export_format,
+            "width": width,
+            "height": height,
+            "alpha": alpha,
+            "import_profile": import_profile,
+        },
+        "license": {
+            "status": license_status,
+            "evidence": " | ".join(evidence),
+            "credit_required": rights_record["credit_required"],
+            "modification_allowed": rights_record["modification_allowed"],
+            "redistribution_allowed": rights_record["redistribution_allowed"],
+        },
+        "status": "APPROVED_RUNTIME_CANDIDATE",
+        "approved_by": "USER_VISUAL_SELECTION",
+        "approved_at": "2026-08-20",
+        "used_in_screens": used_in_screens,
+        "runtime_validation": "NOT_RUN",
+    }
+```
+
+For project-authored SVGs, source storage/path/tool/owner come from the authored SVG and the symbol-direction review, with the same evidence-driven rights requirement; do not fabricate Library IDs for SVGs.
+
+- [ ] **Step 6: Validate every manifest and perform a marker scan**
+
+Run the Python contract and additionally:
 
 ```bash
 python - <<'PY'
 from pathlib import Path
-import hashlib
-for p in Path('/mnt/data').rglob('*'):
-    if p.is_file():
-        print(p, hashlib.sha256(p.read_bytes()).hexdigest())
+import re
+bad = re.compile(r'(actual_|replace_me|example_sha|example_file_id)', re.I)
+for path in Path('assets/manifests').glob('*.json'):
+    text = path.read_text(encoding='utf-8')
+    if bad.search(text):
+        raise SystemExit(f'unresolved marker in {path}')
+print('manifest marker scan: PASS')
 PY
 ```
 
-Match the recorded candidate SHA. Any mismatch blocks export.
+- [ ] **Step 7: Update Asset License Ledger with observed values only**
 
-- [ ] **Step 2: Export opaque backgrounds losslessly**
+Increase counts only for records actually created. Runtime verified/project-approved counts remain unchanged at this point.
 
-Use deterministic image conversion only—no creative retouch at export. Resize/crop only if the approved candidate is not already 2560×1440, preserving 16:9 composition. Export:
-
-```text
-bg_greenhouse_field_base.webp  2560×1440  WebP Lossless  alpha=false
-bg_school_common.webp           2560×1440  WebP Lossless  alpha=false
-```
-
-- [ ] **Step 3: Export Maren portrait**
-
-Create `chr_maren_portrait_instructive.png` at 1024×1536 RGBA. Crop contract is waist/mid-thigh with headroom; do not redraw or costume-change during export. If transparent background generation was imperfect, use deterministic mask cleanup only when the selected source supports it; otherwise send the source back for bounded image edit rather than painting new anatomy with a generic script.
-
-- [ ] **Step 4: Export Nea field source**
-
-Create `chr_nea_field_neutral.png` at 256×256 RGBA from the selected higher-resolution source, preserving silhouette and glow readability.
-
-- [ ] **Step 5: Extend Python manifest tests before creating manifests**
-
-For every `assets/manifests/*.json` created by this plan, load `ASSET_MANIFEST_SCHEMA.json` required fields manually or with available schema validation. Require:
-
-```text
-source.storage in {EXTERNAL_LIBRARY, GENERATED_CANDIDATE}
-license.status in {PROJECT_ORIGINAL, USER_OWNED}
-status in {APPROVED_RUNTIME_CANDIDATE, IMPORTED, RUNTIME_VERIFIED, PROJECT_ASSET_APPROVED}
-runtime_validation initially NOT_RUN
-source.sha256 and export.sha256 are real 64-char lowercase hashes
-```
-
-Run RED; expected: manifests missing.
-
-- [ ] **Step 6: Create each manifest with real values only**
-
-Example shape for the selected Greenhouse export:
-
-```json
-{
-  "schema_version": 1,
-  "asset_id": "bg_greenhouse_field_base",
-  "role": "FROSTBLOOM_FIELD_BACKGROUND",
-  "decision_ids": ["ART-BIBLE-01", "ASSET-SPEC-01", "GM-COMPONENT-SHEET-IMAGE-PRODUCTION-CONTRACT-01"],
-  "source": {
-    "storage": "EXTERNAL_LIBRARY",
-    "file_id_or_path": "ACTUAL_SELECTED_LIBRARY_FILE_ID",
-    "sha256": "ACTUAL_SOURCE_SHA256",
-    "tool": "ChatGPT image generation",
-    "owner": "GRIMOIRE project",
-    "prompt_or_brief_path": "docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_BRIEF.md",
-    "parent_asset_ids": ["REF-ART-STYLE-LOCKED-01", "GR-VISUAL-CHECKPOINT-BOARD-A-01"]
-  },
-  "export": {
-    "file_path": "assets/art/backgrounds/greenhouse/bg_greenhouse_field_base.webp",
-    "sha256": "ACTUAL_EXPORT_SHA256",
-    "format": "WEBP",
-    "width": 2560,
-    "height": 1440,
-    "alpha": false,
-    "import_profile": "BACKGROUND_LOSSLESS_LINEAR_MIPMAP_TRIAL"
-  },
-  "license": {
-    "status": "PROJECT_ORIGINAL",
-    "evidence": "Generated for this project with the user-authorized ChatGPT image-generation workflow; no external asset pack imported.",
-    "credit_required": false,
-    "modification_allowed": true,
-    "redistribution_allowed": true
-  },
-  "status": "APPROVED_RUNTIME_CANDIDATE",
-  "approved_by": "USER_VISUAL_SELECTION",
-  "approved_at": "2026-08-20",
-  "used_in_screens": ["FROSTBLOOM_FIELD", "RESULT_RETURN"],
-  "runtime_validation": "NOT_RUN"
-}
-```
-
-At execution, replace `ACTUAL_*` values with observed values; never commit placeholder strings. The task is not complete until a placeholder scan returns zero hits.
-
-- [ ] **Step 7: Update the Asset License Ledger truthfully**
-
-Record only the assets actually exported. `runtime_asset_records` may increase, but `runtime_verified` and `project_asset_approved` stay at their true values until Task 7.
-
-- [ ] **Step 8: Run manifest tests and commit runtime candidates**
+- [ ] **Step 8: Commit runtime candidates**
 
 ```bash
-python -m unittest tests.test_first_session_image_batch_contract -v
-git add assets/art/backgrounds assets/art/characters assets/art/ui/glyphs assets/art/ui/lens assets/art/ui/result assets/manifests docs/ASSET_LICENSE_LEDGER.md tests/test_first_session_image_batch_contract.py
+git add docs/planning/visual/first_session_image_batch_01_rights_review.json assets/art/backgrounds assets/art/characters assets/art/ui/glyphs assets/art/ui/lens assets/art/ui/result assets/manifests docs/ASSET_LICENSE_LEDGER.md tests/test_first_session_image_batch_contract.py
 git commit -m "feat(art): export first-session runtime asset candidates"
 ```
 
@@ -637,138 +647,120 @@ git commit -m "feat(art): export first-session runtime asset candidates"
 - Create: `src/ui/asset_gallery/first_session_asset_gallery.tscn`
 - Create: `tools/capture_first_session_asset_gallery.gd`
 - Create: `.github/workflows/validate-first-session-image-assets.yml`
-- Modify per-asset manifests from `runtime_validation: NOT_RUN` to `PASS` / status `RUNTIME_VERIFIED` only after actual import/render checks succeed.
+- Modify: manifests only after actual import/render checks succeed.
 
 **Interfaces:**
-- Consumes: approved runtime candidate exports.
-- Produces: one deterministic 1920×1080 gallery PNG and import/render evidence; this is asset/runtime evidence, not Human/Device/Full Slice evidence.
+- Consumes: approved runtime candidates.
+- Produces: real Texture2D load evidence + one 1920×1080 GL-compatible gallery PNG; not Human/Device/Full Slice evidence.
 
-- [ ] **Step 1: Add RED tests for Godot importability**
+- [ ] **Step 1: Add RED checks for gallery files and importability**
 
-Extend Python contract to require gallery/capture/workflow files. Add a Godot integration suite or script checks that `load()` returns real Texture2D for WebP/PNG/SVG runtime exports after import.
+Extend Python contract to require gallery/capture/workflow files. Add `tests/integration/test_first_session_asset_gallery.gd` and register it in `tests/test_runner.gd`. The suite loads every runtime export path from its manifest and asserts returned resources are non-null Texture2D objects.
 
-- [ ] **Step 2: Create the asset gallery scene**
+- [ ] **Step 2: Create the inspection gallery scene**
 
 Use `GrimoireThemeFactory.create_theme()` and live Labels. Layout:
 
 ```text
-left top: greenhouse background crop/fit preview
-right top: classroom background crop/fit preview
-lower left: Maren portrait on neutral checker/navy plate
+left top: greenhouse background fit preview
+right top: classroom background fit preview
+lower left: Maren portrait on neutral Navy plate
 lower center: Nea source on neutral plate
 lower right: glyph 3 + Lens 4 + Result 5 icon grid
 ```
 
-No functional game UI claim; this is an inspection gallery.
+No functional game UI is baked into art or implied by this gallery.
 
-- [ ] **Step 3: Create deterministic capture script**
+- [ ] **Step 3: Create deterministic 1920×1080 capture**
 
-Reuse the existing SubViewport capture pattern; capture exactly 1920×1080 to `build/visual/first-session-asset-gallery.png`. Fail if texture is missing, dimensions mismatch, or PNG is under 20 KB.
+Reuse the existing SubViewport pattern: fresh scene, `Vector2i(1920, 1080)`, five process frames, `RenderingServer.force_draw`, save to `build/visual/first-session-asset-gallery.png`, fail on dimension mismatch or file size under 20 KB.
 
 - [ ] **Step 4: Create dedicated CI**
 
-Workflow steps:
+Workflow sequence:
 
 ```text
 Python manifest/asset contract
 → Godot 4.7.1 setup
 → --headless --import
-→ asset load verification
+→ full custom test runner
 → xvfb GL-compatibility gallery capture
-→ upload gallery PNG + import/capture logs
+→ assert gallery PNG non-empty
+→ upload gallery PNG + import/test/capture logs
 ```
 
-- [ ] **Step 5: Run exact import/render checks**
+- [ ] **Step 5: Promote import-successful manifests only to `RUNTIME_VERIFIED`**
 
-Only after success, set per-asset `runtime_validation` to `PASS` and `status` to `RUNTIME_VERIFIED`. Do not set `PROJECT_ASSET_APPROVED` yet unless the user separately approves the runtime-rendered evidence.
+After exact checks succeed, set `runtime_validation = PASS` and `status = RUNTIME_VERIFIED`. Do not set `PROJECT_ASSET_APPROVED` in this task.
 
-- [ ] **Step 6: Commit gallery/evidence**
+- [ ] **Step 6: Commit runtime evidence**
 
 ```bash
-git add src/ui/asset_gallery tools/capture_first_session_asset_gallery.gd .github/workflows/validate-first-session-image-assets.yml assets/manifests
+git add src/ui/asset_gallery tests/integration/test_first_session_asset_gallery.gd tests/test_runner.gd tools/capture_first_session_asset_gallery.gd .github/workflows/validate-first-session-image-assets.yml assets/manifests
 git commit -m "test(art): verify first-session runtime assets"
 ```
 
 ---
 
-### Task 8: Final user runtime-visual approval, five-pass adversarial closure, merge, and Notion/Asset Library sync
+### Task 8: Runtime-rendered user approval, five-pass closure, merge, and Notion sync
 
 **Files/Systems:**
 - Create: `docs/planning/FIRST_SESSION_IMAGE_BATCH_01_ADVERSARIAL_REVIEW_2026-08-20.md`
 - Create: `docs/planning/sync/GR-SYNC-20260820-34-FIRST-SESSION-IMAGE-ASSETS.md`
-- Update: selected manifests to `PROJECT_ASSET_APPROVED` only after explicit runtime-rendered visual approval.
-- Update: Notion `ASSET LIBRARY · Master` records and TASK-13.
+- Modify: manifests to `PROJECT_ASSET_APPROVED` only after explicit approval of the real Godot-rendered gallery.
+- Update: Notion Asset Library records and TASK-13.
 
 **Interfaces:**
-- Produces: truthfully approved first-session asset set, merged SHA, source/runtime traceability, remaining validation ceilings.
+- Produces: truthfully approved first-session runtime asset set + merged SHA + source/runtime traceability.
 
-- [ ] **Step 1: Present the real Godot-rendered gallery to the user**
+- [ ] **Step 1: Present the actual Godot-rendered gallery to the user**
 
-Approval question is about project use of the actual imported exports—not just the original generation candidates. If the user requests revision, return to the owning asset task; do not patch around a bad source by silently editing unrelated assets.
+Ask approval of the imported/exported assets. If an asset needs revision, return to its owning generation/source task; do not silently patch other assets to compensate.
 
-- [ ] **Step 2: Promote only explicitly approved rendered assets**
+- [ ] **Step 2: Promote only explicitly approved assets**
 
-For each approved manifest:
-
-```text
-status: PROJECT_ASSET_APPROVED
-runtime_validation: PASS
-approved_by: USER_RUNTIME_VISUAL_APPROVAL
-```
-
-If one asset is rejected, keep it `REVISION_REQUIRED` or `REJECTED` independently; do not block unrelated approved assets unless shared style identity is compromised.
-
-- [ ] **Step 3: Adversarial pass 1 — AI artifact/consistency attack**
-
-Review anatomy, pseudo-text, repeated architectural patterns, lighting continuity, perspective, Maren face/costume continuity, Nea silhouette/palette, and cross-scene style cohesion.
-
-- [ ] **Step 4: Pass 2 — gameplay readability attack**
-
-Verify backgrounds leave usable low-detail play/read zones; icons distinguish semantics at 16/24/32/48; glyph Flow/Focus/Disperse remain distinct without relying on hue.
-
-- [ ] **Step 5: Pass 3 — rights/provenance attack**
-
-Every approved asset must trace source File ID/path + SHA + generation brief/tool + export SHA + license evidence. Any missing link blocks `PROJECT_ASSET_APPROVED`.
-
-- [ ] **Step 6: Pass 4 — scope/reuse attack**
-
-Ensure no Festival batch, extra NPC portraits, growth forms, background #3, or speculative VFX was added. Verify layer-reuse labels are truthful and do not convert one-off focal art into forced generic modules.
-
-- [ ] **Step 7: Pass 5 — evidence overclaim attack**
-
-Runtime import/render PASS is not Human playtest, device, performance, accessibility, emotional, or Full Slice PASS. Keep those labels `NOT_RUN`.
-
-- [ ] **Step 8: Open PR and run exact-head workflows**
-
-Require the dedicated image asset workflow and all applicable existing Planning/Visual/Toolchain/Star workflows. Inspect changed files and review threads. Do not touch unrelated active PRs.
-
-- [ ] **Step 9: Squash merge after exact-head success**
-
-Use expected head SHA and re-read `main` after merge.
-
-- [ ] **Step 10: Sync Notion Asset Library**
-
-Create/update one record per approved runtime asset with:
+For each approved manifest set:
 
 ```text
-Name
-Asset ID
-Category
-Record Type = ASSET
-Status = APPROVED
-Approved = checked
-Reuse = MASTER or YES/COMPONENT as appropriate
-Source
-Hash
-Rights / License
-Implementation Path
-Prompt/brief reference
-Project = GRIMOIRE
-Last Synced
+status = PROJECT_ASSET_APPROVED
+runtime_validation = PASS
+approved_by = USER_RUNTIME_VISUAL_APPROVAL
 ```
 
-Generated concept sheets that are not runtime assets remain `REFERENCE`/`WIP` or are omitted from the primary asset library depending on reuse value.
+Rejected assets remain `REVISION_REQUIRED` or `REJECTED` independently.
 
-- [ ] **Step 11: Update TASK-13 and Project Home**
+- [ ] **Step 3: Adversarial pass 1 — AI artifact/consistency**
 
-Record Component Sheets merged SHA (from Plan 1), image asset merged SHA, selected asset IDs, and remaining NOT_RUN boundaries. TASK-13 may be marked `완료` only when both Component Sheet implementation and this approved image batch are complete; Human/Device/Performance/Full Slice continue as separate later work.
+Review anatomy, pseudo-text, repeated nonsensical architecture, lighting/perspective, Maren identity, Nea silhouette/palette, and cross-scene style cohesion.
+
+- [ ] **Step 4: Pass 2 — gameplay readability**
+
+Verify backgrounds preserve quieter play/read zones; icons distinguish semantics at 16/24/32/48; FLOW/FOCUS/DISPERSE remain distinct without hue.
+
+- [ ] **Step 5: Pass 3 — rights/provenance**
+
+Every approved asset must trace source ID/path + SHA + brief/tool + rights evidence + export SHA. Any missing link blocks final approval.
+
+- [ ] **Step 6: Pass 4 — scope/reuse**
+
+Verify no Festival batch, extra NPC portraits, growth forms, speculative extra backgrounds, or unconsumed VFX. Verify layer provenance remains truthful.
+
+- [ ] **Step 7: Pass 5 — evidence overclaim**
+
+Runtime import/render PASS is not Human playtest, physical-device, performance, accessibility, emotion/fun, or Full Slice PASS. Keep those labels `NOT_RUN`.
+
+- [ ] **Step 8: Open PR and require exact-head checks**
+
+Require the dedicated image asset workflow plus all applicable Planning/Visual/Toolchain/Star workflows. Inspect changed files and review threads. Do not touch unrelated active PRs.
+
+- [ ] **Step 9: Squash merge with expected head SHA after clean readback**
+
+Re-read GRIMOIRE `main` after merge and record the merge SHA in Sync34.
+
+- [ ] **Step 10: Sync Notion `ASSET LIBRARY · Master`**
+
+Create/update one record per approved runtime asset with Name, Asset ID, Category, Record Type `ASSET`, Status `APPROVED`, Approved checked, Reuse classification, Source, Hash, Rights/License, Implementation Path, Prompt/brief reference, Project relation, and Last Synced. Concept direction sheets remain reference records or are omitted when they have no reusable value.
+
+- [ ] **Step 11: Close TASK-13 only when both plans are complete**
+
+Record Component Sheet merged SHA, image asset merged SHA, selected asset IDs, and remaining `NOT_RUN` boundaries. Mark TASK-13 `완료` only when Component Sheets A–D and this image batch are both merged/synced; Human/Device/Performance/Full Slice remain separate follow-up validation work.

--- a/docs/superpowers/plans/2026-08-20-first-session-image-asset-production.md
+++ b/docs/superpowers/plans/2026-08-20-first-session-image-asset-production.md
@@ -2,43 +2,42 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Produce, review, decompose, register, and import the approved first-session image asset batch while keeping all functional UI live, preserving GRIMOIRE’s locked visual authority, and preventing generated candidates from becoming runtime assets without provenance, rights evidence, and user approval.
+**Goal:** Produce, review, decompose, register, and import the approved first-session image asset batch while keeping functional UI live, preserving GRIMOIRE’s locked visual authority, and preventing generated candidates from becoming runtime assets without provenance, rights evidence, and user approval.
 
-**Architecture:** Treat image generation as candidate-source production, never as direct runtime export. Recover approved references and briefs, generate bounded alternatives, persist each candidate with exact IDs/hashes, obtain explicit visual selection, classify reusable layers/variants using Base RM-VIS modules, then create deterministic runtime exports/manifests and a Godot asset-gallery evidence scene only for selected candidates whose rights evidence is sufficient.
+**Architecture:** Image generation produces candidate sources, never direct runtime exports. The workflow recovers exact approved references, generates bounded alternatives, persists every candidate with observed IDs/hashes, obtains explicit user selection, performs rights/provenance review, classifies reuse/layers, exports selected sources deterministically, creates schema-valid manifests from observed records, then verifies the real imports in Godot before final project-asset approval.
 
-**Tech Stack:** ChatGPT image generation surface, ChatGPT Files/Library, Python 3.12 for SHA/conversion/manifest validation, Pillow only for deterministic format/crop/export operations, text-free SVG for glyph/Lens/Result symbols, Godot 4.7.1 import/render verification, Python `unittest`, existing `ASSET_MANIFEST_SCHEMA.json`, Notion `ASSET LIBRARY · Master`.
+**Tech Stack:** ChatGPT image generation, ChatGPT Files/Library, Python 3.12, Pillow for deterministic format/crop/export operations only, project-authored text-free SVG, Godot 4.7.1, Python `unittest`, `ASSET_MANIFEST_SCHEMA.json`, Notion `ASSET LIBRARY · Master`.
 
 **Spec:** `docs/superpowers/specs/2026-08-20-component-sheet-image-production-contract-design.md`
 
 ## Global Constraints
 
-- Current project authority at plan creation: GRIMOIRE `main` `4c2f23c4bb8b7487559b113a5d41deab815fb62d`.
-- Current Base observation: `e222e93e79e95364dca668eaaf0f156676123342`; use `RM-VIS-002 GAMEPLAY_SYMBOL_ATLAS`, `RM-VIS-003 MODULAR_BACKGROUND_LAYER_KIT`, `RM-VIS-004 COMBAT_TELEGRAPH_VFX_KIT`, and `RM-VIS-005 PORTRAIT_STATE_VARIANT_KIT` as structural/reuse contracts only.
-- Locked visual authority remains `/GRIMOIRE/Visual Authority/GRIMOIRE_ART_STYLE_01_LOCKED_REFERENCE.png`, SHA-256 `b55ce1dec6c2521668602d1ce6547526e7f40b8c7c9b6f5276d9289a67f14f7a`; do not edit, regenerate, crop-replace, recolor, or overwrite it.
-- Approved Board A/B remain composition/checkpoint references; their embedded UI text/numbers are noncanonical placeholders and must never be extracted as runtime UI sprites.
-- Visual style remains `SOFT_STORYBOOK_ENVIRONMENT + CLEAN_ANIME_CEL_CHARACTER_OVER_STORYBOOK_BACKGROUND + NAVY_GOLD_MAGIC_ACADEMY_FRAME`.
-- AI-generated-look reduction, style consistency/readability, and world/core-system fit remain mandatory review axes.
-- Background source master target: `2560×1440`; runtime opaque background export: WebP Lossless; no alpha.
-- Half-body portrait runtime canvas: `1024×1536 RGBA`; Maren uses the professor family and does not create a new costume family.
-- Main companion runtime frame target: `256×256 RGBA`; generate higher-resolution source, then crop/export deterministically.
-- Base glyph count for this first session remains exactly `FLOW / FOCUS / DISPERSE`; glyph source target is `512×512`, SVG preferred for final runtime symbol.
-- Base icon hard cap remains 24. Lens 4 + Result Axis 5 reuse existing common icons where semantically valid and the execution must count active base icons before adding any new symbol.
-- Text/labels/numbers are live UI. No Korean/English functional text, success %, Mana, count, grade, or button label may be baked into images.
-- Generated asset existence does not imply approval. Candidate → visual review → selected source → rights/provenance review → export → manifest → import → runtime verification → runtime-rendered user approval are distinct states.
-- Every runtime asset must conform to `docs/planning/ASSET_MANIFEST_SCHEMA.json`; source File ID/path + SHA, tool, owner, export SHA/format/dimensions, license status/evidence, screen consumers, approval, and runtime validation are mandatory.
-- Rights status is evidence-driven. Do not assume `PROJECT_ORIGINAL`, `USER_OWNED`, commercial rights, modification rights, or redistribution rights merely because an image was generated. Read the current applicable tool/service terms when the asset is selected and record evidence before runtime promotion.
-- A selected asset with unresolved rights remains `license.status = REVIEW_REQUIRED` and cannot become `APPROVED_RUNTIME_CANDIDATE`, `RUNTIME_VERIFIED`, or `PROJECT_ASSET_APPROVED`.
-- Source layers live in ChatGPT Library/external source storage or `.gdignore` source root; GitHub product paths receive only approved runtime exports/manifests, not uncontrolled layered masters.
-- Human visual selection is required before any generated raster candidate can enter runtime export work. A second user approval of the real Godot-rendered gallery is required before `PROJECT_ASSET_APPROVED`.
-- Physical-device validation, performance validation, accessibility/device validation, and Full Vertical Slice validation remain `NOT_RUN` unless actually executed.
-- No Festival full-content batch, all-NPC portrait batch, Year-One full asset set, companion growth stages, guardian battlefield body, or second-incident art is authorized.
+- Project authority at plan creation: GRIMOIRE `main` `4c2f23c4bb8b7487559b113a5d41deab815fb62d`.
+- Base observation: `e222e93e79e95364dca668eaaf0f156676123342`; reuse `RM-VIS-002`, `RM-VIS-003`, `RM-VIS-004`, `RM-VIS-005` as structural contracts only.
+- Locked visual authority: `/GRIMOIRE/Visual Authority/GRIMOIRE_ART_STYLE_01_LOCKED_REFERENCE.png`, SHA-256 `b55ce1dec6c2521668602d1ce6547526e7f40b8c7c9b6f5276d9289a67f14f7a`. Never edit, regenerate, recolor, crop-replace, or overwrite it.
+- Approved Board A/B are composition/checkpoint references. Their embedded text/numbers are noncanonical and cannot become runtime UI sprites.
+- Visual language: `SOFT_STORYBOOK_ENVIRONMENT + CLEAN_ANIME_CEL_CHARACTER_OVER_STORYBOOK_BACKGROUND + NAVY_GOLD_MAGIC_ACADEMY_FRAME`.
+- Review axes: AI-generated-look reduction, style consistency/readability, world/core-system fit.
+- Background source target: `2560×1440`; opaque runtime export: WebP Lossless, no alpha.
+- Maren portrait runtime canvas: `1024×1536 RGBA`; professor costume family remains unchanged.
+- Nea runtime source target: `256×256 RGBA` after deterministic downscale/crop from a higher-resolution selected source.
+- First-session glyphs remain exactly `FLOW / FOCUS / DISPERSE`; final runtime glyphs are project-authored SVG.
+- Base icon hard cap remains 24. Count existing active icons before adding Lens 4 + Result 5; reuse existing semantics when valid.
+- Functional text, success %, Mana, counts, grades, focus/selection truth, and button labels are live UI, never raster content.
+- Candidate existence is not approval. State progression is `generated candidate → visual review → selected source → rights/provenance cleared → runtime candidate → imported/runtime verified → runtime-rendered user approval → PROJECT_ASSET_APPROVED`.
+- Every runtime asset follows `docs/planning/ASSET_MANIFEST_SCHEMA.json` with real source/export hashes, rights evidence, consumer screens, and truthful runtime status.
+- Rights are evidence-driven. Generation alone does not prove ownership, commercial use, modification, redistribution, or credit conditions. Review current applicable terms at execution time.
+- `license.status = REVIEW_REQUIRED` blocks runtime-candidate promotion.
+- Source candidates/layers stay in Library or a non-runtime source root. GitHub product paths receive selected runtime exports, authored SVGs, manifests, and evidence only.
+- User visual selection is required before raster export work. A second user approval of the actual Godot-rendered gallery is required before `PROJECT_ASSET_APPROVED`.
+- Physical-device, accessibility/device, performance, Human play, and Full Vertical Slice validation remain `NOT_RUN` unless actually executed.
+- No Festival full-content batch, all-NPC portrait batch, Year-One full asset set, companion growth stages, guardian battlefield body, or second-incident art.
 
 ---
 
 ## File Structure
 
-### Planning, candidate, rights, and reuse records
-
+**Planning/evidence**
 - `docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_BRIEF.md`
 - `docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_PLAN.json`
 - `docs/planning/visual/first_session_image_batch_01_background_candidates.json`
@@ -48,12 +47,13 @@
 - `docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_LAYER_REUSE_REVIEW.md`
 - `tests/test_first_session_image_batch_contract.py`
 
-### Runtime export targets after source selection and rights clearance
-
+**Runtime raster exports after selection/rights clearance**
 - `assets/art/backgrounds/greenhouse/bg_greenhouse_field_base.webp`
 - `assets/art/backgrounds/school/bg_school_common.webp`
 - `assets/art/characters/professor/chr_maren_portrait_instructive.png`
 - `assets/art/characters/companion/chr_nea_field_neutral.png`
+
+**Runtime SVGs**
 - `assets/art/ui/glyphs/glyph_flow.svg`
 - `assets/art/ui/glyphs/glyph_focus.svg`
 - `assets/art/ui/glyphs/glyph_disperse.svg`
@@ -67,21 +67,17 @@
 - `assets/art/ui/result/icon_result_relationship.svg`
 - `assets/art/ui/result/icon_result_discovery.svg`
 
-### Runtime manifests
-
-One JSON file under `assets/manifests/` for every runtime export above, using the export basename as the manifest basename.
-
-### Runtime gallery and verification
-
+**Runtime manifest/gallery**
+- One `assets/manifests/<export-basename>.json` per runtime export/SVG.
 - `src/ui/asset_gallery/first_session_asset_gallery.gd`
 - `src/ui/asset_gallery/first_session_asset_gallery.tscn`
+- `tests/integration/test_first_session_asset_gallery.gd`
 - `tools/capture_first_session_asset_gallery.gd`
 - `.github/workflows/validate-first-session-image-assets.yml`
 - `docs/planning/FIRST_SESSION_IMAGE_BATCH_01_ADVERSARIAL_REVIEW_2026-08-20.md`
 - `docs/planning/sync/GR-SYNC-20260820-34-FIRST-SESSION-IMAGE-ASSETS.md`
 
-### Persistent Library candidate roots
-
+**Library roots**
 ```text
 /GRIMOIRE/Production Candidates/first_session_01/backgrounds/greenhouse/
 /GRIMOIRE/Production Candidates/first_session_01/backgrounds/classroom/
@@ -94,7 +90,7 @@ One JSON file under `assets/manifests/` for every runtime export above, using th
 
 ---
 
-### Task 1: Asset-batch contract RED and exact generation briefs
+### Task 1: Contract RED and exact image briefs
 
 **Files:**
 - Create: `tests/test_first_session_image_batch_contract.py`
@@ -102,12 +98,10 @@ One JSON file under `assets/manifests/` for every runtime export above, using th
 - Create: `docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_PLAN.json`
 
 **Interfaces:**
-- Consumes: Art Bible, Asset Spec, approved Board A/B manifests, Component production spec, Base RM-VIS contracts.
-- Produces: seven mandatory production groups plus one conditional ornament/VFX sufficiency group; no generated asset.
+- Consumes: Art Bible, Asset Spec, Board A/B manifests, production spec, Base RM-VIS contracts.
+- Produces: exactly seven production groups plus one ornament/VFX sufficiency check; no image output.
 
-- [ ] **Step 1: Write the RED contract first**
-
-Create `tests/test_first_session_image_batch_contract.py`:
+- [ ] **Step 1: Write the failing Python contract**
 
 ```python
 from pathlib import Path
@@ -119,15 +113,9 @@ ROOT = Path(__file__).resolve().parents[1]
 PLAN = ROOT / "docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_PLAN.json"
 BRIEF = ROOT / "docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_BRIEF.md"
 SCHEMA = ROOT / "docs/planning/ASSET_MANIFEST_SCHEMA.json"
-
-EXPECTED_GROUPS = [
-    "GREENHOUSE_BACKGROUND",
-    "CLASSROOM_BACKGROUND",
-    "MAREN_PORTRAIT",
-    "NEA_SOURCE",
-    "GLYPH_SYMBOLS",
-    "LENS_SYMBOLS",
-    "RESULT_AXIS_SYMBOLS",
+EXPECTED = [
+    "GREENHOUSE_BACKGROUND", "CLASSROOM_BACKGROUND", "MAREN_PORTRAIT",
+    "NEA_SOURCE", "GLYPH_SYMBOLS", "LENS_SYMBOLS", "RESULT_AXIS_SYMBOLS",
     "ORNAMENT_VFX_SUFFICIENCY",
 ]
 
@@ -136,31 +124,31 @@ class FirstSessionImageBatchContractTests(unittest.TestCase):
         self.assertTrue(PLAN.is_file())
         self.assertTrue(BRIEF.is_file())
 
-    def test_plan_is_candidate_only_before_human_review(self):
+    def test_candidate_plan_has_bounded_groups(self):
         data = json.loads(PLAN.read_text(encoding="utf-8"))
-        self.assertEqual(EXPECTED_GROUPS, [g["group_id"] for g in data["groups"]])
-        self.assertTrue(all(g["status"] == "PLANNED" for g in data["groups"]))
-        self.assertTrue(all(g["runtime_validation"] == "NOT_RUN" for g in data["groups"]))
+        self.assertEqual(EXPECTED, [row["group_id"] for row in data["groups"]])
         self.assertFalse(data["mass_generation_authorized"])
+        self.assertTrue(all(row["status"] == "PLANNED" for row in data["groups"]))
+        self.assertTrue(all(row["runtime_validation"] == "NOT_RUN" for row in data["groups"]))
 
-    def test_locked_authority_and_text_boundary_are_explicit(self):
+    def test_brief_preserves_visual_authority_and_live_text_boundary(self):
         text = BRIEF.read_text(encoding="utf-8")
         self.assertIn("b55ce1dec6c2521668602d1ce6547526e7f40b8c7c9b6f5276d9289a67f14f7a", text)
         self.assertIn("NO_FUNCTIONAL_TEXT_BAKED_INTO_IMAGE", text)
         self.assertIn("USER_VISUAL_APPROVAL_REQUIRED", text)
 
-    def test_runtime_schema_still_requires_traceability(self):
+    def test_manifest_schema_keeps_traceability_fields(self):
         schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
         for key in ("asset_id", "source", "export", "license", "status", "used_in_screens", "runtime_validation"):
             self.assertIn(key, schema["required"])
 
-    def test_no_unresolved_template_markers_enter_runtime_manifests(self):
-        manifest_root = ROOT / "assets/manifests"
-        if not manifest_root.is_dir():
+    def test_runtime_manifests_contain_no_template_markers(self):
+        root = ROOT / "assets/manifests"
+        if not root.is_dir():
             return
-        bad = re.compile(r"(actual_|replace_me|example_sha|example_file_id)", re.I)
-        for path in manifest_root.glob("*.json"):
-            self.assertNotRegex(path.read_text(encoding="utf-8"), bad, path.name)
+        marker = re.compile(r"(replace_me|example_sha|example_file_id|__fill__)", re.I)
+        for path in root.glob("*.json"):
+            self.assertNotRegex(path.read_text(encoding="utf-8"), marker, path.name)
 
 if __name__ == "__main__":
     unittest.main()
@@ -168,17 +156,13 @@ if __name__ == "__main__":
 
 - [ ] **Step 2: Run RED**
 
-Run:
-
 ```bash
 python -m unittest tests.test_first_session_image_batch_contract -v
 ```
 
-Expected: fail because BRIEF/PLAN do not yet exist.
+Expected: failure because BRIEF/PLAN do not exist.
 
-- [ ] **Step 3: Create the machine plan**
-
-Create `FIRST_SESSION_IMAGE_BATCH_01_PLAN.json` exactly as:
+- [ ] **Step 3: Create the bounded machine plan**
 
 ```json
 {
@@ -200,10 +184,9 @@ Create `FIRST_SESSION_IMAGE_BATCH_01_PLAN.json` exactly as:
 }
 ```
 
-- [ ] **Step 4: Write exact visual briefs and rejection criteria**
+- [ ] **Step 4: Write the exact brief**
 
-The Markdown brief must contain:
-
+Global tokens in the brief:
 ```text
 NO_FUNCTIONAL_TEXT_BAKED_INTO_IMAGE
 USER_VISUAL_APPROVAL_REQUIRED
@@ -211,18 +194,17 @@ NO_COMPETITOR_TRADE_DRESS_COPY
 LOCKED_REFERENCE_EDIT_FORBIDDEN
 ```
 
-Per-group requirements:
+Group requirements:
+- Greenhouse: 2560×1440 target, fixed 3/4 storybook environment, frostbloom damage/pressure, readable irrigation/root/spirit-channel landmarks, no characters/UI/text; alternatives vary camera elevation, foreground framing, landmark distribution.
+- Classroom: 2560×1440 target, same academy world, practice surface + field-maintenance preparation cues, no tutorial text; alternatives vary room orientation, practice-surface location, staging area.
+- Maren: half-body source, professor identity/costume family fixed, neutral-to-instructive; vary expression, small gesture, framing only.
+- Nea: small white/pale-blue wolf spirit, rounded face, large ears/tail, small elemental glow, no growth form; vary pose/energy emphasis only.
+- Glyph directions: FLOW curved directional stream; FOCUS compressed convergence/core; DISPERSE expanding/diverging wave.
+- Lens directions: REST recovery/quiet; PREPARE tool/readiness; SOCIAL people/context; PRACTICUM field handling/comparison.
+- Result directions: FACILITY structure; LIFE growth; SPIRIT resonance; RELATIONSHIP linked nodes; DISCOVERY revealed knowledge.
+- Ornament/VFX: inspect existing common assets first; no speculative generation.
 
-- **Greenhouse:** 2560×1440 source target; fixed 3/4 storybook environment; damaged frostbloom greenhouse; readable irrigation/root/spirit-channel landmarks; no characters/UI; three alternatives vary camera elevation, foreground framing, and landmark distribution while preserving one location identity.
-- **Classroom:** 2560×1440 source target; same academy world; practical glyph-learning room; visible practice surface and supervised field-maintenance preparation cues; no tutorial text; three alternatives vary room orientation, practice-surface location, and staging space.
-- **Maren:** half-body source; same professor identity family; neutral-to-instructive expression; Navy/Gold academy clothing family; no costume variant; alternatives vary expression, small gesture, and framing only.
-- **Nea:** small wolf-like spirit; white/pale-blue; rounded face; large ears/tail; small elemental glow; no growth form; alternatives vary pose/energy emphasis only.
-- **Glyph directions:** FLOW = directional curved stream; FOCUS = compressed core/convergence; DISPERSE = expanding/diverging wave. Concept sheets are reference-only; runtime glyphs are rebuilt as SVG.
-- **Lens directions:** REST = recovery/quiet; PREPARE = tool/readiness; SOCIAL = people/context; PRACTICUM = field handling/comparison. Runtime icons are rebuilt as SVG.
-- **Result directions:** FACILITY = structure; LIFE = living growth; SPIRIT = resonance; RELATIONSHIP = linked people/records; DISCOVERY = revealed knowledge. Runtime icons are rebuilt as SVG.
-- **Ornament/VFX sufficiency:** inspect existing common ornament/phase/warning/Mana assets first. If sufficient, generate nothing. A new ornament/VFX concept requires a separate bounded revision tied to a concrete consumer.
-
-Reject pseudo-text, watermark/logo, malformed anatomy, repeated nonsensical architectural motifs, inconsistent costume/face, crowded gameplay/read zones, or style drift.
+Reject pseudo-text/watermarks, malformed anatomy, nonsensical repeated architecture, identity drift, crowded gameplay/read zones, and style drift.
 
 - [ ] **Step 5: Run GREEN and commit**
 
@@ -234,36 +216,33 @@ git commit -m "test(art): define first-session image batch contract"
 
 ---
 
-### Task 2: Recover references and generate three Greenhouse/Classroom candidates each
+### Task 2: Generate and select Greenhouse/Classroom candidates
 
 **Files/Library:**
-- Read only: locked Art Style reference and approved Board A/B Library files.
-- Write candidates only to the background candidate Library roots.
+- Read: exact locked reference + Board A/B.
+- Write: 3 Greenhouse + 3 Classroom candidates to Library roots.
 - Create: `docs/planning/visual/first_session_image_batch_01_background_candidates.json`
 
 **Interfaces:**
-- Consumes: exact references + background briefs.
-- Produces: six candidate records containing observed IDs/dimensions/SHA; no runtime export.
+- Produces: six candidate records with observed file IDs/paths/hashes/dimensions; no runtime exports.
 
-- [ ] **Step 1: Recover exact references through Files/Library**
+- [ ] **Step 1: Recover exact references**
 
-Search for the locked reference and Board A/B by exact names. Read native images. Verify the locked reference record names the expected SHA. If the exact locked reference cannot be recovered, stop generation and record the blocker instead of substituting another image.
+Search Library by exact names; inspect native images. Verify the locked reference record names the required SHA. If exact recovery fails, record blocker and stop candidate generation.
 
-- [ ] **Step 2: Generate exactly three Greenhouse alternatives**
+- [ ] **Step 2: Generate exactly three Greenhouse candidates**
 
-Use the image-generation surface with the approved references in context. The request must state: same GRIMOIRE visual language, soft storybook fixed 3/4 greenhouse, frostbloom damage/pressure context, readable irrigation/root/spirit-channel landmarks, quiet gameplay center, no characters, no UI, no text/signage/pseudo-text, 16:9 composition. Candidate axes are camera elevation, foreground framing, and landmark distribution—not world style.
+Image-generation request must preserve GRIMOIRE style, 3/4 greenhouse, frostbloom pressure/damage, irrigation/root/spirit-channel landmarks, quiet gameplay center, no characters/UI/text, 16:9. Only composition axes vary.
 
-- [ ] **Step 3: Recover generated file IDs and persist candidates**
+- [ ] **Step 3: Recover generated file IDs, hash once, and persist**
 
-After generation, use Files search scoped to the current conversation with `model_generated=true` and identify exactly the three new Greenhouse images. Materialize each once for SHA calculation, then upload/copy each to the Greenhouse Library folder as `greenhouse_candidate_01.png`, `greenhouse_candidate_02.png`, `greenhouse_candidate_03.png`. Record actual returned Library path/file ID, dimensions, byte size, generation identifier if surfaced, and SHA-256.
+Use current-conversation Files search with `model_generated=true`, identify the three new outputs, materialize once for SHA/dimensions, and upload/copy to Library as `greenhouse_candidate_01.png` through `03.png`.
 
-- [ ] **Step 4: Generate and persist exactly three Classroom alternatives**
+- [ ] **Step 4: Generate/persist exactly three Classroom candidates**
 
-Repeat with the Classroom brief and save as `classroom_candidate_01.png` through `03.png`.
+Use the Classroom brief and save `classroom_candidate_01.png` through `03.png`.
 
-- [ ] **Step 5: Write the background candidate receipt from observed metadata**
-
-The receipt uses this schema and receives values directly from tool/read/hash results:
+- [ ] **Step 5: Build the receipt from observed metadata**
 
 ```json
 {
@@ -278,13 +257,13 @@ The receipt uses this schema and receives values directly from tool/read/hash re
 }
 ```
 
-Each candidate object contains `file_id`, `library_path`, `sha256`, `width`, `height`, and `generation_id` only when that ID is actually surfaced.
+Each candidate object is populated from tool outputs with `file_id`, `library_path`, `sha256`, `width`, `height`, and `generation_id` only if surfaced.
 
-- [ ] **Step 6: Present all six candidates to the user for visual selection**
+- [ ] **Step 6: User selects one candidate per group**
 
-Show A/B/C for each group with one-line differences. Do not auto-select. Record the exact selected file IDs after the user chooses or requests a bounded revision.
+Present A/B/C differences. Do not auto-select. Write the selected exact file IDs into the receipt after user choice.
 
-- [ ] **Step 7: Commit provenance/selection receipt only**
+- [ ] **Step 7: Commit receipt only**
 
 ```bash
 git add docs/planning/visual/first_session_image_batch_01_background_candidates.json
@@ -293,19 +272,17 @@ git commit -m "docs(art): record first-session background candidates"
 
 ---
 
-### Task 3: Generate Maren and Nea identity-safe candidates and select source families
+### Task 3: Generate and select Maren/Nea source families
 
 **Files/Library:**
-- Candidate roots: Maren and Nea Library folders.
+- Write: 3 Maren + 3 Nea candidates.
 - Create: `docs/planning/visual/first_session_image_batch_01_character_candidates.json`
 
 **Interfaces:**
-- Consumes: Art Bible/Board continuity + Base `RM-VIS-005`.
-- Produces: one user-selected Maren source and one user-selected Nea source; no runtime export.
+- Consumes: Art Bible/Board continuity + RM-VIS-005.
+- Produces: one selected Maren and one selected Nea source; no runtime export.
 
-- [ ] **Step 1: Record only supported identity locks**
-
-Before generation, write the candidate receipt with immutable axes:
+- [ ] **Step 1: Record supported identity locks**
 
 ```json
 {
@@ -326,25 +303,25 @@ Before generation, write the candidate receipt with immutable axes:
 }
 ```
 
-If a facial/costume detail is not supported by the approved reference, do not add it to the lock.
+Do not add unsupported facial/costume details to the lock.
 
 - [ ] **Step 2: Generate exactly three Maren candidates**
 
-Use transparent background when supported. Hold costume/palette/light family constant and vary only instructive expression, small gesture, and framing. Reject face drift, costume redesign, extra accessories, pseudo-text, or style drift.
+Transparent background when supported; costume/palette/light family fixed; vary only expression, small gesture, framing. Reject face drift/costume redesign/accessory creep.
 
 - [ ] **Step 3: Generate exactly three Nea candidates**
 
-Use transparent background when supported. Hold body/palette/silhouette family fixed; vary neutral, alert, and field-attention poses only. Reject armor/evolution, mount scale, extra tails/wings, or mascot redesign.
+Transparent background when supported; body/palette/silhouette fixed; vary neutral, alert, field-attention poses. Reject growth/armor/mount scale/extra appendages.
 
-- [ ] **Step 4: Persist, materialize once, hash, and record candidates**
+- [ ] **Step 4: Persist/hash/record all six outputs**
 
-Use the same Files/Library procedure as Task 2. Every candidate record gets observed file ID/path/SHA/dimensions. Status remains `IN_VISUAL_REVIEW`.
+Use the same Files/Library procedure as Task 2. Status remains `IN_VISUAL_REVIEW`.
 
-- [ ] **Step 5: User selects one Maren and one Nea source family**
+- [ ] **Step 5: User selects one Maren and one Nea source**
 
-Record selected file IDs. Selection promotes the source family only to `SOURCE_READY`; it does not imply runtime import or rights clearance.
+Write selected file IDs; selection moves source family only to `SOURCE_READY`.
 
-- [ ] **Step 6: Commit character receipt**
+- [ ] **Step 6: Commit receipt**
 
 ```bash
 git add docs/planning/visual/first_session_image_batch_01_character_candidates.json
@@ -353,44 +330,34 @@ git commit -m "docs(art): record first-session character candidates"
 
 ---
 
-### Task 4: Explore symbol directions, select directions, then author final SVG symbols
+### Task 4: Explore symbol directions and author final SVGs
 
 **Files:**
-- Candidate concept sheets: Library only.
-- Create final 12 SVGs at the runtime paths listed in File Structure.
+- Library: concept direction sheets only.
+- Create: 12 runtime SVGs listed in File Structure.
 - Create: `docs/planning/visual/first_session_image_batch_01_symbol_direction_review.md`
 - Modify: `tests/test_first_session_image_batch_contract.py`
 
 **Interfaces:**
-- Consumes: Base `RM-VIS-002`, selected GRIMOIRE visual language, existing simple SVG conventions.
-- Produces: 3 glyph + 4 Lens + 5 Result SVGs; text-free, raster-free, filter-free.
+- Consumes: RM-VIS-002 + GRIMOIRE visual language.
+- Produces: text-free/raster-free/filter-free SVGs.
 
-- [ ] **Step 1: Generate three concept-direction sheets for each symbol family**
+- [ ] **Step 1: Generate three direction sheets per symbol family**
 
-Use image generation for visual exploration only. Each sheet contains all members of its family without readable text. Persist concept sheets as `REFERENCE_ONLY`; never import them directly into runtime.
+Generate glyph, Lens, and Result family sheets separately; no readable text. Persist as `REFERENCE_ONLY`.
 
-- [ ] **Step 2: Obtain one user-selected direction per family**
+- [ ] **Step 2: User chooses one direction per family**
 
-Review at semantic criteria: 16/24/32/48 px legibility, GRIMOIRE identity, shape distinctness, AI-look reduction, and no collision with existing Mana/Warning/Phase symbols.
+Evaluate 16/24/32/48 px legibility, semantic distinctness, GRIMOIRE fit, AI-look reduction, collision with existing symbols.
 
-- [ ] **Step 3: Write SVG RED assertions**
-
-Extend the Python contract:
+- [ ] **Step 3: Add SVG RED checks**
 
 ```python
 SVG_PATHS = [
-    "assets/art/ui/glyphs/glyph_flow.svg",
-    "assets/art/ui/glyphs/glyph_focus.svg",
-    "assets/art/ui/glyphs/glyph_disperse.svg",
-    "assets/art/ui/lens/icon_lens_rest.svg",
-    "assets/art/ui/lens/icon_lens_prepare.svg",
-    "assets/art/ui/lens/icon_lens_social.svg",
-    "assets/art/ui/lens/icon_lens_practicum.svg",
-    "assets/art/ui/result/icon_result_facility.svg",
-    "assets/art/ui/result/icon_result_life.svg",
-    "assets/art/ui/result/icon_result_spirit.svg",
-    "assets/art/ui/result/icon_result_relationship.svg",
-    "assets/art/ui/result/icon_result_discovery.svg",
+    "assets/art/ui/glyphs/glyph_flow.svg", "assets/art/ui/glyphs/glyph_focus.svg", "assets/art/ui/glyphs/glyph_disperse.svg",
+    "assets/art/ui/lens/icon_lens_rest.svg", "assets/art/ui/lens/icon_lens_prepare.svg", "assets/art/ui/lens/icon_lens_social.svg", "assets/art/ui/lens/icon_lens_practicum.svg",
+    "assets/art/ui/result/icon_result_facility.svg", "assets/art/ui/result/icon_result_life.svg", "assets/art/ui/result/icon_result_spirit.svg",
+    "assets/art/ui/result/icon_result_relationship.svg", "assets/art/ui/result/icon_result_discovery.svg",
 ]
 for relative in SVG_PATHS:
     path = ROOT / relative
@@ -402,38 +369,38 @@ for relative in SVG_PATHS:
         self.assertNotIn(forbidden, text)
 ```
 
-Run RED; expected: missing SVGs.
+Run RED; missing SVGs are expected.
 
-- [ ] **Step 4: Author the three glyph SVGs from semantic geometry**
-
-Use simple project-authored paths, not trace copies of concept-sheet pixels:
+- [ ] **Step 4: Author glyph SVGs from semantic geometry**
 
 ```text
-FLOW      = continuous curved stream + secondary parallel accent
-FOCUS     = converging outer geometry + small central core
-DISPERSE  = central origin + three expanding/diverging arcs
+FLOW = continuous curved stream + secondary parallel accent
+FOCUS = converging outer geometry + small central core
+DISPERSE = central origin + three expanding/diverging arcs
 ```
+
+Do not trace concept-sheet pixels.
 
 - [ ] **Step 5: Author Lens SVGs**
 
 ```text
-REST      = quiet crescent/settled pulse
-PREPARE   = compact tool/readiness diamond + handle
-SOCIAL    = two linked nodes + context bridge
+REST = quiet crescent/settled pulse
+PREPARE = tool/readiness diamond + handle
+SOCIAL = linked nodes + context bridge
 PRACTICUM = field marker + handling/compare split
 ```
 
 - [ ] **Step 6: Author Result SVGs**
 
 ```text
-FACILITY      = structural arch/beam
-LIFE          = sprout/leaf
-SPIRIT        = resonance spiral/core
-RELATIONSHIP  = two linked rings/nodes
-DISCOVERY     = open-page/reveal silhouette without letters
+FACILITY = structural arch/beam
+LIFE = sprout/leaf
+SPIRIT = resonance spiral/core
+RELATIONSHIP = linked rings/nodes
+DISCOVERY = open-page/reveal silhouette without letters
 ```
 
-- [ ] **Step 7: Run SVG contract and commit**
+- [ ] **Step 7: Test and commit**
 
 ```bash
 python -m unittest tests.test_first_session_image_batch_contract -v
@@ -443,36 +410,36 @@ git commit -m "feat(art): add first-session semantic symbols"
 
 ---
 
-### Task 5: Layer/reuse classification and ornament/VFX sufficiency decision
+### Task 5: Layer/reuse review and ornament/VFX sufficiency
 
 **Files:**
 - Create: `docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_LAYER_REUSE_REVIEW.md`
 
 **Interfaces:**
-- Consumes: selected source candidates + Base `RM-VIS-003/004/005`.
-- Produces: truthful layer provenance/reuse classification and one ornament/VFX sufficiency verdict.
+- Consumes: selected sources + RM-VIS-003/004/005.
+- Produces: truthful provenance/reuse classification; one sufficiency verdict.
 
-- [ ] **Step 1: Classify selected backgrounds**
+- [ ] **Step 1: Classify each selected background**
 
-For each selected background, record `base_environment`, `midground`, `foreground_props`, `lighting`, `story_state_overlay`, `atmosphere_fx`. Each part gets one provenance: `SOURCE_LAYER`, `MASK_CUTOUT`, `MANUAL_OR_SEMANTIC_REBUILD`, or `DERIVED_GENERATIVE_RECOVERY`. Generated recovery of an occluded region is never labeled `SOURCE_LAYER`.
+Record `base_environment`, `midground`, `foreground_props`, `lighting`, `story_state_overlay`, `atmosphere_fx`; each part gets exactly one provenance: `SOURCE_LAYER`, `MASK_CUTOUT`, `MANUAL_OR_SEMANTIC_REBUILD`, `DERIVED_GENERATIVE_RECOVERY`.
 
-- [ ] **Step 2: Classify selected Maren/Nea families**
+- [ ] **Step 2: Classify Maren/Nea**
 
-Maren is `VARIANT_SEED` for expression-only variants. Nea is `VARIANT_SEED` for bounded pose/reaction variants. Record growth form and costume-family expansion as outside this batch.
+Maren = `VARIANT_SEED` for expression-only variants. Nea = `VARIANT_SEED` for bounded pose/reaction variants. Growth/costume expansion remains outside scope.
 
-- [ ] **Step 3: Inspect existing ornament/icon assets**
+- [ ] **Step 3: Inspect existing ornament/VFX assets**
 
-Check `assets/art/ui/common/academy_corner_ornament.svg`, phase/warning/Mana icons, and existing StarCircuitBoard visuals against Component Sheets A–D. If sufficient, record `NO_NEW_ORNAMENT_VFX_REQUIRED`. If one concrete semantic gap remains, stop and create a separate bounded design before generation; do not add speculative art here.
+Check `academy_corner_ornament.svg`, phase/warning/Mana icons, StarCircuitBoard visuals. If sufficient, record `NO_NEW_ORNAMENT_VFX_REQUIRED`. A concrete missing semantic triggers a separate bounded design, not speculative generation here.
 
-- [ ] **Step 4: Run five adversarial reuse passes**
+- [ ] **Step 4: Run five reuse adversarial passes**
 
-1. Primary-quality attack — decomposition must not degrade the selected primary image.
-2. Fake-layer attack — generated reconstruction provenance is truthful.
-3. Identity-drift attack — variant seed boundaries protect face/costume/world identity.
-4. Over-reuse attack — one-off focal parts are not forced into generic modules.
-5. Scope-creep attack — optional ornament/VFX has not become an unowned batch.
+1. Primary-quality attack.
+2. Fake-layer provenance attack.
+3. Identity-drift attack.
+4. Over-reuse attack.
+5. Scope-creep attack.
 
-- [ ] **Step 5: Commit reuse review**
+- [ ] **Step 5: Commit review**
 
 ```bash
 git add docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_LAYER_REUSE_REVIEW.md
@@ -481,157 +448,136 @@ git commit -m "docs(art): classify first-session asset reuse"
 
 ---
 
-### Task 6: Rights review, deterministic exports, and schema-valid manifests
+### Task 6: Rights review, deterministic export, and manifest generation
 
 **Files:**
 - Create: `docs/planning/visual/first_session_image_batch_01_rights_review.json`
-- Create: selected raster runtime exports.
-- Create: one manifest per runtime export/symbol under `assets/manifests/`.
+- Create: selected raster exports + per-export manifests.
 - Modify: `tests/test_first_session_image_batch_contract.py`
 - Modify: `docs/ASSET_LICENSE_LEDGER.md` with observed records only.
 
 **Interfaces:**
-- Consumes: exact selected Library file IDs, computed SHA-256 values, current tool/service rights evidence, selected SVGs.
-- Produces: runtime candidates only when rights status is resolved; otherwise a documented block.
+- Consumes: exact selected source receipt + computed hashes + current rights evidence.
+- Produces: `APPROVED_RUNTIME_CANDIDATE` only for rights-cleared assets.
 
-- [ ] **Step 1: Perform current rights review before export promotion**
+- [ ] **Step 1: Create rights records from selected receipts, not hand-entered IDs**
 
-Read the current applicable generation/service terms and any project policy relevant to ownership, commercial use, modification, redistribution, and required credit. Record one entry per selected raster source:
+Execution code reads the selected file ID directly:
 
-```json
-{
-  "source_file_id": "file_00000000000000000000000000000000",
-  "status": "REVIEW_REQUIRED",
-  "evidence": [],
-  "commercial_use": "UNRESOLVED",
-  "modification": "UNRESOLVED",
-  "redistribution": "UNRESOLVED",
-  "credit_required": "UNRESOLVED"
+```python
+selection = json.loads(Path("docs/planning/visual/first_session_image_batch_01_background_candidates.json").read_text(encoding="utf-8"))
+selected_id = selection["groups"]["GREENHOUSE_BACKGROUND"]["selected_file_id"]
+assert selected_id
+rights_entry = {
+    "source_file_id": selected_id,
+    "status": "REVIEW_REQUIRED",
+    "evidence": [],
+    "commercial_use": "UNRESOLVED",
+    "modification": "UNRESOLVED",
+    "redistribution": "UNRESOLVED",
+    "credit_required": "UNRESOLVED"
 }
 ```
 
-The literal example file ID above is schema illustration in the planning document only; execution writes the rights-review file from the exact selected file ID returned by Files. It must not be copied into a project record. After checking current evidence, change `status` only to a schema-supported resolved status whose claims are directly supported. If unresolved, stop runtime promotion for that asset.
+Repeat from the relevant receipt for all selected raster sources. Then read current applicable service/tool terms and project policy. Replace `REVIEW_REQUIRED`/`UNRESOLVED` only when evidence directly supports a specific claim. Unresolved assets stop here.
 
-- [ ] **Step 2: Materialize selected sources by exact file ID and verify source SHA**
+- [ ] **Step 2: Materialize by selected file ID and verify SHA**
 
-For each selected source, materialize it once, compute SHA-256, and compare it to the selected-candidate receipt. Mismatch is a hard block.
+Compute SHA-256 and compare it against the candidate receipt before any export. A mismatch is a hard block.
 
-- [ ] **Step 3: Export raster assets without creative alteration**
-
-Use deterministic conversion only:
+- [ ] **Step 3: Export without creative alteration**
 
 ```text
-bg_greenhouse_field_base.webp  2560×1440 WebP lossless alpha=false
-bg_school_common.webp           2560×1440 WebP lossless alpha=false
-chr_maren_portrait_instructive.png 1024×1536 PNG RGBA
-chr_nea_field_neutral.png       256×256 PNG RGBA
+bg_greenhouse_field_base.webp       2560×1440 WebP lossless alpha=false
+bg_school_common.webp                2560×1440 WebP lossless alpha=false
+chr_maren_portrait_instructive.png  1024×1536 PNG RGBA
+chr_nea_field_neutral.png            256×256 PNG RGBA
 ```
 
-If a source requires creative anatomy/background repair rather than deterministic crop/mask cleanup, return to image editing/generation and user review; do not hide creative repair inside export code.
+Creative anatomy/background repair returns to image editing/generation + review, never hidden inside conversion code.
 
-- [ ] **Step 4: Add manifest-validation helpers to the Python contract before writing manifests**
-
-Add:
+- [ ] **Step 4: Add manifest validation helpers before manifest creation**
 
 ```python
 import hashlib
-
 SHA_RE = re.compile(r"^[a-f0-9]{64}$")
-ALLOWED_RESOLVED_LICENSE = {"PROJECT_ORIGINAL", "USER_OWNED", "COMMERCIAL_USE_APPROVED"}
+RESOLVED_LICENSE = {"PROJECT_ORIGINAL", "USER_OWNED", "COMMERCIAL_USE_APPROVED"}
 
 def sha256_file(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
-def assert_runtime_manifest(testcase: unittest.TestCase, manifest: dict, manifest_path: Path):
-    testcase.assertRegex(manifest["source"]["sha256"], SHA_RE, manifest_path.name)
-    testcase.assertRegex(manifest["export"]["sha256"], SHA_RE, manifest_path.name)
-    testcase.assertIn(manifest["license"]["status"], ALLOWED_RESOLVED_LICENSE, manifest_path.name)
-    testcase.assertNotEqual("REVIEW_REQUIRED", manifest["license"]["status"])
+def assert_runtime_manifest(testcase, manifest, path):
+    testcase.assertRegex(manifest["source"]["sha256"], SHA_RE, path.name)
+    testcase.assertRegex(manifest["export"]["sha256"], SHA_RE, path.name)
+    testcase.assertIn(manifest["license"]["status"], RESOLVED_LICENSE, path.name)
     testcase.assertEqual(sha256_file(ROOT / manifest["export"]["file_path"]), manifest["export"]["sha256"])
     testcase.assertEqual("NOT_RUN", manifest["runtime_validation"])
 ```
 
-Run RED; expected: manifests do not yet exist.
+- [ ] **Step 5: Generate manifests entirely from observed records**
 
-- [ ] **Step 5: Generate manifests from observed records, never from template strings**
-
-Create a local script during execution (or a one-shot Python command) that loads the selected candidate receipt and rights-review record, reads the exported file, computes both hashes, and builds the manifest dictionary. The builder contract is:
+Use this builder; inputs come from selected receipts, rights records, and actual export files:
 
 ```python
-def build_manifest(*, asset_id, role, decision_ids, source_record, rights_record,
-                   export_path, export_format, width, height, alpha,
-                   import_profile, used_in_screens):
-    source_file_id = source_record["file_id"]
-    source_sha = source_record["sha256"]
-    license_status = rights_record["status"]
-    evidence = rights_record["evidence"]
-    assert source_file_id
-    assert SHA_RE.fullmatch(source_sha)
-    assert license_status in ALLOWED_RESOLVED_LICENSE
-    assert evidence
+def build_manifest(*, asset_id, role, decisions, source, rights, export_path,
+                   export_format, width, height, alpha, import_profile, screens):
+    assert source["file_id"]
+    assert SHA_RE.fullmatch(source["sha256"])
+    assert rights["status"] in RESOLVED_LICENSE
+    assert rights["evidence"]
     export_sha = sha256_file(ROOT / export_path)
     return {
         "schema_version": 1,
         "asset_id": asset_id,
         "role": role,
-        "decision_ids": decision_ids,
+        "decision_ids": decisions,
         "source": {
-            "storage": "EXTERNAL_LIBRARY",
-            "file_id_or_path": source_file_id,
-            "sha256": source_sha,
-            "tool": source_record["tool"],
-            "owner": source_record["owner"],
+            "storage": source["storage"],
+            "file_id_or_path": source["file_id"],
+            "sha256": source["sha256"],
+            "tool": source["tool"],
+            "owner": source["owner"],
             "prompt_or_brief_path": "docs/planning/visual/FIRST_SESSION_IMAGE_BATCH_01_BRIEF.md",
-            "parent_asset_ids": source_record.get("parent_asset_ids", []),
+            "parent_asset_ids": source.get("parent_asset_ids", [])
         },
         "export": {
-            "file_path": str(export_path),
-            "sha256": export_sha,
-            "format": export_format,
-            "width": width,
-            "height": height,
-            "alpha": alpha,
-            "import_profile": import_profile,
+            "file_path": str(export_path), "sha256": export_sha, "format": export_format,
+            "width": width, "height": height, "alpha": alpha, "import_profile": import_profile
         },
         "license": {
-            "status": license_status,
-            "evidence": " | ".join(evidence),
-            "credit_required": rights_record["credit_required"],
-            "modification_allowed": rights_record["modification_allowed"],
-            "redistribution_allowed": rights_record["redistribution_allowed"],
+            "status": rights["status"], "evidence": " | ".join(rights["evidence"]),
+            "credit_required": rights["credit_required"],
+            "modification_allowed": rights["modification_allowed"],
+            "redistribution_allowed": rights["redistribution_allowed"]
         },
         "status": "APPROVED_RUNTIME_CANDIDATE",
         "approved_by": "USER_VISUAL_SELECTION",
         "approved_at": "2026-08-20",
-        "used_in_screens": used_in_screens,
-        "runtime_validation": "NOT_RUN",
+        "used_in_screens": screens,
+        "runtime_validation": "NOT_RUN"
     }
 ```
 
-For project-authored SVGs, source storage/path/tool/owner come from the authored SVG and the symbol-direction review, with the same evidence-driven rights requirement; do not fabricate Library IDs for SVGs.
+For project-authored SVGs, use repository path + file SHA + authored-tool/owner evidence; never invent Library IDs.
 
-- [ ] **Step 6: Validate every manifest and perform a marker scan**
-
-Run the Python contract and additionally:
+- [ ] **Step 6: Validate manifests and scan for template markers**
 
 ```bash
+python -m unittest tests.test_first_session_image_batch_contract -v
 python - <<'PY'
 from pathlib import Path
 import re
-bad = re.compile(r'(actual_|replace_me|example_sha|example_file_id)', re.I)
+marker = re.compile(r'(replace_me|example_sha|example_file_id|__fill__)', re.I)
 for path in Path('assets/manifests').glob('*.json'):
-    text = path.read_text(encoding='utf-8')
-    if bad.search(text):
-        raise SystemExit(f'unresolved marker in {path}')
+    if marker.search(path.read_text(encoding='utf-8')):
+        raise SystemExit(f'manifest marker found: {path}')
 print('manifest marker scan: PASS')
 PY
 ```
 
-- [ ] **Step 7: Update Asset License Ledger with observed values only**
+- [ ] **Step 7: Update Asset License Ledger truthfully and commit**
 
-Increase counts only for records actually created. Runtime verified/project-approved counts remain unchanged at this point.
-
-- [ ] **Step 8: Commit runtime candidates**
+Runtime verified/project-approved counts remain unchanged.
 
 ```bash
 git add docs/planning/visual/first_session_image_batch_01_rights_review.json assets/art/backgrounds assets/art/characters assets/art/ui/glyphs assets/art/ui/lens assets/art/ui/result assets/manifests docs/ASSET_LICENSE_LEDGER.md tests/test_first_session_image_batch_contract.py
@@ -640,60 +586,55 @@ git commit -m "feat(art): export first-session runtime asset candidates"
 
 ---
 
-### Task 7: Godot import verification and first-session asset gallery evidence
+### Task 7: Godot import verification and asset gallery
 
 **Files:**
 - Create: `src/ui/asset_gallery/first_session_asset_gallery.gd`
 - Create: `src/ui/asset_gallery/first_session_asset_gallery.tscn`
+- Create: `tests/integration/test_first_session_asset_gallery.gd`
 - Create: `tools/capture_first_session_asset_gallery.gd`
 - Create: `.github/workflows/validate-first-session-image-assets.yml`
-- Modify: manifests only after actual import/render checks succeed.
+- Modify: `tests/test_runner.gd`
+- Modify: manifests after real import/render PASS.
 
 **Interfaces:**
-- Consumes: approved runtime candidates.
-- Produces: real Texture2D load evidence + one 1920×1080 GL-compatible gallery PNG; not Human/Device/Full Slice evidence.
+- Produces: Texture2D import evidence + one 1920×1080 GL-compatible gallery PNG; not Human/Device/Full Slice evidence.
 
-- [ ] **Step 1: Add RED checks for gallery files and importability**
+- [ ] **Step 1: Write RED gallery/import tests**
 
-Extend Python contract to require gallery/capture/workflow files. Add `tests/integration/test_first_session_asset_gallery.gd` and register it in `tests/test_runner.gd`. The suite loads every runtime export path from its manifest and asserts returned resources are non-null Texture2D objects.
+Register `test_first_session_asset_gallery.gd`. Load every manifest export path and assert a non-null `Texture2D` after Godot import.
 
-- [ ] **Step 2: Create the inspection gallery scene**
+- [ ] **Step 2: Create gallery scene**
 
-Use `GrimoireThemeFactory.create_theme()` and live Labels. Layout:
-
+Use `GrimoireThemeFactory.create_theme()` and live labels:
 ```text
-left top: greenhouse background fit preview
-right top: classroom background fit preview
-lower left: Maren portrait on neutral Navy plate
-lower center: Nea source on neutral plate
+left top: greenhouse fit preview
+right top: classroom fit preview
+lower left: Maren on Navy inspection plate
+lower center: Nea on Navy inspection plate
 lower right: glyph 3 + Lens 4 + Result 5 icon grid
 ```
 
-No functional game UI is baked into art or implied by this gallery.
+- [ ] **Step 3: Capture deterministic 1920×1080 evidence**
 
-- [ ] **Step 3: Create deterministic 1920×1080 capture**
-
-Reuse the existing SubViewport pattern: fresh scene, `Vector2i(1920, 1080)`, five process frames, `RenderingServer.force_draw`, save to `build/visual/first-session-asset-gallery.png`, fail on dimension mismatch or file size under 20 KB.
+Reuse SubViewport + five frames + `RenderingServer.force_draw`; save `build/visual/first-session-asset-gallery.png`; fail on dimension mismatch or file size <20 KB.
 
 - [ ] **Step 4: Create dedicated CI**
 
-Workflow sequence:
-
 ```text
-Python manifest/asset contract
+Python contract
 → Godot 4.7.1 setup
 → --headless --import
 → full custom test runner
-→ xvfb GL-compatibility gallery capture
-→ assert gallery PNG non-empty
-→ upload gallery PNG + import/test/capture logs
+→ xvfb GL-compatible gallery capture
+→ PNG/log upload
 ```
 
-- [ ] **Step 5: Promote import-successful manifests only to `RUNTIME_VERIFIED`**
+- [ ] **Step 5: Promote only successful imports to `RUNTIME_VERIFIED`**
 
-After exact checks succeed, set `runtime_validation = PASS` and `status = RUNTIME_VERIFIED`. Do not set `PROJECT_ASSET_APPROVED` in this task.
+Set `runtime_validation = PASS`, `status = RUNTIME_VERIFIED`; do not set `PROJECT_ASSET_APPROVED`.
 
-- [ ] **Step 6: Commit runtime evidence**
+- [ ] **Step 6: Commit evidence**
 
 ```bash
 git add src/ui/asset_gallery tests/integration/test_first_session_asset_gallery.gd tests/test_runner.gd tools/capture_first_session_asset_gallery.gd .github/workflows/validate-first-session-image-assets.yml assets/manifests
@@ -702,24 +643,22 @@ git commit -m "test(art): verify first-session runtime assets"
 
 ---
 
-### Task 8: Runtime-rendered user approval, five-pass closure, merge, and Notion sync
+### Task 8: Runtime-rendered approval, adversarial closure, merge, and Notion sync
 
 **Files/Systems:**
 - Create: `docs/planning/FIRST_SESSION_IMAGE_BATCH_01_ADVERSARIAL_REVIEW_2026-08-20.md`
 - Create: `docs/planning/sync/GR-SYNC-20260820-34-FIRST-SESSION-IMAGE-ASSETS.md`
-- Modify: manifests to `PROJECT_ASSET_APPROVED` only after explicit approval of the real Godot-rendered gallery.
-- Update: Notion Asset Library records and TASK-13.
+- Modify: manifests only after explicit user approval of the Godot-rendered gallery.
+- Update: Notion Asset Library + TASK-13.
 
 **Interfaces:**
-- Produces: truthfully approved first-session runtime asset set + merged SHA + source/runtime traceability.
+- Produces: project-approved first-session runtime asset set + merged SHA + complete provenance.
 
-- [ ] **Step 1: Present the actual Godot-rendered gallery to the user**
+- [ ] **Step 1: Present the real Godot-rendered gallery**
 
-Ask approval of the imported/exported assets. If an asset needs revision, return to its owning generation/source task; do not silently patch other assets to compensate.
+If an asset is rejected, return to its owning source task. Do not compensate by silently editing other assets.
 
 - [ ] **Step 2: Promote only explicitly approved assets**
-
-For each approved manifest set:
 
 ```text
 status = PROJECT_ASSET_APPROVED
@@ -727,40 +666,38 @@ runtime_validation = PASS
 approved_by = USER_RUNTIME_VISUAL_APPROVAL
 ```
 
-Rejected assets remain `REVISION_REQUIRED` or `REJECTED` independently.
-
 - [ ] **Step 3: Adversarial pass 1 — AI artifact/consistency**
 
-Review anatomy, pseudo-text, repeated nonsensical architecture, lighting/perspective, Maren identity, Nea silhouette/palette, and cross-scene style cohesion.
+Inspect anatomy, pseudo-text, repeated architecture, perspective/light, Maren continuity, Nea silhouette/palette, cross-scene cohesion.
 
 - [ ] **Step 4: Pass 2 — gameplay readability**
 
-Verify backgrounds preserve quieter play/read zones; icons distinguish semantics at 16/24/32/48; FLOW/FOCUS/DISPERSE remain distinct without hue.
+Check quiet play/read zones; icon readability at 16/24/32/48; FLOW/FOCUS/DISPERSE without hue dependence.
 
 - [ ] **Step 5: Pass 3 — rights/provenance**
 
-Every approved asset must trace source ID/path + SHA + brief/tool + rights evidence + export SHA. Any missing link blocks final approval.
+Every approved asset must trace source ID/path + source SHA + brief/tool + rights evidence + export SHA.
 
 - [ ] **Step 6: Pass 4 — scope/reuse**
 
-Verify no Festival batch, extra NPC portraits, growth forms, speculative extra backgrounds, or unconsumed VFX. Verify layer provenance remains truthful.
+Verify no Festival batch, extra NPC portraits, growth forms, speculative extra backgrounds, or unconsumed VFX; verify layer provenance.
 
 - [ ] **Step 7: Pass 5 — evidence overclaim**
 
-Runtime import/render PASS is not Human playtest, physical-device, performance, accessibility, emotion/fun, or Full Slice PASS. Keep those labels `NOT_RUN`.
+Runtime import/render PASS is not Human playtest, device, accessibility, performance, emotion/fun, or Full Slice PASS. Those remain `NOT_RUN`.
 
 - [ ] **Step 8: Open PR and require exact-head checks**
 
-Require the dedicated image asset workflow plus all applicable Planning/Visual/Toolchain/Star workflows. Inspect changed files and review threads. Do not touch unrelated active PRs.
+Require dedicated asset CI and all applicable Planning/Visual/Toolchain/Star workflows. Inspect changed files/review threads. Do not touch unrelated active PRs.
 
-- [ ] **Step 9: Squash merge with expected head SHA after clean readback**
+- [ ] **Step 9: Squash merge with expected head SHA**
 
-Re-read GRIMOIRE `main` after merge and record the merge SHA in Sync34.
+Re-read GRIMOIRE `main` and record merge SHA in Sync34.
 
 - [ ] **Step 10: Sync Notion `ASSET LIBRARY · Master`**
 
-Create/update one record per approved runtime asset with Name, Asset ID, Category, Record Type `ASSET`, Status `APPROVED`, Approved checked, Reuse classification, Source, Hash, Rights/License, Implementation Path, Prompt/brief reference, Project relation, and Last Synced. Concept direction sheets remain reference records or are omitted when they have no reusable value.
+For every approved runtime asset, update Name, Asset ID, Category, Record Type `ASSET`, Status `APPROVED`, Approved checkbox, Reuse classification, Source, Hash, Rights/License, Implementation Path, brief reference, Project relation, Last Synced. Concept sheets remain reference records only when they have reuse value.
 
-- [ ] **Step 11: Close TASK-13 only when both plans are complete**
+- [ ] **Step 11: Close TASK-13 only after both implementation plans complete**
 
-Record Component Sheet merged SHA, image asset merged SHA, selected asset IDs, and remaining `NOT_RUN` boundaries. Mark TASK-13 `완료` only when Component Sheets A–D and this image batch are both merged/synced; Human/Device/Performance/Full Slice remain separate follow-up validation work.
+Record Component Sheet merged SHA, image asset merged SHA, selected asset IDs, and all remaining `NOT_RUN` boundaries. TASK-13 becomes `완료` only when Sheets A–D and this image batch are both merged/synced.


### PR DESCRIPTION
## Goal
Add execution-ready implementation plans for the user-approved Component Sheet & Image Production contract.

## Plan split
1. Component Sheets A–D / semantic Godot UI components.
2. First-session image asset candidate → selection → rights/provenance → export → Godot gallery pipeline.

## Existing Solution First
- reuse `GrimoireThemeFactory`
- reuse `StarCircuitBoard`
- preserve Spell Workflow Stage 2/3 ownership
- consume Base RM-VIS contracts structurally without flattening GRIMOIRE identity
- reuse existing 1280×720 GL-render evidence pattern and custom Godot test runner

## Plan quality gates
- TDD RED→GREEN tasks are explicit
- no unresolved TODO/TBD/template IDs/hashes
- image manifests are built from observed candidate receipts and computed SHA values
- rights status is evidence-driven, not pre-assumed
- no Task8 mutation
- Human/Device/Performance/Full Slice remain NOT_RUN

This PR is documentation/planning only; it does not implement UI components or generate image assets.