### PR TITLE
docs: simplify player-facing spell flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,10 +19,15 @@ orientation: LANDSCAPE_FIXED
 product_stage: DEMO_FIRST_VERTICAL_SLICE
 planning: COMPLETE_FROSTBLOOM_FIRST_SESSION
 implementation: PARTIAL_FOUNDATION
-current_user_work_scope: VISUAL_ASSET_COVERAGE_AND_NEXT_SINGLE_VISUAL_BRIEF
+current_user_work_scope: SPELL_WORKFLOW_PLAYER_FACING_SIMPLIFICATION_AND_VISUAL_ALIGNMENT
 product_implementation_authorized_by_current_user_work_scope: false
 visual_asset_coverage: docs/planning/visual/GRIMOIRE_VISUAL_ASSET_COVERAGE_2026-08-26.json
-visual_generation_state: TEXT_BRIEF_READY_AWAITING_EXPLICIT_USER_GENERATION_APPROVAL
+visual_generation_state: NOT_REQUESTED_AFTER_PLAYER_FLOW_APPROVAL
+product_decision: GM-SPELL-WORKFLOW-UI-V2-01
+product_decision_overlay: docs/planning/SPELL_WORKFLOW_PLAYER_FACING_SIMPLIFICATION_2026-08-26.md
+product_decision_revision: 2026-08-26-PLAYER-FACING-SIMPLIFICATION
+player_facing_spell_flow: GLYPH_TO_SPELL_TO_TARGET_TO_CAST
+player_facing_ux_groups: SPELL_BUILD_AND_SPELL_CAST
 next_product_task: TASK8_SPELL_USE_SCREEN
 next_product_gate: TASK8_PR_PREP_REVERIFY_PENDING
 task8_recovery_state: TASK8_LOCAL_CANDIDATE_PRESERVATION_OBSERVED_PASS
@@ -66,9 +71,10 @@ numeric_status: PLAYTEST_TUNING_REQUIRED
 9. 보존 성공은 제품 호환성·HiGodot readiness·fresh tests를 증명하지 않는다. 다음 gate는 `TASK8_CLEAN_RECONCILIATION_WORKTREE_REQUIRED`다.
 10. `TASK8_LOCAL_WORKTREE_DELTA_RECOVERY_REQUIRED`는 이미 닫힌 **historical compatibility locator**로 보존한다. consumer 검색 가능성 때문에 지우지 않지만 current execution gate로 해석하지 않는다.
 11. `docs/planning/CURRENT_CONFIRMED_DECISIONS.md`와 `CURRENT_UNRESOLVED_GATES.md`의 v4.5-era machine snapshot은 v4.8 migration 이후 **historical compatibility locator**로만 취급한다. 현재 authority는 이 파일 + `START_HERE.md` + `docs/ACTIVE_CONTEXT.md` + v4.8 r5.4 binding이다.
-12. 2026-08-26 `작업재개 → 진행해`의 현재 범위는 **Visual/Image/Asset planning**이다. r5.4 Visual Coverage와 다음 정확히 1장 Text Brief까지 진행하며, Task8/Godot 제품 구현과 실제 이미지 생성은 각각 별도 명시 승인이 필요하다.
-13. `TASK8_SPELL_USE_SCREEN`은 다음 제품 task locator이며 현재 Visual-only 범위의 구현 허가가 아니다.
-14. Visual serial production은 `docs/planning/visual/GRIMOIRE_VISUAL_ASSET_COVERAGE_2026-08-26.json`의 `REUSE / ADAPT / CREATE / DEFER / CUT` 판정을 먼저 읽고, `TEXT_BRIEF → 사용자 명시 승인 → EXACTLY_ONE_RESULT → STOP`을 따른다.
+12. 2026-08-26 사용자는 `GM-SPELL-WORKFLOW-UI-V2-01`의 플레이어 노출을 **글자 → 주문 → 대상 → 시전**으로 단순화하는 방향을 승인했다. 같은 Decision ID의 revision owner는 `docs/planning/SPELL_WORKFLOW_PLAYER_FACING_SIMPLIFICATION_2026-08-26.md`다.
+13. 이번 승인 범위는 기획/Visual 정본 교정이다. Task8/Godot 제품 구현과 추가 이미지 생성은 별도 명시 요청이 필요하다.
+14. `TASK8_SPELL_USE_SCREEN`은 다음 제품 task locator이며 현재 범위의 구현 허가가 아니다.
+15. Visual serial production은 coverage를 먼저 읽고, 새 이미지가 필요할 때만 `TEXT_BRIEF → 사용자 명시 승인 → EXACTLY_ONE_RESULT → STOP`을 따른다.
 
 ## 프로젝트 코어
 
@@ -83,6 +89,20 @@ target_selection: AFTER_CIRCUIT_PREVIEW_BY_KEYWORD
 stock_scope: TYPED_GLYPH_ONLY
 commit: EXPLICIT_EXACTLY_ONCE
 ```
+
+이 내부 코어는 유지한다. 플레이어가 화면에서 먼저 이해하는 표현만 다음처럼 단순화한다.
+
+```text
+글자 → 주문 → 대상 → 시전
+
+주문 만들기
+= 글자 선택·작성 + FIVE_POINT_STAR 회로 조합 + 완성 주문 이름 확인
+
+주문 쓰기
+= 게임 장면에서 대상 지정 + 필요한 최종 Preview + 명시 시전
+```
+
+`Stock / PreparedSpell / Stage2 / Stage3 / Main / Auxiliary`는 내부 구현·데이터·테스트 용어로 유지하되 기본 플레이어 UI의 주 용어로 먼저 가르치지 않는다.
 
 ## Godot 현실
 
@@ -109,6 +129,7 @@ r5.4에서는 project-specific `CODEX_HOME`, 별도 전용 Godot binary, 8001/95
 
 ## Spell Workflow 현재 경계
 
+- current player-facing revision: `docs/planning/SPELL_WORKFLOW_PLAYER_FACING_SIMPLIFICATION_2026-08-26.md`
 - `GR-SYNC-20260811-01-SPELL-WORKFLOW-TASK7-CURRENT-STATE`
 - `TASK7_MERGED_MAIN_VERIFIED`
 - 호환 locator: `TASK8_LOCAL_REFINEMENT_GREEN_UNMERGED_MERGE_GATES_PENDING`
@@ -125,6 +146,14 @@ r5.4에서는 project-specific `CODEX_HOME`, 별도 전용 Godot binary, 8001/95
 - `task8_remote_product_branch: NOT_PRESENT`
 - `task8_remote_product_pr: NONE`
 
+Task mapping:
+
+```text
+Task6 Glyph Drawing → 주문 만들기 / 글자
+Task7 Circuit Placement → 주문 만들기 / 주문 회로 + 완성 주문 이름
+Task8 Spell Use → 주문 쓰기 / 대상 + 시전
+```
+
 `8c611f...`는 PR #131 HiGodot v3.1.4 authority reconciliation commit이며 Task8 제품 코드가 들어 있는 commit이 아니다. Task8 제품 구현은 이 HEAD 위의 uncommitted local delta로 보존됐다.
 
 따라서 제품 구현을 명시적으로 재개할 때 Task8은 다음 순서를 따른다.
@@ -134,6 +163,7 @@ preserved historical candidates
 → separate clean reconciliation worktree from exact fresh origin/main
 → fresh exact-project HiGodot readback
 → primary v2 recovery + secondary parity comparison
+→ player-facing overlay를 기존 Stage3 authority에 thin mapping
 → fresh GUT/Hera/diff/adversarial revalidation
 → stage/commit/push/PR
 → exact-head CI/review
@@ -151,11 +181,20 @@ visual_overlay: GM-VISUAL-DIRECTION-20260825-01
 logo: LOGO_01_FIXED_AS_DEFAULT_VISUAL_DIRECTION
 representative_screens: GM-REPRESENTATIVE-SCREENS-20260825-01
 coverage_owner: docs/planning/visual/GRIMOIRE_VISUAL_ASSET_COVERAGE_2026-08-26.json
-next_single_visual: TYPED_GLYPH_VAULT_STOCK_TO_FIVE_POINT_STAR_TO_PREPARED_SPELL
-image_generation_state: TEXT_BRIEF_READY_AWAITING_EXPLICIT_USER_GENERATION_APPROVAL
+spell_visual_player_terms: GLYPH_COMPLETE_SPELL_NAME_TARGET_CAST
+image_generation_state: NOT_REQUESTED_AFTER_PLAYER_FLOW_APPROVAL
 ```
 
