### PR TITLE
fix: accept equivalent Task8 GitHub origin forms

### DIFF
--- a/tests/test_task8_preservation_observed_reconciliation_prep.py
+++ b/tests/test_task8_preservation_observed_reconciliation_prep.py
@@ -18,6 +18,7 @@ PRIMARY_BRANCH = "feat/task8-spell-use-screen-v2"
 PRIMARY_HEAD = "8c611f601aa98397ed1558e92ab207e0e8347a9b"
 SECONDARY_BRANCH = "task8/spell-use-screen"
 SECONDARY_HEAD = "fcb5dbe1cbbb23ef195633b1f6680f45d46c5a3f"
+CANONICAL_ORIGIN_IDENTITY = "github.com/alsdmlals4-eng/grimoire-"
 
 
 def run_git(cwd: Path, *args: str) -> str:
@@ -71,6 +72,11 @@ class Task8PreservationObservedReconciliationPrepTests(unittest.TestCase):
             "Get-HistoricalWorktreeFingerprint",
             "HISTORICAL_WORKTREE_STATE_CHANGED",
             "historical_worktrees_verified_unchanged",
+            "Convert-GitHubRemoteIdentity",
+            "git config --get remote.origin.url",
+            "origin_configured",
+            "origin_identity",
+            "ORIGIN_IDENTITY_MISMATCH",
         ):
             self.assertIn(token, text)
         for forbidden in (
@@ -151,6 +157,97 @@ class Task8PreservationObservedReconciliationPrepTests(unittest.TestCase):
             self.assertNotEqual(0, completed.returncode)
             self.assertFalse((repo / "reconcile").exists())
             self.assertIn("RECONCILIATION_LINKED_ANCESTOR_FORBIDDEN", completed.stdout + completed.stderr)
+
+    def _run_origin_variant_fixture(self, root: Path, origin_url: str) -> tuple[subprocess.CompletedProcess[str], Path]:
+        pwsh = shutil.which("pwsh")
+        if pwsh is None:
+            self.skipTest("pwsh unavailable")
+
+        remote = root / "remote.git"
+        repo = root / "GRIMOIRE-"
+        reconcile = root / "reconcile"
+        snapshot = root / "snapshot"
+        run_git(root, "init", "--bare", str(remote))
+        run_git(root, "clone", str(remote), str(repo))
+        run_git(repo, "config", "user.email", "task8@example.invalid")
+        run_git(repo, "config", "user.name", "Task8 Fixture")
+        (repo / "project.godot").write_text("[application]\n", encoding="utf-8")
+        run_git(repo, "add", "project.godot")
+        run_git(repo, "commit", "-m", "fixture main")
+        run_git(repo, "branch", "-M", "main")
+        run_git(repo, "push", "-u", "origin", "main")
+        expected_main = run_git(repo, "rev-parse", "HEAD")
+
+        primary = repo / ".worktrees" / "task8-spell-use-screen-v2"
+        secondary = repo / ".worktrees" / "task8-spell-use-screen"
+        primary.parent.mkdir(parents=True, exist_ok=True)
+        run_git(repo, "branch", PRIMARY_BRANCH)
+        run_git(repo, "branch", SECONDARY_BRANCH)
+        run_git(repo, "worktree", "add", str(primary), PRIMARY_BRANCH)
+        run_git(repo, "worktree", "add", str(secondary), SECONDARY_BRANCH)
+        primary_head = run_git(primary, "rev-parse", "HEAD")
+        secondary_head = run_git(secondary, "rev-parse", "HEAD")
+
+        for role, branch, head in (
+            ("primary_v2", PRIMARY_BRANCH, primary_head),
+            ("secondary_original", SECONDARY_BRANCH, secondary_head),
+        ):
+            role_root = snapshot / role
+            role_root.mkdir(parents=True)
+            (role_root / "manifest.json").write_text(
+                json.dumps({"role": role, "branch": branch, "head": head, "copied_files": []}),
+                encoding="utf-8",
+            )
+
+        run_git(repo, "remote", "set-url", "origin", origin_url)
+        run_git(repo, "config", f"url.{remote}.insteadOf", origin_url)
+
+        env = os.environ.copy()
+        env["CI"] = "true"
+        env["TASK8_RECONCILIATION_FIXTURE"] = "1"
+        completed = subprocess.run(
+            [
+                pwsh, "-NoProfile", "-NonInteractive", "-File", str(TOOL),
+                "-Repo", str(repo),
+                "-SnapshotRoot", str(snapshot),
+                "-ExpectedMain", expected_main,
+                "-ReconciliationPath", str(reconcile),
+                "-FixtureIdentityOverride",
+                "-ExpectedPrimaryHead", primary_head,
+                "-ExpectedSecondaryHead", secondary_head,
+            ],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        return completed, reconcile
+
+    def test_equivalent_github_origin_forms_are_accepted_as_one_repository_identity(self) -> None:
+        variants = (
+            "https://github.com/alsdmlals4-eng/GRIMOIRE-.git",
+            "git@github.com:alsdmlals4-eng/GRIMOIRE-.git",
+            "ssh://git@github.com/alsdmlals4-eng/GRIMOIRE-.git",
+        )
+        for origin_url in variants:
+            with self.subTest(origin_url=origin_url), tempfile.TemporaryDirectory() as temporary:
+                completed, reconcile = self._run_origin_variant_fixture(Path(temporary), origin_url)
+                self.assertEqual(0, completed.returncode, completed.stderr)
+                receipt = json.loads(completed.stdout)
+                self.assertEqual(origin_url, receipt["origin_configured"])
+                self.assertEqual(CANONICAL_ORIGIN_IDENTITY, receipt["origin_identity"])
+                self.assertTrue(reconcile.is_dir())
+
+    def test_different_github_repository_is_rejected_even_in_fixture_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            completed, reconcile = self._run_origin_variant_fixture(
+                Path(temporary),
+                "https://github.com/alsdmlals4-eng/NOT-GRIMOIRE.git",
+            )
+            self.assertNotEqual(0, completed.returncode)
+            self.assertFalse(reconcile.exists())
+            self.assertIn("ORIGIN_IDENTITY_MISMATCH", completed.stdout + completed.stderr)
 
     def test_fixture_creates_clean_reconciliation_worktree_without_touching_historical_worktrees(self) -> None:
         pwsh = shutil.which("pwsh")

--- a/tools/task8_prepare_clean_reconciliation.ps1
+++ b/tools/task8_prepare_clean_reconciliation.ps1
@@ -26,7 +26,7 @@ $PrimaryRelative = '.worktrees/task8-spell-use-screen-v2'
 $SecondaryRelative = '.worktrees/task8-spell-use-screen'
 $DefaultPrimaryHead = '8c611f601aa98397ed1558e92ab207e0e8347a9b'
 $DefaultSecondaryHead = 'fcb5dbe1cbbb23ef195633b1f6680f45d46c5a3f'
-$ExpectedOrigin = 'https://github.com/alsdmlals4-eng/GRIMOIRE-'
+$ExpectedOriginIdentity = 'github.com/alsdmlals4-eng/grimoire-'
 
 function Stop-WithCode {
     param([string]$Code)
@@ -34,10 +34,10 @@ function Stop-WithCode {
     exit 2
 }
 
+$FixtureGate = $FixtureIdentityOverride.IsPresent -and ($env:CI -eq 'true') -and ($env:TASK8_RECONCILIATION_FIXTURE -eq '1')
 $OverrideRequested = ($ExpectedPrimaryHead -ne $DefaultPrimaryHead) -or ($ExpectedSecondaryHead -ne $DefaultSecondaryHead)
-if ($OverrideRequested) {
-    $FixtureGate = $FixtureIdentityOverride.IsPresent -and ($env:CI -eq 'true') -and ($env:TASK8_RECONCILIATION_FIXTURE -eq '1')
-    if (-not $FixtureGate) { Stop-WithCode -Code 'IDENTITY_OVERRIDE_FORBIDDEN' }
+if ($OverrideRequested -and -not $FixtureGate) {
+    Stop-WithCode -Code 'IDENTITY_OVERRIDE_FORBIDDEN'
 }
 
 function Normalize-PathKey {
@@ -105,6 +105,36 @@ function Get-GitOne {
     $Value = @(Invoke-GitText -WorkingDirectory $WorkingDirectory -Arguments $Arguments)
     if ($Value.Count -ne 1) { Stop-WithCode -Code 'GIT_IDENTITY_UNAVAILABLE' }
     return $Value[0].Trim()
+}
+
+function Convert-GitHubRemoteIdentity {
+    param([string]$Remote)
+
+    if ([string]::IsNullOrWhiteSpace($Remote)) { return $null }
+    $Value = $Remote.Trim()
+    $RepositoryPath = $null
+
+    if ($Value -match '^git@github\.com:(?<path>[^?#]+)$') {
+        $RepositoryPath = $Matches['path']
+    }
+    else {
+        $Uri = $null
+        if (-not [System.Uri]::TryCreate($Value, [System.UriKind]::Absolute, [ref]$Uri)) { return $null }
+        if ($Uri.Host.ToLowerInvariant() -ne 'github.com') { return $null }
+        if ($Uri.Scheme.ToLowerInvariant() -notin @('https', 'ssh')) { return $null }
+        if (-not [string]::IsNullOrEmpty($Uri.Query) -or -not [string]::IsNullOrEmpty($Uri.Fragment)) { return $null }
+        if ($Uri.Scheme.ToLowerInvariant() -eq 'ssh' -and -not [string]::IsNullOrEmpty($Uri.UserInfo) -and $Uri.UserInfo -ne 'git') { return $null }
+        if ($Uri.Scheme.ToLowerInvariant() -eq 'https' -and -not [string]::IsNullOrEmpty($Uri.UserInfo)) { return $null }
+        $RepositoryPath = $Uri.AbsolutePath.Trim('/')
+    }
+
+    $RepositoryPath = ($RepositoryPath -replace '\\', '/').Trim('/')
+    if ($RepositoryPath.EndsWith('.git', [System.StringComparison]::OrdinalIgnoreCase)) {
+        $RepositoryPath = $RepositoryPath.Substring(0, $RepositoryPath.Length - 4)
+    }
+    $Segments = @($RepositoryPath.Split('/') | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    if ($Segments.Count -ne 2) { return $null }
+    return ('github.com/{0}/{1}' -f $Segments[0], $Segments[1]).ToLowerInvariant()
 }
 
 function Get-IndexHash {
@@ -234,8 +264,15 @@ $SecondaryHistoricalPath = Join-Path $ResolvedRepo $SecondaryRelative
 $PrimaryBefore = Get-HistoricalWorktreeFingerprint -Path $PrimaryHistoricalPath -ExpectedBranch $PrimaryBranch -ExpectedHead $ExpectedPrimaryHead
 $SecondaryBefore = Get-HistoricalWorktreeFingerprint -Path $SecondaryHistoricalPath -ExpectedBranch $SecondaryBranch -ExpectedHead $ExpectedSecondaryHead
 
-$Origin = Get-GitOne -WorkingDirectory $ResolvedRepo -Arguments @('remote', 'get-url', 'origin')
-if (-not $FixtureIdentityOverride.IsPresent -and $Origin.TrimEnd('/') -ne $ExpectedOrigin.TrimEnd('/')) { Stop-WithCode -Code 'ORIGIN_IDENTITY_MISMATCH' }
+# Read the configured value equivalent to: git config --get remote.origin.url
+$OriginConfigured = Get-GitOne -WorkingDirectory $ResolvedRepo -Arguments @('config', '--get', 'remote.origin.url')
+$OriginIdentity = Convert-GitHubRemoteIdentity -Remote $OriginConfigured
+if ($null -eq $OriginIdentity) {
+    if (-not $FixtureGate) { Stop-WithCode -Code 'ORIGIN_IDENTITY_MISMATCH' }
+}
+elseif ($OriginIdentity -ne $ExpectedOriginIdentity) {
+    Stop-WithCode -Code 'ORIGIN_IDENTITY_MISMATCH'
+}
 
 Push-Location $ResolvedRepo
 try {
@@ -288,6 +325,8 @@ $Receipt = [ordered]@{
     repository = $ResolvedRepo
     snapshot_root = $ResolvedSnapshot
     expected_main = $ExpectedMain
+    origin_configured = $OriginConfigured
+    origin_identity = $OriginIdentity
     origin_main = $OriginMain
     reconciliation_path = $ReconciliationFull
     branch = $NewBranch


### PR DESCRIPTION
## Goal
Fix the user-machine Task8 clean-reconciliation failure `ORIGIN_IDENTITY_MISMATCH` without weakening repository identity or recovery safety. Equivalent GitHub HTTPS/SSH spellings of the same repository are accepted; a different repository is still rejected.

## Observed user-machine failure
The merged #163 tool at project main `6503f3db26b1939d6f20313f16bf8367d8e982b3` was downloaded and run against the preserved Task8 snapshot. It stopped fail-closed at:

`ORIGIN_IDENTITY_MISMATCH`

No reconciliation worktree was created by that failed run.

## Root cause
The #163 implementation compared `git remote get-url origin` to one literal string:

`https://github.com/alsdmlals4-eng/GRIMOIRE-`

That confuses **transport spelling** with **repository identity**. Equivalent valid forms such as HTTPS with `.git`, scp-style SSH, or `ssh://` can identify the same GitHub repository. In addition, `git remote get-url` can reflect Git URL rewrite rules, while this gate needs the configured origin identity.

The fix reads the configured value with the equivalent of `git config --get remote.origin.url`, canonicalizes supported GitHub HTTPS/SSH forms to `github.com/owner/repo`, removes only an optional `.git` suffix, and compares that canonical identity to `github.com/alsdmlals4-eng/grimoire-`.

## TDD receipt
### RED
Exact test-only head: `74640a12c1df3712e43d745387b0ca5df49660d1`

Validate Spell Workflow Current-State Sync run `32735034563`:
- 33 tests executed;
- existing recovery/preservation behavior remained intact;
- new origin contract failed as intended with 2 failures + 3 errors;
- equivalent GitHub forms did not expose canonical origin evidence;
- a different GitHub repository incorrectly passed under fixture override;
- `Convert-GitHubRemoteIdentity` did not yet exist.

### GREEN
Exact final head: `d461c6c133f246021647264034426be71e824d39`

Validate Spell Workflow Current-State Sync run `32735287397`:
- **33 tests / 0 failures / OK**;
- HTTPS `.git`, scp-style SSH, and `ssh://git@github.com/...` equivalents all pass as the same repository identity;
- a different GitHub repository fails `ORIGIN_IDENTITY_MISMATCH` even in the explicit CI fixture mode;
- all previous path/snapshot/historical-worktree tests remain green.

## Final changed paths
Exactly two:
- `tests/test_task8_preservation_observed_reconciliation_prep.py`
- `tools/task8_prepare_clean_reconciliation.ps1`

Product/runtime overlap: **0**. No `src/**`, `data/**`, `assets/**`, `.gd`, `.tscn`, `.tres`, `.res`, or `project.godot` mutation.

## Security / recovery boundary
- Supported production identities are only GitHub HTTPS/SSH forms resolving to exactly `github.com/alsdmlals4-eng/grimoire-`.
- HTTPS credentials/userinfo, unsupported hosts/schemes, malformed extra path segments, or a different GitHub repository fail closed.
- Filesystem remotes remain permitted only inside the pre-existing explicit CI fixture gate (`CI=true` + `TASK8_RECONCILIATION_FIXTURE=1` + switch).
- A parsed GitHub repository with the wrong identity fails even inside that fixture gate.
- `ExpectedMain` exact-SHA verification after fetch remains unchanged.
- external snapshot manifest/hash verification remains unchanged.
- reconciliation path/snapshot/reparse-point guards remain unchanged.
- historical Task8 branch/HEAD/status/index/content pre/post fingerprint verification remains unchanged.
- no pull/reset/restore/clean/stash/rebase/checkout was introduced.

Success receipt now additionally exposes:
- `origin_configured`
- `origin_identity`

These are evidence fields only; they do not promote Task8 product or runtime state.

## Exact-head workflows
Final `d461c6c…`:
- Validate Spell Workflow Current-State Sync — `32735287397` — SUCCESS; **33 tests / OK**
- Validate GRIMOIRE planning and Base v9.4.3 — `32735287444` — SUCCESS
- Validate Godot Authoring and GUT Authority Gate — `32735287648` — SUCCESS
- Validate Star Physical Validation Pack — `32735287547` — SUCCESS
- Validate Godot 4.7.1 toolchain — `32735287462` — SUCCESS
- Validate Star Circuit Runtime POC — `32735287550` — SUCCESS
- Validate Component Sheet Pack — `32735287463` — SUCCESS
- GUT Formal Adoption Validation — `32735287523` — SKIPPED / path-non-applicable; not promoted to PASS.

## Fresh authority readback
- GRIMOIRE main before merge: `6503f3db26b1939d6f20313f16bf8367d8e982b3`
- latest Base main: `862938478cfea6c9db16691900c9c4fdc464f9ff`; its latest change closes BCP-2026-030 and does not conflict with Task8 recovery/origin handling.
- Google Sheet fresh readback still shows v4.5-era/main/Task8 values; under v4.8 it remains migration-only and receives no new canon writes.
- Task8 product remains UNMERGED; Issue #111 remains OPEN.

## Manual adversarial whole-state review — 5/5 CLEAN
1. **Scope** — only the reconciliation tool + its tests changed; product/runtime overlap 0.
2. **Repository identity** — transport spellings normalize to one exact GitHub owner/repo identity; wrong repo is rejected by executed PowerShell tests.
3. **Fixture/security** — fixture mode cannot bypass a wrong parsed GitHub identity; filesystem fixture remotes require all explicit CI gates.
4. **Recovery invariants** — exact main SHA, snapshot integrity, target path safety, historical worktree fingerprints, and destructive-command prohibitions remain intact.
5. **Lifecycle/current authority** — project main unchanged before merge; #164 is the only open PR; Issue #111 is open; Base/current Sheet boundaries re-read; review threads/reviews are 0; no evidence ceiling was promoted.

New P0/P1 findings after loop 5: **0**.

## Next gate after merge
Actual user-machine clean reconciliation remains **NOT_RUN after this fix**. After merge, rerun the commit-pinned merged tool using the same preserved snapshot and the new post-merge main SHA. Only a receipt containing `TASK8_CLEAN_RECONCILIATION_WORKTREE_READY`, the canonical origin identity, exact main/head, `clean: true`, and `historical_worktrees_verified_unchanged: true` permits the fresh exact-project HiGodot recovery phase.

Ready for normal expected-head merge. No force/ruleset bypass.