### PR TITLE
docs(visual): close visual handoff and lessons

### DIFF
--- a/docs/planning/lessons/2026-08-25-visual-generation-approval-boundary-lessons.md
+++ b/docs/planning/lessons/2026-08-25-visual-generation-approval-boundary-lessons.md
@@ -1,0 +1,77 @@
+# GRIMOIRE Visual Generation Approval Boundary — Problems & Lessons — 2026-08-25
+
+```yaml
+lesson_id: GR-LESSON-VISUAL-20260825-01
+status: PROJECT_LESSON_AND_BASE_PROMOTION_CANDIDATE
+implementation_authority: NONE
+```
+
+## Problems
+
+1. A visually strong generated screen can silently drift from mechanic canon.
+2. `좋다/맘에 든다` for an image does not automatically approve embedded mechanics, copy, character identity, numbers, or fiction.
+3. Historical wording can revive superseded mechanics if a brief follows the first keyword match instead of Decision supersession.
+4. Rejected directions must be stored as negative knowledge or later workers can repeat them.
+5. Notion upload completion requires native-attachment readback, not only successful temporary transport.
+6. Cross-chat handoff must preserve the user's current work-mode boundary.
+7. Repository connector writes must name the task branch explicitly. During this closeout one approved documentation file was accidentally written to default `main` because `branch` was omitted; content was valid but the write path violated PR-first process.
+
+## Lessons
+
+For mechanic-bearing generated visuals:
+
+```text
+fresh domain canon read
+→ text brief with KEEP / MUST_SHOW / MUST_NOT_SHOW
+→ explicit user brief approval
+→ bounded image generation
+→ semantic drift review
+→ scoped approval
+→ durable reference sync/readback
+→ cross-chat handoff
+```
+
+Review generated images as independent claim surfaces: `STYLE`, `COMPOSITION`, `CHARACTER_PRESENTATION`, `ENVIRONMENT`, `UI_INFORMATION_ARCHITECTURE`, `MECHANIC_SEMANTICS`, `COPY_AND_NUMBERS`, `FICTION_CANON`, `RUNTIME_ASSET_STATUS`.
+
+For GRIMOIRE conflict resolution:
+
+```text
+Stock semantics → typed-glyph Stock owner remains useful
+Circuit topology → GM-STAR-CIRCUIT-MASTERY-BALANCE-01 wins (FIVE_POINT_STAR)
+Workflow timing → GM-SPELL-WORKFLOW-UI-V2-01 + actual coordinator/services win
+```
+
+Negative knowledge:
+
+- 3D-like corridor exploration is rejected for current movement presentation.
+- simpler 2D movement/scene transition is only a direction; exact form still requires discussion.
+- generated names/dialogue/numbers are noncanonical.
+- representative battle screen composition is approved, but its Stock/Circuit/Spell UI is rework-required.
+
+Notion durability rule:
+
+```text
+attach → fetch page → verify native file block → remove temporary transport if used → fetch again → attachment remains
+```
+
+Repository write rule:
+
+```text
+fresh main → create named branch → every create/update names branch → PR → exact-head checks/review → merge/readback
+```
+
+## Base promotion candidate
+
+`SCOPED_GENERATED_VISUAL_APPROVAL_AND_DURABLE_REFERENCE_HANDOFF`
+
+Promote first as a reusable case/proposal, not an unconditional root rule. Candidate obligations:
+
+- domain-canon read before mechanic-bearing visual generation;
+- explicit text brief approval before generation;
+- post-generation semantic drift audit;
+- scoped approval across style/composition/mechanics/copy/fiction/runtime status;
+- rejected/rework-required semantics retained as negative knowledge;
+- canonical workspace attachment/readback verification;
+- handoff preserves approval boundaries and current user work mode.
+
+Evidence ceiling: strongly validated in one active game project and consistent with existing Base handoff/visual-case patterns. Base review decides whether to harden it into a shared guide/skill contract.


### PR DESCRIPTION
## Summary
- adds GR-LESSON-VISUAL-20260825-01 with generated-visual approval-boundary lessons
- records semantic-drift, Notion attachment-readback, negative-knowledge, user-mode handoff, and explicit branch-target lessons
- identifies `SCOPED_GENERATED_VISUAL_APPROVAL_AND_DURABLE_REFERENCE_HANDOFF` as a Base promotion candidate

## Boundary
Documentation/learning only. No Godot/product/Task8 implementation. Existing PR #166 remains read-only. Google Sheets remains migration-only.