-승인된 Dialogue 구성은 유지한다. Battle/Spell 시안의 분위기·구도는 참고하되 Stock/Circuit/Spell system UI는 current canon에 맞게 재작업한다. 이전 3D-like movement 방향은 거부 상태이며, 이동은 단순 2D 장면 전환/배경/지도 카드 재사용 방향을 따른다.
+승인된 Dialogue 구성은 유지한다. Battle/Spell 시안의 분위기·구도는 참고하되 시스템 UI는 current canon에 맞게 재작업한다. 이전 3D-like movement 방향은 거부 상태이며, 이동은 단순 2D 장면 전환/배경/지도 카드 재사용 방향을 따른다.
+
+Spell Visual은 다음을 추가로 따른다.
+
+- 글자는 세로 패찰·부적·수집 카드보다 **직접 쓰인 문자**로 보여야 한다.
+- 획과 필기감, 빛나는 잉크/마력 흔적을 우선한다.
+- FIVE_POINT_STAR에는 패찰을 꽂기보다 글자를 직접 놓거나 쓰는 느낌을 우선한다.
+- `PreparedSpell`의 기본 플레이어 결과 라벨은 `준비 주문`보다 **완성 주문 / 완성 주문 이름**을 우선한다.
+- 완성 주문 선택 뒤 대상 지정은 가능하면 게임 장면에서 직접 수행하고 필요한 Preview 뒤 `시전`한다.
+- 실제 주문 이름 생성 문법/로컬라이징 알고리즘은 아직 별도 설계 대상이다.
 
 ## 금지
 
@@ -173,6 +212,6 @@ image_generation_state: TEXT_BRIEF_READY_AWAITING_EXPLICIT_USER_GENERATION_APPRO
 
 `GR-SYNC-20260821-34-CANON-AUTHORITY-REALITY-SYNC`와 `GR-SYNC-20260824-35-V4-8-AUTHORITY-SYNC`는 이전 current-authority 교정의 병합 provenance다. 안정된 predecessor PR은 #158이며 current open PR 상태 자체는 live GitHub가 소유한다.
 
-현재 r5.4 전환 및 Visual Coverage는 `GR-SYNC-20260826-36-V4-8-R5-4-VISUAL-COVERAGE`가 추적한다. 해당 current-task PR의 lifecycle은 live GitHub가 소유하며, unrelated PR #166은 read-only다.
+r5.4 Visual Coverage는 `GR-SYNC-20260826-36-V4-8-R5-4-VISUAL-COVERAGE`가 추적한다. 이번 플레이어 노출 간략화는 `GR-SYNC-20260826-37-SPELL-FLOW-PLAYER-FACING`가 추적한다. unrelated PR #166은 read-only다.
 
 현재 v4.8 바인딩은 `docs/contracts/GRIMOIRE_PROJECT_CONTRACT_V4_8_BINDING.md`가 소유한다. v4.5 이하 바인딩은 `HISTORICAL_SUPERSEDED_CURRENT_BINDING`으로 보존한다.

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -23,16 +23,20 @@ workspace_repository_canon: REPOSITORY_STRUCTURED_AND_RUNTIME_CANON
 google_sheets: MIGRATION_ONLY_UNTIL_REMOVAL
 github_actions_decision: GM-PUBLIC-REPO-FREE-GITHUB-ACTIONS-01
 repo_wide_actions_full_sha: PASS
-current_user_work_scope: VISUAL_ASSET_COVERAGE_AND_NEXT_SINGLE_VISUAL_BRIEF
+current_user_work_scope: SPELL_WORKFLOW_PLAYER_FACING_SIMPLIFICATION_AND_VISUAL_ALIGNMENT
 product_implementation_authorized_by_current_user_work_scope: false
 visual_asset_coverage: docs/planning/visual/GRIMOIRE_VISUAL_ASSET_COVERAGE_2026-08-26.json
 visual_asset_coverage_status: CURRENT_PREFLIGHT_COMPLETE
-visual_generation_state: TEXT_BRIEF_READY_AWAITING_EXPLICIT_USER_GENERATION_APPROVAL
+visual_generation_state: NOT_REQUESTED_AFTER_PLAYER_FLOW_APPROVAL
 visual_direction_decision: GM-VISUAL-DIRECTION-20260825-01
 representative_screens_decision: GM-REPRESENTATIVE-SCREENS-20260825-01
 art_style_lock: ART-STYLE-01
 logo_direction: LOGO_01_FIXED_AS_DEFAULT_VISUAL_DIRECTION
 product_decision: GM-SPELL-WORKFLOW-UI-V2-01
+product_decision_overlay: docs/planning/SPELL_WORKFLOW_PLAYER_FACING_SIMPLIFICATION_2026-08-26.md
+product_decision_revision: 2026-08-26-PLAYER-FACING-SIMPLIFICATION
+player_facing_spell_flow: GLYPH_TO_SPELL_TO_TARGET_TO_CAST
+player_facing_ux_groups: SPELL_BUILD_AND_SPELL_CAST
 preserved_runtime_decision: GM-STAR-CIRCUIT-MASTERY-BALANCE-01
 circuit_topology: FIVE_POINT_STAR
 task8_product_unit: TASK8_SPELL_USE_SCREEN
@@ -73,7 +77,7 @@ android_device: NOT_RUN
 
 `v4.8 r5.4 / GM-CONTRACT-V4-8-BINDING-01`이 현재 프로젝트 실행 계약이다. v4.5 이하 binding은 역사 provenance로 보존하며 current authority로 사용하지 않는다. Base의 과거 SHA도 영구 authority가 아니고 새 실질 work unit마다 latest completed Base `main`과 필요한 owner를 다시 읽는다.
 
-이번 `작업재개 → 진행해`는 **Visual/Image/Asset planning continuation**이다. Task8/Godot 제품 구현은 사용자가 구현 작업을 명시적으로 재개하기 전까지 시작하지 않는다. `TASK8_SPELL_USE_SCREEN`은 다음 제품 task locator일 뿐 현재 구현 권한을 뜻하지 않는다.
+2026-08-26 사용자는 `GM-SPELL-WORKFLOW-UI-V2-01`의 **플레이어 노출 흐름 간략화**를 승인했다. 현재 작업은 기획/Visual 정본 교정이며 Task8/Godot 제품 구현은 사용자가 구현 작업을 명시적으로 재개하기 전까지 시작하지 않는다. `TASK8_SPELL_USE_SCREEN`은 다음 제품 task locator일 뿐 현재 구현 권한을 뜻하지 않는다.
 
 ## Workspace authority
 
@@ -90,17 +94,34 @@ Google Sheets
 → 고유 자료 흡수 확인 전 삭제 금지
 ```
 
-Google Sheet는 current state writer가 아니다. 이번 r5.4 Visual preflight에서는 기존 Asset/이미지 inventory의 **고유한 역사 범위만 migration input으로 흡수**하고, current coverage는 GitHub + Notion Visual Bible이 소유한다.
+Google Sheet는 current state writer가 아니다. 현재 Sheet의 과거 `GM-SPELL-WORKFLOW-UI-V2-01` 문구가 새 플레이어 용어보다 오래되어도 신규 canon write로 교정하지 않는다. 새 정본은 GitHub + Notion이며 Sheet는 migration compatibility 자료로만 읽는다.
 
 ## 현재 제품 경계
 
-`GM-SPELL-WORKFLOW-UI-V2-01`의 제품 흐름은 다음이다.
+`GM-SPELL-WORKFLOW-UI-V2-01`의 **플레이어 노출 흐름**은 다음이다.
 
 ```text
