### PR TITLE
fix: keep Task8 native git stderr out of PowerShell error stream

### DIFF
--- a/tests/test_task8_preservation_observed_reconciliation_prep.py
+++ b/tests/test_task8_preservation_observed_reconciliation_prep.py
@@ -91,6 +91,17 @@ class Task8PreservationObservedReconciliationPrepTests(unittest.TestCase):
         ):
             self.assertNotIn(forbidden, text)
 
+    def test_native_git_progress_stderr_is_not_merged_into_powershell_error_stream(self) -> None:
+        text = TOOL.read_text(encoding="utf-8")
+        self.assertIn("& git fetch --prune origin", text)
+        self.assertIn("$FetchExit = $LASTEXITCODE", text)
+        self.assertIn("& git worktree add -b $ReconciliationBranch $ReconciliationFull 'origin/main'", text)
+        self.assertIn("$WorktreeExit = $LASTEXITCODE", text)
+        self.assertNotIn("git fetch --prune origin 2>&1", text)
+        self.assertNotIn("git worktree add -b $ReconciliationBranch $ReconciliationFull 'origin/main' 2>&1", text)
+        self.assertNotIn("$FetchOutput", text)
+        self.assertNotIn("$WorktreeOutput", text)
+
     def test_reconciliation_path_inside_snapshot_is_rejected_before_manifest_read(self) -> None:
         pwsh = shutil.which("pwsh")
         if pwsh is None:

--- a/tools/task8_prepare_clean_reconciliation.ps1
+++ b/tools/task8_prepare_clean_reconciliation.ps1
@@ -276,8 +276,8 @@ elseif ($OriginIdentity -ne $ExpectedOriginIdentity) {
 
 Push-Location $ResolvedRepo
 try {
-    # git fetch is the only source-repository synchronization action in this tool.
-    $FetchOutput = @(& git fetch --prune origin 2>&1)
+    # Keep native Git stderr separate from the PowerShell error stream. Windows PowerShell 5.1 can promote normal progress stderr into NativeCommandError when merged with 2>&1 under ErrorActionPreference=Stop.
+    & git fetch --prune origin
     $FetchExit = $LASTEXITCODE
     if ($FetchExit -ne 0) { Stop-WithCode -Code 'ORIGIN_FETCH_FAILED' }
 }
@@ -300,7 +300,7 @@ if (-not (Test-Path -LiteralPath $Parent -PathType Container)) { New-Item -ItemT
 
 Push-Location $ResolvedRepo
 try {
-    $WorktreeOutput = @(& git worktree add -b $ReconciliationBranch $ReconciliationFull 'origin/main' 2>&1)
+    & git worktree add -b $ReconciliationBranch $ReconciliationFull 'origin/main'
     $WorktreeExit = $LASTEXITCODE
     if ($WorktreeExit -ne 0) { Stop-WithCode -Code 'RECONCILIATION_WORKTREE_CREATE_FAILED' }
 }

--- a/tools/task8_prepare_clean_reconciliation.ps1
+++ b/tools/task8_prepare_clean_reconciliation.ps1
@@ -276,8 +276,8 @@ elseif ($OriginIdentity -ne $ExpectedOriginIdentity) {
 
 Push-Location $ResolvedRepo
 try {
-    # Keep native Git stderr separate from the PowerShell error stream. Windows PowerShell 5.1 can promote normal progress stderr into NativeCommandError when merged with 2>&1 under ErrorActionPreference=Stop.
-    & git fetch --prune origin
+    # Keep native Git stderr separate from the PowerShell error stream. Windows PowerShell 5.1 can promote normal progress stderr into NativeCommandError when merged with 2>&1 under ErrorActionPreference=Stop. Suppress stdout only so the final stdout remains JSON-only.
+    & git fetch --prune origin >$null
     $FetchExit = $LASTEXITCODE
     if ($FetchExit -ne 0) { Stop-WithCode -Code 'ORIGIN_FETCH_FAILED' }
 }
@@ -300,7 +300,7 @@ if (-not (Test-Path -LiteralPath $Parent -PathType Container)) { New-Item -ItemT
 
 Push-Location $ResolvedRepo
 try {
-    & git worktree add -b $ReconciliationBranch $ReconciliationFull 'origin/main'
+    & git worktree add -b $ReconciliationBranch $ReconciliationFull 'origin/main' >$null
     $WorktreeExit = $LASTEXITCODE
     if ($WorktreeExit -ne 0) { Stop-WithCode -Code 'RECONCILIATION_WORKTREE_CREATE_FAILED' }
 }


### PR DESCRIPTION
## Goal
Fix the user-machine Task8 clean-reconciliation failure where Windows PowerShell 5.1 promoted normal native Git progress stderr (`From https://...`) into `NativeCommandError` because the script merged stderr into the PowerShell error stream with `2>&1` under `$ErrorActionPreference='Stop'`.

## Observed user-machine failure
Merged tool from project main `0998d65d3776b3a728725023f98da4980580ea18` reached `git fetch --prune origin` and stopped at the native fetch line with:
- normal Git progress beginning `From https://github.com/alsdmlals4-eng/GRIMOIRE-`
- `FullyQualifiedErrorId : NativeCommandError`

The run did not reach exact `origin/main` verification or `git worktree add`. Fetch may have updated remote refs before Windows PowerShell terminated; that is an intended non-destructive synchronization effect. No evidence supports a reconciliation worktree having been created by this failed run.

## Root cause
Windows PowerShell 5.1 can wrap redirected native stderr as PowerShell error records. Under `$ErrorActionPreference='Stop'`, the tool's `2>&1` merge converted ordinary Git progress stderr into a terminating `NativeCommandError` even when Git itself was not reporting a non-zero process exit.

The same vulnerable pattern existed on both `git fetch` and `git worktree add`.

The safe behavior is:
- keep native stderr separate from the PowerShell error stream;
- suppress native stdout only, so the final success stdout remains JSON-only;
- continue using `$LASTEXITCODE` as the actual native process success/failure authority.

Final form:
- `& git fetch --prune origin >$null`
- `& git worktree add ... >$null`
- no `2>&1` on those native sync/write commands.

## TDD / debugging evidence
### RED — Windows stderr contract
Test-only head: `9716df76ace8afde58c834332a358e2347acceab`

Current-state run `32737216564`:
- **34 tests total**;
- all previous 33 recovery/preservation/reconciliation tests PASS;
- only `test_native_git_progress_stderr_is_not_merged_into_powershell_error_stream` FAILS because the merged tool still contains `git fetch --prune origin 2>&1` / output captures.

### First GREEN attempt — new regression discovered
Head: `cb2c7345a955a2952fd611b0ccdcce1fd8f61b47`

The `2>&1` merge and capture variables were removed. The new Windows stderr static contract passed, but current-state run `32737476799` failed with 4 integration errors: native `git worktree add` stdout reached the script's stdout and polluted the JSON receipt, causing `json.loads(completed.stdout)` failures.

This established the second requirement: stderr must remain separate **and** native stdout must be suppressed.

### Final GREEN
Exact head: `d96c08a7509f036bfbddcb57141f6c7dab7d48fa`

Current-state run `32737736511`:
- **34 tests / 0 failures / OK**;
- Windows stderr regression PASS;
- equivalent GitHub-origin fixtures PASS;
- wrong-repository rejection PASS;
- clean reconciliation fixture PASS with JSON-only stdout;
- historical dirty worktree integrity fixture PASS;
- path/snapshot/reparse safety fixtures PASS.

## Changed paths
Exactly two:
- `tests/test_task8_preservation_observed_reconciliation_prep.py`
- `tools/task8_prepare_clean_reconciliation.ps1`

Product/runtime overlap: **0**. No `src/**`, `data/**`, `assets/**`, `.gd`, `.tscn`, `.tres`, `.res`, or `project.godot` mutation.

## Recovery/security boundary preserved
Unchanged from merged #164:
- external preservation manifest + copied-file SHA-256 validation;
- exact historical branch/HEAD identities;
- pre/post historical worktree branch/HEAD/status/index/content fingerprints;
- exact configured GitHub repository identity;
- exact fetched `origin/main == ExpectedMain` requirement;
- reconciliation target outside repo/snapshot and outside linked/reparse ancestry;
- no existing reconciliation path/branch overwrite;
- clean new worktree + exact head/branch + `project.godot` verification;
- no pull/reset/restore/clean/stash/rebase/checkout.

The only synchronization action on the source repository remains `git fetch --prune origin`.

## Exact-head workflows
Final `d96c08a…`:
- Validate Spell Workflow Current-State Sync — `32737736511` — SUCCESS; **34 tests / OK**
- Validate GRIMOIRE planning and Base v9.4.3 — `32737736622` — SUCCESS
- Validate Godot Authoring and GUT Authority Gate — `32737736512` — SUCCESS
- Validate Star Physical Validation Pack — `32737736664` — SUCCESS
- Validate Godot 4.7.1 toolchain — `32737736808` — SUCCESS
- Validate Star Circuit Runtime POC — `32737736443` — SUCCESS
- Validate Component Sheet Pack — `32737736506` — SUCCESS
- GUT Formal Adoption Validation — `32737736490` — SKIPPED / path-non-applicable; not promoted to PASS.

## Authority/concurrency readback
- GRIMOIRE main before merge: `0998d65d3776b3a728725023f98da4980580ea18`
- latest Base main: `862938478cfea6c9db16691900c9c4fdc464f9ff`
- open GRIMOIRE PRs: #165 only
- Issue #111: OPEN
- review threads / reviews: 0
- Google Sheet fresh readback still exposes v4.5-era/main/Task8 values; under v4.8 it remains migration-only and receives no new canon writes.
- Base has unrelated open PRs; all are read-only for this task.

## Manual adversarial whole-state review — 5/5 CLEAN
1. **Scope** — exactly tool + regression test; product/runtime overlap 0.
2. **Windows stream semantics** — native stderr is not merged into PowerShell errors; stdout only is suppressed; `$LASTEXITCODE` remains process authority.
3. **Recovery invariants** — origin/main/snapshot/path/historical-worktree guards are unchanged.
4. **Evidence ceiling** — CI proves regression/integration contracts, but actual Windows PowerShell rerun after this fix remains NOT_RUN and is not promoted.
5. **Lifecycle/concurrency** — current main/Base/Sheet/Issue/open-PR/review state freshly re-read; no unrelated PR takeover and no canon/runtime promotion.

New P0/P1 findings after loop 5: **0**.

## Next gate after merge
Rerun the commit-pinned merged tool on the user's Windows GRIMOIRE checkout with the same preserved snapshot and the new post-merge main SHA. Only an actual Windows receipt containing `TASK8_CLEAN_RECONCILIATION_WORKTREE_READY`, exact `origin_main/head`, `clean: true`, and `historical_worktrees_verified_unchanged: true` closes the clean-reconciliation gate.

Ready for normal expected-head merge. No force/ruleset bypass.