-글자 그리기
-→ 회로 배치
-→ 주문 사용
+글자
+→ 주문
+→ 대상
+→ 시전
 ```
+
+화면 경험은 두 덩어리로 묶는다.
+
+```text
+주문 만들기
+= 글자 선택·작성
++ FIVE_POINT_STAR 회로 조합
++ 완성 주문 이름 확인
+
+주문 쓰기
+= 게임 장면에서 대상 지정
++ 필요한 최종 Preview
++ 명시 시전
+```
+
+`Stock / PreparedSpell / Stage2 / Stage3 / Main / Auxiliary`는 구현·데이터·테스트 내부 용어로 계속 유지하지만 기본 플레이어 UI의 주 용어로 먼저 가르치지 않는다. `PreparedSpell`의 기본 플레이어 표현은 **완성 주문 / 완성 주문 이름**, Stage3의 기본 플레이어 표현은 **대상 / 시전**이다.
 
 현재까지 병합된 제품 계층:
 
@@ -111,7 +132,11 @@ Google Sheet는 current state writer가 아니다. 이번 r5.4 Visual preflight�
 - Task 7 / PR #110 — circuit placement workflow screen (`TASK7_MERGED_MAIN_VERIFIED`)
 - PR #151 — Component Sheets A–D + reusable semantic UI pack (`MERGED_MAIN_VERIFIED`)
 
-Task8은 Task5 Stage3 authority의 thin UI consumer이며 새 target/use/Mana/inventory/result/rollback authority를 만들지 않는다.
+내부 authority는 바꾸지 않는다. Task8은 계속 Task5 Stage3 authority의 thin UI consumer이며 새 target/use/Mana/inventory/result/rollback authority를 만들지 않는다. 자동 Target·자동 시전·회로 자동 최적화도 금지한다.
+
+현재 revision owner:
+
+`docs/planning/SPELL_WORKFLOW_PLAYER_FACING_SIMPLIFICATION_2026-08-26.md`
 
 ## 현재 Visual 정본
 
@@ -142,28 +167,23 @@ movement:
 
 - **REUSE**: Logo 01, 승인 스타일, Component Sheets A–D, semantic UI pack, Star UI Kit 계열.
 - **ADAPT**: Dialogue layout, Glyph Drawing, Result/Grimoire, simple 2D transition, core feedback VFX.
-- **CREATE**: Frostbloom environment runtime candidates, first-session character/companion/threat assets, 그리고 현재 가장 큰 시스템-시각 gap인 Stage2 representative visual.
+- **CREATE**: Frostbloom environment runtime candidates, first-session character/companion/threat assets.
 - **DEFER**: Task8 final use screen visual, store key art/platform assets.
 - **CUT**: 새 3D exploration asset family, baked functional text/numbers, Slice용 다중 enemy-wave production.
 
-## 다음 정확히 한 장의 Visual 브리프
+## 현재 Spell UX 시각 방향
 
-현재 가장 가치가 높은 1장은:
+최근 Stage2 시안은 `보관 글자 → 주문 회로 → 준비 주문` 구조와 FIVE_POINT_STAR의 가독성을 검토하는 데 사용됐다. 사용자 피드백으로 세로 패찰/부적 느낌은 폐기하고, **직접 쓰인 마법 글자**를 중심으로 단순화한 표현이 승인됐다.
 
-```text
-Typed Glyph Vault/Stock
-→ FIVE_POINT_STAR Circuit
-→ Prepared Spell
-```
+현재 시각 규칙:
 
-선정 이유:
+1. 글자는 부적·패찰·수집 카드보다 **획이 보이는 직접 쓰인 문자**로 읽혀야 한다.
+2. 회로에는 글자를 패찰째 꽂기보다 **글자를 직접 놓거나 써 넣는 느낌**을 우선한다.
+3. 회로 조합의 가장 중요한 결과 라벨은 `준비 주문`보다 **완성 주문 이름**이다.
+4. 완성 주문 선택 뒤에는 별도 복잡한 대상 화면을 기본 가정하지 않고, 가능하면 게임 장면에서 직접 대상 지정 → 필요한 Preview → **시전**으로 이어간다.
+5. 주문 이름의 실제 생성 문법/로컬라이징 알고리즘은 아직 별도 설계 대상이며 임의로 확정하지 않는다.
 
-1. 승인된 전투/주문 시안의 가장 큰 rework finding이 `Stock / circuit / spell` 의미 축약이었다.
-2. Task6 Glyph Drawing은 이미 구현/참고가 있어 상대적으로 coverage가 높다.
-3. Task8 Stage3 사용 화면은 current main에 없으므로 지금 final visual을 먼저 만들면 재작업 위험이 높다.
-4. Stage2 화면은 현재 정본의 `typed glyph source → center main + 0~5 auxiliary → prepared spell`을 직접 보여주면서 Task8 behavior를 발명하지 않는다.
-
-브리프 상태는 `TEXT_BRIEF_READY_AWAITING_EXPLICIT_USER_GENERATION_APPROVAL`이다. r5.4 규칙에 따라 **이 텍스트 브리프 뒤 자동으로 이미지를 생성하지 않는다.**
+현재 사용자 메시지는 새 이미지 생성 요청이 아니다. 다음 이미지 작업은 fresh text brief와 명시적 생성 요청이 있을 때만 진행한다.
 
 ## Task8 실제 복구 상태
 
@@ -176,7 +196,7 @@ secondary: task8/spell-use-screen@fcb5dbe1cbbb23ef195633b1f6680f45d46c5a3f
 current_execution_subgate: TASK8_CLEAN_RECONCILIATION_WORKTREE_REQUIRED
 ```
 
-이것은 current-main compatibility, fresh HiGodot, GUT/Hera, runtime 또는 제품 병합 증거가 아니다. 이번 Visual work unit에서 Task8 제품 코드는 변경하지 않는다.
+이것은 current-main compatibility, fresh HiGodot, GUT/Hera, runtime 또는 제품 병합 증거가 아니다. 이번 기획/Visual work unit에서 Task8 제품 코드는 변경하지 않는다.
 
 ## Historical compatibility anchors — current gate 아님
 
@@ -213,7 +233,7 @@ Godot/Godot AI의 설치·exact pin·port 정책은 r5.4와 current Base owner�
 
 ## Open PR 경계
 
-새 작업 시작 시 live GitHub를 다시 읽는다. 2026-08-26 r5.4 reconciliation 시작 시점의 open PR은:
+새 작업 시작 시 live GitHub를 다시 읽는다. 2026-08-26 이번 work unit 시작 시점의 open PR은:
 
 - PR #166 `docs: route README to current GRIMOIRE canon` — Draft, `README.md` only, **READ_ONLY other workstream**.
 
@@ -227,6 +247,7 @@ Godot/Godot AI의 설치·exact pin·port 정책은 r5.4와 current Base owner�
 → START_HERE.md
 → docs/ACTIVE_CONTEXT.md
 → docs/contracts/GRIMOIRE_PROJECT_CONTRACT_V4_8_BINDING.md
+→ docs/planning/SPELL_WORKFLOW_PLAYER_FACING_SIMPLIFICATION_2026-08-26.md
 → docs/planning/visual/GRIMOIRE_VISUAL_ASSET_COVERAGE_2026-08-26.json
 → current Visual / domain owner
 → actual code/data/Scene/Resource/Test/runtime evidence
@@ -236,16 +257,17 @@ Godot/Godot AI의 설치·exact pin·port 정책은 r5.4와 current Base owner�
 
 ## 제품 구현을 다시 시작할 때의 순서
 
-현재 Visual work와 별개로, 사용자가 구현을 명시적으로 재개하면 제품 순서는 다음을 유지한다.
+현재 기획/Visual work와 별개로, 사용자가 구현을 명시적으로 재개하면 제품 순서는 다음을 유지한다.
 
 ```text
 1. TASK8_CLEAN_RECONCILIATION_WORKTREE_REQUIRED
 2. fresh exact-project HiGodot readback + primary v2 recovery / secondary parity comparison
-3. fresh Task8 GUT + predecessor/full runner + Hera source-delta + exact-path adversarial review
-4. Task8 product PR / exact-head CI / merge / merged-main readback
-5. Task9 Product Root + responsive/E2E integration
-6. 대표 00~10분 Human Slice
-7. 10~23 → 46분 증거 확장
+3. 새 플레이어 용어 overlay를 Task8 UI에 매핑하고 기존 Stage3 authority와 충돌 없는지 확인
+4. fresh Task8 GUT + predecessor/full runner + Hera source-delta + exact-path adversarial review
+5. Task8 product PR / exact-head CI / merge / merged-main readback
+6. Task9 Product Root + responsive/E2E integration
+7. 대표 00~10분 Human Slice
+8. 10~23 → 46분 증거 확장
 ```
 
 ## 현재 완료로 주장하지 않는 항목
@@ -271,8 +293,9 @@ RUNTIME_VISUAL_COMPLETE_NOT_PROVEN
 2. `START_HERE.md`
 3. `docs/ACTIVE_CONTEXT.md`
 4. `docs/contracts/GRIMOIRE_PROJECT_CONTRACT_V4_8_BINDING.md`
-5. `docs/planning/visual/GRIMOIRE_VISUAL_ASSET_COVERAGE_2026-08-26.json`
-6. `docs/planning/visual/GRIMOIRE_VISUAL_DIRECTION_APPROVAL_2026-08-25.json`
-7. `docs/planning/visual/GRIMOIRE_REPRESENTATIVE_SCREENS_2026-08-25.json`
-8. 현재 목표의 분야별 owner / actual code·Scene·Resource·Test
-9. `CURRENT_*` machine snapshot — historical compatibility lookup only
+5. `docs/planning/SPELL_WORKFLOW_PLAYER_FACING_SIMPLIFICATION_2026-08-26.md`
+6. `docs/planning/visual/GRIMOIRE_VISUAL_ASSET_COVERAGE_2026-08-26.json`
+7. `docs/planning/visual/GRIMOIRE_VISUAL_DIRECTION_APPROVAL_2026-08-25.json`
+8. `docs/planning/visual/GRIMOIRE_REPRESENTATIVE_SCREENS_2026-08-25.json`
+9. 현재 목표의 분야별 owner / actual code·Scene·Resource·Test
+10. `CURRENT_*` machine snapshot — historical compatibility lookup only

--- a/docs/ACTIVE_CONTEXT.md
+++ b/docs/ACTIVE_CONTEXT.md
@@ -12,7 +12,7 @@ historical_contract_binding: GM-CONTRACT-V4-5-BINDING-01
 project_main_authority: LIVE_GITHUB_DEFAULT_BRANCH_READBACK
 current_state_sync_predecessor: GR-SYNC-20260824-35-V4-8-AUTHORITY-SYNC
 authority_sync_pr_predecessor: 158
-current_authority_sync: GR-SYNC-20260826-36-V4-8-R5-4-VISUAL-COVERAGE
+current_authority_sync: GR-SYNC-20260826-37-SPELL-FLOW-PLAYER-FACING
 spell_workflow_predecessor_sync: GR-SYNC-20260811-01-SPELL-WORKFLOW-TASK7-CURRENT-STATE
 task8_continuation_sync: GR-SYNC-20260812-21-TASK8-HANDOFF-BCP
 task8_current_reverify: docs/planning/TASK8_REMOTE_LOCAL_REVERIFY_2026-08-21.md
@@ -22,11 +22,11 @@ adapter_policy: THIN_ADAPTER_DO_NOT_DUPLICATE_BASE_CANON
 base_project_pin: v9.4.3
 planning: COMPLETE_FROSTBLOOM_FIRST_SESSION
 implementation: PARTIAL_FOUNDATION
-current_user_work_scope: VISUAL_ASSET_COVERAGE_AND_NEXT_SINGLE_VISUAL_BRIEF
+current_user_work_scope: SPELL_WORKFLOW_PLAYER_FACING_SIMPLIFICATION_AND_VISUAL_ALIGNMENT
 product_implementation_authorized_by_current_user_work_scope: false
 visual_asset_coverage: docs/planning/visual/GRIMOIRE_VISUAL_ASSET_COVERAGE_2026-08-26.json
 visual_asset_coverage_status: CURRENT_PREFLIGHT_COMPLETE
-visual_generation_state: TEXT_BRIEF_READY_AWAITING_EXPLICIT_USER_GENERATION_APPROVAL
+visual_generation_state: NOT_REQUESTED_AFTER_PLAYER_FLOW_APPROVAL
 visual_direction_decision: GM-VISUAL-DIRECTION-20260825-01
 representative_screen_decision: GM-REPRESENTATIVE-SCREENS-20260825-01
 art_style_lock: ART-STYLE-01
@@ -36,6 +36,10 @@ google_sheets: MIGRATION_ONLY_UNTIL_REMOVAL
 github_actions_decision: GM-PUBLIC-REPO-FREE-GITHUB-ACTIONS-01
 repo_wide_actions_full_sha: PASS
 product_decision: GM-SPELL-WORKFLOW-UI-V2-01
+product_decision_overlay: docs/planning/SPELL_WORKFLOW_PLAYER_FACING_SIMPLIFICATION_2026-08-26.md
+product_decision_revision: 2026-08-26-PLAYER-FACING-SIMPLIFICATION
+player_facing_spell_flow: GLYPH_TO_SPELL_TO_TARGET_TO_CAST
+player_facing_ux_groups: SPELL_BUILD_AND_SPELL_CAST
 latest_product_main_for_task7_lineage: fcb5dbe1cbbb23ef195633b1f6680f45d46c5a3f
 spell_workflow_predecessor_status: TASK7_MERGED_MAIN_VERIFIED
 next_product_task: TASK8_SPELL_USE_SCREEN
@@ -78,25 +82,40 @@ android_export: NOT_RUN
 android_device: NOT_RUN
 ```
 
-`authority_sync_local_observation` / `authority_sync_godot_observation`은 이전 authority sync 당시의 역사 관찰값이다. 현재 로컬 Task8 존재·보존 상태는 별도 `task8_recovery_state`가 소유하며, 이번 Visual work unit은 로컬 Godot/Task8 실행을 수행하지 않았다.
+`authority_sync_local_observation` / `authority_sync_godot_observation`은 이전 authority sync 당시의 역사 관찰값이다. 현재 로컬 Task8 존재·보존 상태는 별도 `task8_recovery_state`가 소유하며, 이번 기획/Visual work unit은 로컬 Godot/Task8 실행을 수행하지 않았다.
 
 ## 현재 사용자 작업 범위
 
-2026-08-26 사용자가 `작업재개`를 명시했고, 이어 이전 감사에서 권장한 A안에 `진행해`라고 continuation을 승인했다.
+2026-08-26 사용자는 Visual 시안 검토 뒤 `GM-SPELL-WORKFLOW-UI-V2-01`의 플레이어 노출 흐름을 다음처럼 단순화하는 방향을 명시적으로 승인했다.
 
 ```text
-r5.4 authority reconciliation
-→ Visual Asset Coverage preflight
-→ 다음 정확히 1장 Text Brief
+글자
+→ 주문
+→ 대상
+→ 시전
 ```
 
-따라서 현재 범위는 `VISUAL_ASSET_COVERAGE_AND_NEXT_SINGLE_VISUAL_BRIEF`다.
+화면 경험은 다음 두 덩어리다.
+
+```text
+주문 만들기
+= 글자 선택·작성 + FIVE_POINT_STAR 회로 조합 + 완성 주문 이름 확인
+
+주문 쓰기
+= 게임 장면의 대상 지정 + 필요한 최종 Preview + 명시 시전
+```
+
+따라서 현재 범위는 `SPELL_WORKFLOW_PLAYER_FACING_SIMPLIFICATION_AND_VISUAL_ALIGNMENT`다.
 
 - Task8/Godot 제품 구현: **NOT_AUTHORIZED_BY_CURRENT_WORK_SCOPE**
 - `TASK8_SPELL_USE_SCREEN`: 다음 제품 task locator일 뿐 현재 구현 권한이 아님
-- 이미지 생성: **TEXT_BRIEF_READY_AWAITING_EXPLICIT_USER_GENERATION_APPROVAL**
+- 이미지 생성: **NOT_REQUESTED_AFTER_PLAYER_FLOW_APPROVAL**
 - Google Sheet 신규 canon write: **FORBIDDEN / MIGRATION_ONLY**
 - unrelated open PR: **READ_ONLY**
+
+현재 revision owner:
+
+`docs/planning/SPELL_WORKFLOW_PLAYER_FACING_SIMPLIFICATION_2026-08-26.md`
 
 ## 현재 제품 현실
 
@@ -118,7 +137,45 @@ Google Sheets
 → NO_NEW_CANON_WRITES
 ```
 
-Google Sheet의 기존 visual/image inventory와 asset cap은 이번 r5.4 Coverage에서 고유한 역사 범위를 복구하는 **migration compatibility input**으로만 읽었다. 현재 Visual Coverage owner는 GitHub `docs/planning/visual/GRIMOIRE_VISUAL_ASSET_COVERAGE_2026-08-26.json` + Notion Visual Bible이다.
+Google Sheet에는 과거 `GM-SPELL-WORKFLOW-UI-V2-01`의 `글자 그리기→회로 배치→주문 사용`, `Prepared Spell→Target...` 표현이 남아 있다. 이는 이번 fresh-read에서 확인한 migration compatibility 자료이며 새 사용자 승인으로 current authority가 되지 않는다. 신규 정본은 GitHub + Notion에 같은 Decision ID로 기록한다.
+
+## 현재 Player-facing Spell Workflow
+
+```yaml
+player_flow:
+  - 글자
+  - 주문
+  - 대상
+  - 시전
+ux_group_1:
+  name: 주문 만들기
+  includes:
+    - 글자 선택·작성
+    - FIVE_POINT_STAR 회로 조합
+    - 완성 주문 이름 확인
+ux_group_2:
+  name: 주문 쓰기
+  includes:
+    - 게임 장면에서 대상 지정
+    - 필요한 최종 Preview
+    - 명시 시전
+```
+
+플레이어 UI 기본 용어에서는 `Stock / PreparedSpell / Stage2 / Stage3 / Main / Auxiliary`를 먼저 가르치지 않는다. 내부 구현·데이터·테스트 정본에서는 이 용어와 authority를 그대로 유지한다.
+
+플레이어 용어 매핑:
+
+```text
+Stock / Vault source → 글자 / 보관 글자
+Stage2 placement → 주문 회로
+PreparedSpell → 완성 주문 / 완성 주문 이름
+Stage3 target selection → 대상
+Stage3 explicit commit/use → 시전
+```
+
+회로 조합 결과는 숫자 목록보다 **완성 주문 이름**을 먼저 읽게 한다. 단, 실제 이름 생성 문법·조사·로컬라이징·중복 처리·효과 수치와의 대응 규칙은 이번 결정에서 새로 발명하지 않으며 별도 설계 대상이다.
+
+완성 주문 선택 뒤 별도의 복잡한 대상 선택 전용 화면을 필수 가정하지 않는다. 권장 UX는 **게임 장면 유지/복귀 → 대상 직접 선택 → 필요한 Preview → 시전**이다.
 
 ## 현재 Visual authority
 
@@ -152,6 +209,7 @@ ADAPT
 - dialogue
 - glyph drawing
 - typed glyph Vault/Stock presentation
+- spell name/result presentation
 - feedback/VFX
 - Result/Grimoire
 - simple 2D movement/scene transition
@@ -159,13 +217,12 @@ ADAPT
 - font/icon support
 
 CREATE
-- FIVE_POINT_STAR → Prepared Spell Stage2 representative visual
 - Frostbloom environment candidates
 - first-session character half-body set
 - Frostbloom focal threat/entity
 
 DEFER
-- Task8 Stage3 final use representative visual
+- Task8 implementation-bound final use visual until product implementation is authorized/reconciled
 - store/key art
 - long-term companion growth forms
 
@@ -175,46 +232,19 @@ CUT
 - baked functional text/numbers/state truth
 ```
 
-## 다음 정확히 한 장의 Visual Text Brief
+## 최근 Spell Visual 검토 결과
 
-3개 유효 대안을 비교했다.
+Stage2 시안은 FIVE_POINT_STAR 흐름을 읽는 데는 유효했지만, 처음 생성본의 글자가 세로 패찰/부적처럼 보이는 문제가 있었다. 후속 수정에서 사용자는 이전 글자 작성 시안의 **간략한 직접 필기형 마법 문자**를 재사용하는 방향을 승인했다.
 
-A. Glyph Drawing + Vault — direct-writing fantasy는 강하지만 Task6/current reference로 coverage가 상대적으로 높음.
+현재 시각 규칙:
 
-B. **Typed Glyph Vault/Stock → FIVE_POINT_STAR → Prepared Spell** — 승인 battle/spell 시안에서 확인된 Stock/circuit semantic rework gap을 가장 직접적으로 닫음.
+- 글자는 부적·패찰·카드보다 획/필기감이 있는 직접 쓰인 문자로 보인다.
+- 회로 슬롯에는 패찰을 꽂기보다 글자를 직접 놓거나 쓰는 느낌을 우선한다.
+- `준비 주문`보다 **완성 주문 / 완성 주문 이름**을 플레이어 결과 라벨로 우선한다.
+- `대상 / 시전`은 게임 장면과 연결된 두 번째 UX 덩어리로 취급한다.
+- 사용자 메시지는 새 이미지 생성 요청이 아니므로 이 work unit에서 추가 이미지를 만들지 않는다.
 
-C. Prepared Spell → Target → Final Preview → Use — 중요한 P0이지만 Task8 product screen이 current main에 없어 지금 고정하면 재작업 위험이 더 큼.
-
-**Selected: B**
-
-```yaml
-brief_id: GR-VISUAL-BRIEF-STAGE2-STOCK-CIRCUIT-20260826-01
-status: TEXT_BRIEF_READY_AWAITING_EXPLICIT_USER_GENERATION_APPROVAL
-aspect: 16:9 LANDSCAPE
-result_count: 1
-```
-
-Composition:
-
-1. left Source Rail — exact Vault와 typed Glyph Stock을 서로 다른 출처로 구분
-2. center — FIVE_POINT_STAR, 중앙 Main 1 + 외곽 보조 0~5 동일 위상
-3. right — circuit Preview + Prepared Spell 상태까지만 표시
-4. 온실/사건 scene context는 UI 뒤에서도 유지
-
-Required semantics:
-
-- Stock is typed glyph source, not completed spell
-- no hidden position bonus
-- no auto target
-- no auto commit
-- Stage2 prepares spell before Stage3 target/use
-- reserved/consumed/unavailable states use icon/shape/text redundancy, not color only
-
-Functional success rate, Mana, target, arbitrary names/dialogue/costs/button copy는 이미지에 굽지 않는다. 필요한 최소 concept label만 `보관 글자 / 주문 회로 / 준비 주문`을 사용할 수 있다.
-
-r5.4 conversation gate에 따라 이 Text Brief 뒤에는 **STOP**한다. 사용자 명시 생성 승인 뒤 정확히 1장 생성한다.
-
-## Spell Workflow
+## Spell Workflow 내부 authority
 
 ```yaml
 task3:
@@ -229,14 +259,17 @@ task5:
 task6:
   pr: 108
   scope: GLYPH_DRAWING_WORKFLOW_SCREEN
+  player_group: 주문 만들기
 task7:
   pr: 110
   merge: fcb5dbe1cbbb23ef195633b1f6680f45d46c5a3f
   status: TASK7_MERGED_MAIN_VERIFIED
+  player_group: 주문 만들기
 next_product_task: TASK8_SPELL_USE_SCREEN
+next_product_player_group: 주문 쓰기
 ```
 
-Task8은 기존 Task5 Stage3 authority의 thin UI consumer다. 새 Mana/inventory/result/rollback/transaction authority를 만들지 않는다.
+이번 간략화는 내부 transaction authority를 변경하지 않는다. Task8은 기존 Task5 Stage3 authority의 thin UI consumer다. 새 Mana/inventory/result/rollback/transaction authority를 만들지 않는다. 자동 target·자동 commit·회로 자동 최적화도 금지한다.
 
 역사 compatibility locator:
 
@@ -315,7 +348,7 @@ learning_closure: LEARNING_CLOSURE_OPEN_COUNT = 0
 
 PR #151 `feat(ui): build GRIMOIRE component sheets A-D`는 **병합 완료**된 current-main 역사다. Component Sheet A–D와 semantic UI pack은 병합된 사실로 읽되, 이것이 Task8 또는 Human/Device/Performance/Full Slice PASS를 의미하지 않는다.
 
-2026-08-26 r5.4 work 시작 시 live open PR은 PR #166 하나이며 `README.md`만 변경하는 Draft other-workstream이다. `OPEN_PR_READ_ONLY_BY_DEFAULT`로 유지하고 이번 current-task branch에 흡수하지 않는다.
+2026-08-26 이번 work unit 시작 시 live open PR은 PR #166 하나이며 `README.md`만 변경하는 Draft other-workstream이다. `OPEN_PR_READ_ONLY_BY_DEFAULT`로 유지하고 이번 current-task branch에 흡수하지 않는다.
 
 ## v4.8 migration / legacy snapshot boundary
 
@@ -329,6 +362,7 @@ PR #151 `feat(ui): build GRIMOIRE component sheets A-D`는 **병합 완료**된 
 → START_HERE.md
 → docs/ACTIVE_CONTEXT.md
 → docs/contracts/GRIMOIRE_PROJECT_CONTRACT_V4_8_BINDING.md
+→ docs/planning/SPELL_WORKFLOW_PLAYER_FACING_SIMPLIFICATION_2026-08-26.md
 → docs/planning/visual/GRIMOIRE_VISUAL_ASSET_COVERAGE_2026-08-26.json
 → task/domain-specific current owner
 → actual code/data/Scene/Resource/Test/runtime evidence
@@ -339,11 +373,12 @@ PR #151 `feat(ui): build GRIMOIRE component sheets A-D`는 **병합 완료**된 
 ```text
 1. TASK8_CLEAN_RECONCILIATION_WORKTREE_REQUIRED
 2. fresh exact-project HiGodot readback + primary v2 recovery / secondary parity comparison
-3. fresh Task8 GUT + predecessor/full runner + Hera source-delta + exact-path adversarial review
-4. Task8 product PR / exact-head CI / merge / merged-main readback
-5. Task9 Product Root + responsive/E2E integration
-6. 대표 00~10분 Human Slice
-7. 10~23 → 46분 증거 확장
+3. 새 player-facing overlay를 Task8 UI 용어·동선에 매핑하고 기존 Stage3 authority와 충돌 없는지 확인
+4. fresh Task8 GUT + predecessor/full runner + Hera source-delta + exact-path adversarial review
+5. Task8 product PR / exact-head CI / merge / merged-main readback
+6. Task9 Product Root + responsive/E2E integration
+7. 대표 00~10분 Human Slice
+8. 10~23 → 46분 증거 확장
 ```
 
 ## 완료로 주장하지 않는 항목

--- a/docs/planning/SPELL_WORKFLOW_PLAYER_FACING_SIMPLIFICATION_2026-08-26.md
+++ b/docs/planning/SPELL_WORKFLOW_PLAYER_FACING_SIMPLIFICATION_2026-08-26.md
@@ -8,6 +8,7 @@ status: USER_APPROVED_ACTIVE
 approval_date: 2026-08-26
 approval_source: 사용자 명시 승인 "좋아 그렇게하자"
 change_type: PLAYER_FACING_UX_SIMPLIFICATION_ONLY
+visual_revision_owner: docs/planning/visual/GRIMOIRE_VISUAL_ASSET_COVERAGE_PLAYER_FLOW_REVISION_2026-08-26.json
 product_implementation_mutation: NONE
 runtime_authority_change: NONE
 ```
@@ -144,6 +145,10 @@ Task8은 여전히 Task5 Stage3 authority의 thin UI consumer다. 이번 결정�
 - FIVE_POINT_STAR 슬롯에는 패찰을 꽂는 것보다 **글자를 회로에 직접 놓거나 쓰는 느낌**을 우선한다.
 - 기존 3단 패널 `보관 글자 / 주문 회로 / 준비 주문`은 탐색용 시안으로 보존하지만, 앞으로 플레이어 용어는 **글자 / 완성 주문 이름 / 대상 / 시전** 중심으로 정리한다.
 - `준비 주문`은 개발 의미의 PreparedSpell 설명에는 쓸 수 있지만, 기본 결과 라벨은 **완성 주문** 또는 **완성 주문 이름**을 우선한다.
+
+시각 coverage revision:
+
+`docs/planning/visual/GRIMOIRE_VISUAL_ASSET_COVERAGE_PLAYER_FLOW_REVISION_2026-08-26.json`
 
 ## 8. Evidence ceiling
 

--- a/docs/planning/SPELL_WORKFLOW_PLAYER_FACING_SIMPLIFICATION_2026-08-26.md
+++ b/docs/planning/SPELL_WORKFLOW_PLAYER_FACING_SIMPLIFICATION_2026-08-26.md
@@ -1,0 +1,165 @@
+# GRIMOIRE Spell Workflow · Player-Facing Simplification
+
+```yaml
+decision_id: GM-SPELL-WORKFLOW-UI-V2-01
+decision_revision: 2026-08-26-PLAYER-FACING-SIMPLIFICATION
+sync_id: GR-SYNC-20260826-37-SPELL-FLOW-PLAYER-FACING
+status: USER_APPROVED_ACTIVE
+approval_date: 2026-08-26
+approval_source: 사용자 명시 승인 "좋아 그렇게하자"
+change_type: PLAYER_FACING_UX_SIMPLIFICATION_ONLY
+product_implementation_mutation: NONE
+runtime_authority_change: NONE
+```
+
+## 1. 승인된 플레이어 흐름
+
+플레이어에게는 내부 Stage/서비스 구조를 그대로 노출하지 않고 아래 네 단어만 핵심 흐름으로 사용한다.
+
+```text
+글자
+→ 주문
+→ 대상
+→ 시전
+```
+
+이를 실제 화면 경험 기준으로는 두 덩어리로 묶는다.
+
+```text
+주문 만들기
+= 글자 선택·작성
++ FIVE_POINT_STAR 회로 조합
++ 완성 주문 이름 확인
+
+주문 쓰기
+= 게임 장면에서 대상 지정
++ 필요한 최종 Preview
++ 명시 시전
+```
+
+플레이어가 기억해야 하는 질문은 다음 두 개면 충분하다.
+
+1. **이 글자로 어떤 주문을 만들까?**
+2. **이 주문을 누구/무엇에게 쓸까?**
+
+## 2. 플레이어 용어와 내부 용어 분리
+
+다음 용어는 구현·데이터·테스트 정본에서 계속 사용하지만 기본 플레이어 UI의 주 용어로 사용하지 않는다.
+
+- `Stock`
+- `PreparedSpell`
+- `Stage2`
+- `Stage3`
+- `Main Glyph`
+- `Auxiliary Glyph`
+
+플레이어 UI에서는 우선 다음 표현을 사용한다.
+
+```yaml
+Stock / Vault source: 글자 / 보관 글자
+Stage2 placement: 주문 회로
+PreparedSpell: 완성 주문 또는 완성 주문 이름
+Stage3 target selection: 대상
+Stage3 explicit commit/use: 시전
+```
+
+`Main / Auxiliary` 관계는 시스템을 배우는 도움말이나 상세 설명에서는 사용할 수 있지만, 초반 화면에서 먼저 암기시킬 용어가 아니다. 기본 설명은 **가운데 글자가 주문의 중심이고 주변 글자가 성질을 더한다** 수준을 우선한다.
+
+## 3. 완성 주문 이름
+
+회로 조합이 바뀌면 플레이어가 가장 먼저 확인해야 하는 결과는 숫자 목록보다 **완성 주문 이름**이다.
+
+```text
+글자 조합 변화
+→ 회로 의미 변화
+→ 완성 주문 이름 변화
+```
+
+단, 현재 승인 범위는 **주문 이름을 결과 요약의 중심에 둔다**는 UX 결정까지다. 실제 명명 문법, 조사/어미, 로컬라이징 규칙, 중복 이름 처리, 이름과 효과 수치의 정확한 대응 알고리즘은 아직 이 결정에서 새로 발명하지 않는다. 해당 규칙은 별도 설계·검증 대상이다.
+
+## 4. 대상 지정 간략화
+
+완성 주문을 선택한 뒤 별도의 복잡한 대상 선택 전용 화면을 필수로 두지 않는다.
+
+권장 플레이어 흐름:
+
+```text
+완성 주문 선택
+→ 게임 장면으로 복귀/유지
+→ 장면의 대상 직접 선택
+→ 필요한 최종 Preview
+→ 명시 시전
+```
+
+대상 선택과 최종 시전은 **주문 쓰기**라는 하나의 UX 덩어리로 취급한다.
+
+## 5. 내부 시스템 불변식
+
+이번 결정은 현재 구현 authority를 제거하거나 단순화하지 않는다.
+
+보존:
+
+- `GM-STAR-CIRCUIT-MASTERY-BALANCE-01`
+- `FIVE_POINT_STAR`
+- 중앙 Main 1 + 외곽 Auxiliary 0~5 내부 구조
+- typed glyph source / reservation / atomic consume
+- Task4 Stage2 preparation authority
+- immutable `PreparedSpell`
+- Task5 Stage3 target/use atomic transaction authority
+- explicit target
+- final validation/preview가 필요한 경우 시전 전 제공
+- explicit exactly-once commit/use
+- invalid/cancel/error에서의 기존 rollback/consume 불변식
+
+금지:
+
+- 자동 Target
+- 자동 시전
+- 회로 고민을 제거하는 자동 최적 조합
+- Stock을 완성 주문 보관함으로 재정의
+- 플레이어 용어 간략화를 이유로 내부 transaction authority 중복 구현
+
+## 6. 기존 Task와의 매핑
+
+```yaml
+Task6_Glyph_Drawing:
+  player_group: 주문 만들기
+  player_term: 글자
+Task7_Circuit_Placement:
+  player_group: 주문 만들기
+  player_term: 주문 회로 / 완성 주문 이름
+Task8_Spell_Use:
+  player_group: 주문 쓰기
+  player_term: 대상 / 시전
+```
+
+Task8은 여전히 Task5 Stage3 authority의 thin UI consumer다. 이번 결정은 Task8 구현 승인이 아니며, 현재 제품 구현 gate `TASK8_PR_PREP_REVERIFY_PENDING`를 자동 해제하지 않는다.
+
+## 7. 시각 방향
+
+최근 생성 시안에서 확인된 방향을 반영한다.
+
+- 글자는 부적·패찰·카드보다 **직접 쓰인 마법 문자**로 읽혀야 한다.
+- 획, 필기감, 빛나는 잉크/마력 흔적이 글자 정체성을 만든다.
+- FIVE_POINT_STAR 슬롯에는 패찰을 꽂는 것보다 **글자를 회로에 직접 놓거나 쓰는 느낌**을 우선한다.
+- 기존 3단 패널 `보관 글자 / 주문 회로 / 준비 주문`은 탐색용 시안으로 보존하지만, 앞으로 플레이어 용어는 **글자 / 완성 주문 이름 / 대상 / 시전** 중심으로 정리한다.
+- `준비 주문`은 개발 의미의 PreparedSpell 설명에는 쓸 수 있지만, 기본 결과 라벨은 **완성 주문** 또는 **완성 주문 이름**을 우선한다.
+
+## 8. Evidence ceiling
+
+```text
+PLAYER_FACING_FLOW_DECISION: USER_APPROVED
+PRODUCT_IMPLEMENTATION: NOT_CHANGED
+TASK8_IMPLEMENTATION: NOT_AUTHORIZED_BY_THIS_DECISION
+HUMAN_USABILITY: NOT_RUN
+DEVICE_VALIDATION: NOT_RUN
+PERFORMANCE_VALIDATION: NOT_RUN
+FULL_VERTICAL_SLICE: NOT_RUN
+```
+
+이 결정의 성공 여부는 향후 Human Slice에서 다음을 직접 확인해야 한다.
+
+- 플레이어가 `글자 → 주문 → 대상 → 시전`을 별도 설명 없이 재진술할 수 있는가.
+- 완성 주문 이름만 보고 회로 변화의 의미를 어느 정도 추론할 수 있는가.
+- 대상 선택과 시전을 하나의 자연스러운 행동으로 느끼는가.
+- 내부 용어를 숨겨도 비용·위험·실패 책임이 불투명해지지 않는가.

--- a/docs/planning/sync/GR-SYNC-20260826-37-SPELL-FLOW-PLAYER-FACING.md
+++ b/docs/planning/sync/GR-SYNC-20260826-37-SPELL-FLOW-PLAYER-FACING.md
@@ -1,0 +1,114 @@
+# GR-SYNC-20260826-37 · Spell Flow Player-Facing Simplification
+
+```yaml
+sync_id: GR-SYNC-20260826-37-SPELL-FLOW-PLAYER-FACING
+decision_id: GM-SPELL-WORKFLOW-UI-V2-01
+decision_revision: 2026-08-26-PLAYER-FACING-SIMPLIFICATION
+status: CURRENT_TASK_PR_PENDING
+approved_at: 2026-08-26
+approval_source: 사용자 명시 승인 "좋아 그렇게하자"
+baseline_project_main: 1a37460f4953a322e228daac0215b0b9dd82b22e
+baseline_base_main: edb3b3376603c9f6b00d64af3126304f8c9946bf
+branch: docs/spell-flow-player-facing-20260826
+open_other_workstream: PR_166_READ_ONLY_README_ONLY
+product_code_mutation: NONE
+scene_resource_mutation: NONE
+image_generation_in_this_unit: NONE
+```
+
+## 승인 내용
+
+플레이어가 이해하는 주문 흐름을 다음처럼 단순화한다.
+
+```text
+글자
+→ 주문
+→ 대상
+→ 시전
+```
+
+화면/행동은 두 덩어리로 정리한다.
+
+```text
+주문 만들기
+= 글자 선택·작성
++ FIVE_POINT_STAR 회로 조합
++ 완성 주문 이름 확인
+
+주문 쓰기
+= 게임 장면에서 대상 지정
++ 필요한 최종 Preview
++ 명시 시전
+```
+
+## 내부 authority 보존
+
+이번 결정은 player-facing vocabulary와 화면 묶음을 단순화하는 revision이다. 다음 구현 authority는 변경하지 않는다.
+
+- Task4 Stage2 atomic preparation
+- immutable `PreparedSpell`
+- Task5 Stage3 target/use atomic transaction
+- typed glyph reservation / atomic consume
+- explicit target
+- explicit exactly-once use
+- invalid/cancel/error rollback
+- `GM-STAR-CIRCUIT-MASTERY-BALANCE-01`
+- `FIVE_POINT_STAR`
+
+따라서 `Stock / PreparedSpell / Stage2 / Stage3 / Main / Auxiliary`는 내부 구현·데이터·테스트 용어로 유지한다.
+
+## Visual revision
+
+- 세로 패찰·부적·charms처럼 보이는 glyph metaphor는 폐기한다.
+- 글자는 획·필기감·빛나는 잉크 흔적이 있는 **직접 쓰인 마법 문자**로 읽히게 한다.
+- FIVE_POINT_STAR에는 글자를 패찰째 꽂기보다 직접 쓰거나 놓는 느낌을 우선한다.
+- Stage2 결과의 player-facing primary label은 `준비 주문`보다 **완성 주문 / 완성 주문 이름**이다.
+- 대상 지정은 가능하면 게임 장면에서 직접 수행하고 필요한 Preview 뒤 `시전`한다.
+
+## Naming boundary
+
+승인된 것은 **완성 주문 이름을 회로 결과의 1차 readout으로 둔다**는 UX 원칙이다.
+
+아래는 아직 별도 설계 대상이다.
+
+- 이름 생성 문법
+- 한국어 조사/어미 규칙
+- 로컬라이징
+- 중복 이름 처리
+- 이름과 정확한 효과 수치의 대응 알고리즘
+
+## Fresh-read conflict record
+
+Google Sheet `02_현재_확정결정`의 기존 `GM-SPELL-WORKFLOW-UI-V2-01` 행에는 과거 표현인 `글자 그리기→회로 배치→주문 사용`, `Prepared Spell→explicit target→...`가 남아 있다.
+
+```yaml
+google_sheet_role: MIGRATION_ONLY_UNTIL_REMOVAL
+conflict_type: STALE_PLAYER_FACING_WORDING
+new_sheet_canon_write: FORBIDDEN
+resolution: GITHUB_AND_NOTION_CURRENT_REVISION_SUPERSEDES_PLAYER_FACING_LABELS
+```
+
+이 충돌은 Sheet를 current writer로 복귀시키지 않고 기록만 한다.
+
+## Notion synchronization
+
+현재 human-facing surfaces:
+
+- `글자 학습 → 주문 설계 루프` — 새 `글자→주문→대상→시전` 규칙과 Player Meaning 반영, `REPO_UPDATE_REQUIRED` until merge.
+- `Visual Asset Coverage · 2026-08-26 · r5.4` — 새 player-facing flow, direct-written glyph direction, previous Stage2 brief generated/reviewed 상태 반영.
+
+Post-merge에는 Core Loop `Source SHA / Sync State`와 Project System Record `Repo Main SHA / Sync State`를 merged main으로 readback한다.
+
+## Evidence ceiling
+
+```text
+PLAYER_FACING_FLOW_DECISION: USER_APPROVED
+GITHUB_BRANCH_DOCS: WRITTEN_PENDING_PR
+NOTION_HUMAN_CANON: UPDATED_PENDING_REPO_MERGE
+GOOGLE_SHEET: MIGRATION_ONLY_STALE_WORDING_OBSERVED_NO_WRITE
+TASK8_PRODUCT_IMPLEMENTATION: NOT_AUTHORIZED
+HUMAN_USABILITY: NOT_RUN
+DEVICE: NOT_RUN
+PERFORMANCE: NOT_RUN
+FULL_VERTICAL_SLICE: NOT_RUN
+```

--- a/docs/planning/visual/GRIMOIRE_VISUAL_ASSET_COVERAGE_PLAYER_FLOW_REVISION_2026-08-26.json
+++ b/docs/planning/visual/GRIMOIRE_VISUAL_ASSET_COVERAGE_PLAYER_FLOW_REVISION_2026-08-26.json
@@ -1,0 +1,111 @@
+{
+  "schema_version": 1,
+  "project": "GRIMOIRE: 세계를 다시 쓰는 법",
+  "revision_id": "GR-VISUAL-ASSET-COVERAGE-PLAYER-FLOW-20260826-01",
+  "status": "USER_APPROVED_PLAYER_FLOW_REVISION_ACTIVE",
+  "decision_id": "GM-SPELL-WORKFLOW-UI-V2-01",
+  "decision_revision": "2026-08-26-PLAYER-FACING-SIMPLIFICATION",
+  "sync_id": "GR-SYNC-20260826-37-SPELL-FLOW-PLAYER-FACING",
+  "baseline_coverage": "docs/planning/visual/GRIMOIRE_VISUAL_ASSET_COVERAGE_2026-08-26.json",
+  "baseline_disposition": "PRESERVE_FULL_PREFLIGHT_INVENTORY_AND_DELETE_TEST_RESULTS",
+  "supersession_scope": [
+    "PLAYER_FACING_SPELL_WORKFLOW_TERMS",
+    "STAGE2_RESULT_LABEL",
+    "TARGET_SELECTION_PRESENTATION",
+    "GLYPH_VISUAL_METAPHOR",
+    "PREVIOUS_NEXT_SINGLE_VISUAL_GENERATION_STATUS"
+  ],
+  "player_facing_flow": [
+    "글자",
+    "주문",
+    "대상",
+    "시전"
+  ],
+  "ux_groups": {
+    "주문 만들기": [
+      "글자 선택·작성",
+      "FIVE_POINT_STAR 회로 조합",
+      "완성 주문 이름 확인"
+    ],
+    "주문 쓰기": [
+      "게임 장면에서 대상 직접 지정",
+      "필요한 최종 Preview",
+      "명시 시전"
+    ]
+  },
+  "player_term_mapping": {
+    "Stock_or_Vault_source": "글자 / 보관 글자",
+    "Stage2_placement": "주문 회로",
+    "PreparedSpell": "완성 주문 / 완성 주문 이름",
+    "Stage3_target_selection": "대상",
+    "Stage3_explicit_commit_use": "시전"
+  },
+  "visual_revision": {
+    "glyph_metaphor": "DIRECT_WRITTEN_MAGICAL_LETTER",
+    "rejected_metaphor": [
+      "TALISMAN",
+      "HANGING_TAG",
+      "CHARM_PLAQUE",
+      "COLLECTIBLE_SPELL_CARD"
+    ],
+    "glyph_readability": [
+      "VISIBLE_STROKES",
+      "HANDWRITING_OR_BRUSH_FEEL",
+      "LUMINOUS_INK_OR_MAGIC_TRACE",
+      "LETTER_FIRST_NOT_PICTOGRAM_FIRST"
+    ],
+    "circuit_placement": "LETTERS_ARE_WRITTEN_OR_PLACED_DIRECTLY_ON_FIVE_POINT_STAR",
+    "stage2_primary_result_label": "완성 주문 이름",
+    "target_presentation": "PREFER_IN_WORLD_DIRECT_TARGET_SELECTION_OVER_SEPARATE_COMPLEX_TARGET_ONLY_SCREEN"
+  },
+  "previous_stage2_brief": {
+    "brief_id": "GR-VISUAL-BRIEF-STAGE2-STOCK-CIRCUIT-20260826-01",
+    "status": "GENERATED_REVIEWED_AND_SUPERSEDED_FOR_PLAYER_LABELS",
+    "finding": "FIRST_GENERATION_READ_AS_TALISMAN_OR_TAG; FOLLOWUP_DIRECT_WRITTEN_GLYPH_DIRECTION_ACCEPTED",
+    "preserved_value": "FIVE_POINT_STAR_AND_SOURCE_TO_CIRCUIT_COMPOSITION_REFERENCE"
+  },
+  "image_generation_state": "NO_NEW_IMAGE_REQUEST_AFTER_PLAYER_FLOW_APPROVAL",
+  "naming_rule_boundary": {
+    "approved": "COMPLETED_SPELL_NAME_IS_PRIMARY_PLAYER_READOUT_OF_CIRCUIT_RESULT",
+    "not_yet_defined": [
+      "SPELL_NAME_GRAMMAR",
+      "KOREAN_PARTICLE_OR_INFLECTION_RULES",
+      "LOCALIZATION_RULES",
+      "DUPLICATE_NAME_HANDLING",
+      "EXACT_NAME_TO_EFFECT_NUMERIC_MAPPING"
+    ]
+  },
+  "internal_authority_preserved": [
+    "GM-STAR-CIRCUIT-MASTERY-BALANCE-01",
+    "FIVE_POINT_STAR",
+    "CENTER_MAIN_1_PLUS_OUTER_AUXILIARY_0_TO_5",
+    "TYPED_GLYPH_RESERVATION_AND_ATOMIC_CONSUME",
+    "TASK4_STAGE2_PREPARATION_AUTHORITY",
+    "IMMUTABLE_PREPARED_SPELL",
+    "TASK5_STAGE3_TARGET_USE_ATOMIC_TRANSACTION",
+    "EXPLICIT_TARGET",
+    "EXPLICIT_EXACTLY_ONCE_USE",
+    "ROLLBACK_AND_NO_CONSUME_ON_INVALID_CANCEL_ERROR"
+  ],
+  "forbidden": [
+    "AUTO_TARGET",
+    "AUTO_CAST",
+    "AUTO_OPTIMAL_CIRCUIT",
+    "STOCK_AS_COMPLETED_SPELL_STORAGE",
+    "DUPLICATE_TRANSACTION_AUTHORITY",
+    "BAKED_FUNCTIONAL_NUMERIC_TRUTH"
+  ],
+  "evidence_ceiling": {
+    "product_implementation_mutated": false,
+    "task8_implementation_authorized": false,
+    "human_usability": "NOT_RUN",
+    "device": "NOT_RUN",
+    "performance": "NOT_RUN",
+    "full_vertical_slice": "NOT_RUN"
+  },
+  "google_sheets": {
+    "role": "MIGRATION_ONLY_UNTIL_REMOVAL",
+    "legacy_wording_conflict_observed": true,
+    "new_canon_write_authorized": false
+  }
+}


### PR DESCRIPTION
## Scope

Record the user-approved `GM-SPELL-WORKFLOW-UI-V2-01` player-facing revision without changing runtime/product authority.

## Player-facing revision

- core player flow: `글자 → 주문 → 대상 → 시전`
- `주문 만들기` = 글자 선택·작성 + FIVE_POINT_STAR 회로 조합 + 완성 주문 이름 확인
- `주문 쓰기` = 게임 장면에서 대상 지정 + 필요한 final Preview + 명시 시전
- player-facing `PreparedSpell` label becomes `완성 주문 / 완성 주문 이름`
- prefer direct in-world target selection over a mandatory separate complex target-only screen

## Visual revision

- reject talisman / hanging-tag / charm-card glyph metaphor
- prefer direct-written magical letters with visible strokes and luminous ink/magic traces
- preserve FIVE_POINT_STAR and existing Magic/Anime + Storybook style
- previous Stage2 visual brief is preserved as generated/reviewed exploration; no new image is generated in this PR

## Preserved internal authority

- Task4 Stage2 atomic preparation
- immutable PreparedSpell
- Task5 Stage3 target/use atomic transaction
- explicit target and exactly-once use
- typed glyph reservation/consume/rollback
- `GM-STAR-CIRCUIT-MASTERY-BALANCE-01 / FIVE_POINT_STAR`
- Task8 implementation remains NOT authorized by this work unit

## Workspace sync

- Notion Home / Core Loop / Visual Coverage / TASK-13 updated and marked repo-update pending where applicable
- Google Sheet retains legacy wording as migration-only; no new Sheet canon write
- PR #166 remains a separate README-only read-only workstream

## Evidence ceiling

Human / Device / Performance / Full Vertical Slice remain NOT_RUN. Product code, scenes, resources, and runtime behavior are not changed.