### PR TITLE
docs: hand off image goals to ChatGPT Work

### DIFF
--- a/docs/planning/GRIMOIRE_GPT_WORK_IMAGE_GOAL_HANDOFF_2026-08-26.md
+++ b/docs/planning/GRIMOIRE_GPT_WORK_IMAGE_GOAL_HANDOFF_2026-08-26.md
@@ -1,0 +1,296 @@
+# GRIMOIRE · GPT Work Image Goal Handoff · 2026-08-26
+
+```yaml
+handoff_id: GR-WORK-HANDOFF-20260826-01
+project: "GRIMOIRE: 세계를 다시 쓰는 법"
+target_workspace: CHATGPT_WORK
+handoff_status: READY_FOR_USER_REVIEW_AND_WORK_RESUME
+source_project_main: 27749d2b3a552193283182143fe772e18f0ef45f
+source_base_main: 06669fe9c6a3ccd6f3b0d19c5757540bfdcc0623
+open_pr_at_handoff: 166_DRAFT_READ_ONLY_OTHER_WORKSTREAM
+google_sheet: MIGRATION_ONLY_NO_NEW_CANON_WRITE
+image_generation_authorized_by_handoff: false
+godot_implementation_authorized_by_handoff: false
+human_validation: NOT_RUN
+device_validation: NOT_RUN
+performance_validation: NOT_RUN
+full_vertical_slice: NOT_RUN
+```
+
+## 1. Work에서 가장 먼저 읽을 것
+
+Work의 지속 컨텍스트/메모리는 작업 편의를 위한 보조층이다. 프로젝트 정본보다 높은 권위로 취급하지 않는다. 매 실질 작업 시작마다 current truth를 다시 읽는다.
+
+1. Notion `GRIMOIRE · Home`
+2. repository `AGENTS.md`
+3. `docs/ACTIVE_CONTEXT.md`
+4. `docs/planning/visual/GRIMOIRE_IMAGE_GOAL_QUEUE_2026-08-26.json`
+5. `docs/planning/visual/GRIMOIRE_VISUAL_PRODUCTION_CHECKLIST_2026-08-26.json`
+6. `docs/planning/visual/GRIMOIRE_VISUAL_ASSET_COVERAGE_2026-08-26.json`
+7. `docs/planning/SPELL_WORKFLOW_PLAYER_FACING_SIMPLIFICATION_2026-08-26.md`
+8. 실제 code / Scene / Resource / Test / runtime consumer
+9. latest Base completed `main`과 관련 owner
+10. Google Sheet는 migration-only unique legacy drift가 필요할 때만 읽는다.
+
+새 Work 세션에서 과거 채팅의 SHA, PR 상태, Notion 내용, asset 상태를 current truth로 가정하지 않는다.
+
+## 2. 현재 프로젝트/Visual 정본
+
+- 제품 단계: `DEMO_FIRST_VERTICAL_SLICE`
+- 기획: `COMPLETE_FROSTBLOOM_FIRST_SESSION`
+- 구현: `PARTIAL_FOUNDATION`
+- 현재 Main Scene: `res://src/ui/star_circuit_harness.tscn`
+- Main Scene 역할: `DEVELOPMENT_RUNTIME_POC_ENTRY`
+- Art Style Lock: `ART-STYLE-01 · Soft Storybook Cel 2D Hybrid`
+- Visual overlay: `GM-VISUAL-DIRECTION-20260825-01 · Logo 01 + Magic/Anime`
+- Logo 01: 사람용 승인 Visual 방향. 자동으로 final runtime export가 된 것은 아님.
+- 대표 전투/주문 화면: 분위기·온실 구도·Navy/Gold·Blue magic glow만 reference. 구형 Stock/Circuit/Spell UI는 current canon이 아님.
+- 대표 대화 화면: 반신 Anime character + Storybook background + Navy/Gold frame + 하단 선택지 구도 reference. 이미지 속 임의 이름/캐릭터 identity/대사는 비정본.
+- 이전 3D-like 이동 화면: `REJECTED`. 단순 2D Field/scene transition 방향.
+
+## 3. 플레이어 주문 흐름
+
+Decision `GM-SPELL-WORKFLOW-UI-V2-01`의 현재 player-facing revision은 다음과 같다.
+
+```text
+글자 → 주문 → 대상 → 시전
+```
+
+```text
+주문 만들기
+= 글자 선택·작성 + FIVE_POINT_STAR 회로 조합 + 완성 주문 이름 확인
+
+주문 쓰기
+= 게임 장면에서 대상 직접 지정 + 필요한 최종 Preview + 명시 시전
+```
+
+내부 `Stock / PreparedSpell / Stage2 / Stage3 / Main / Auxiliary`는 runtime/data/test authority로 유지한다. 자동 Target, 자동 Commit, Best Route를 만들지 않는다.
+
+## 4. 이미지 생산 원칙
+
+이미지 backlog 진입 전에 실제 consumer를 묻는다.
+
+```text
+actual consumer
+→ existing solution/reuse
+→ asset slot/path/format/state boundary
+→ Image Goal text brief
+→ STOP
+→ explicit user generation approval
+→ exactly one result
+→ STOP
+→ user approve/revise
+→ Notion registration
+→ implementation-ready export/provenance
+→ CODEX-IMG Goal
+→ Godot integration
+→ runtime screenshot/play validation
+```
+
+설명용 디자인 시트, 전체 화면 한 장짜리 UI PNG, 체크리스트 장식, baked Korean text/Mana/success rate/button labels는 production asset으로 만들지 않는다.
+
+## 5. 이미 실제 Runtime에서 재사용할 것
+
+현재 main의 `src/ui/star_circuit_harness.tscn`이 실제 Texture2D로 소비한다.
+
+- `assets/art/ui/common/academy_corner_ornament.svg`
+- `assets/art/ui/common/icon_mana.svg`
+- `assets/art/ui/common/icon_phase_diamond.svg`
+- `assets/art/ui/common/icon_typed_stock.svg`
+- `assets/art/ui/common/icon_warning_diamond.svg`
+
+또한 FIVE_POINT_STAR 자체는 `src/ui/components/star_circuit_board.gd`의 procedural draw와 기존 semantic UI/Component Sheets A-D를 우선 재사용한다.
+
+## 6. Known Drift · Glyph 3종 → Slice Runtime 6종
+
+기존 Runtime Consumer Checklist의 `GR-RA-01-GLYPH-BASE`는 Asset-Spec 역사값인 `FLOW / FOCUS / DISPERSE` 3종을 적고 있다.
+
+하지만 실제 current Slice vocabulary는:
+
+```text
+HEAT
+PROTECT
+FLOW
+FOCUS
+DISPERSE
+BURST
+```
+
+6종이다. Task6 recognition과 Task7 loadout/circuit consumer도 이 Slice vocabulary를 사용한다.
+
+사용자는 2026-08-26 이 **6종 Runtime 기준으로 진행**하는 것을 승인했다. 따라서 Work의 IMG-01은 6종을 사용한다. 이전 3종 행은 provenance이며 현재 IMG-01 수량 authority가 아니다.
+
+## 7. Final Image Goal Queue
+
+구조화 owner: `docs/planning/visual/GRIMOIRE_IMAGE_GOAL_QUEUE_2026-08-26.json`
+
+| 순서 | Goal | Priority | Consumer | 상태 |
+|---:|---|---|---|---|
+| 1 | IMG-01 · Slice Magic Glyph Runtime Set | P0 | Task6 / Task7 / future Task8 | NEXT |
+| 2 | IMG-02 · First-Session Environment Base Pack | P1 | Class / Field / Greenhouse Battle | Scene slot pending |
+| 3 | IMG-03 · Frostbloom Environment State Pack | P1 | Greenhouse state/result | IMG-02 + effect reuse test pending |
+| 4 | IMG-04 · Maren Dialogue Portrait Pack | P1 | Dialogue UI | character identity brief pending |
+| 5 | IMG-05 · Protagonist Portrait Pack | P1 | Dialogue / future battle portrait | protagonist identity pending |
+| 6 | IMG-06 · Greenhouse Spirit Combat Pack | P1 | Frostbloom Battle | battle consumer scene pending |
+| 7 | IMG-07 · Main Companion Initial Runtime Pack | P1 | Field / Dialogue / Battle reaction / Result | companion canon recheck pending |
+| 8 | IMG-08 · Field SD Character Pack | P1 | Simple 2D Field | field scene/clip contract pending |
+| 9 | IMG-09 · Main/Title Runtime Pack | P2 | Main/Title | Product Root pending |
+| 10 | IMG-10 · Store Key Art | P3 | Product distribution | Playable proof + platform recheck pending |
+
+## 8. NEXT · IMG-01
+
+### Product Goal
+
+플레이어가 아이콘/부적을 슬롯에 넣는다고 느끼는 것이 아니라 **배운 마법 글자를 직접 써서 주문을 만든다**고 느껴야 한다.
+
+### Actual Consumers
+
+- `src/ui/spell_workflow/glyph_drawing_screen.tscn`
+- `src/ui/spell_workflow/components/glyph_card.tscn`
+- `src/ui/spell_workflow/circuit_placement_screen.tscn`
+- `src/ui/components/star_circuit_board.tscn`
+- future Task8 Spell Use thin UI
+
+### Required Runtime Assets
+
+```text
+glyph_heat
+glyph_protect
+glyph_flow
+glyph_focus
+glyph_disperse
+glyph_burst
+```
+
+Planned runtime folder:
+
+```text
+assets/art/ui/glyphs/
+```
+
+Planned runtime export target: `512×512 PNG RGBA` per glyph, unless Work review proves SVG/vector is technically superior and preserves the same consumption/provenance contract.
+
+Runtime states such as recognized/selected/invalid/insufficient/committed should use Material/Outline/Modulate/Semantic Mark before creating duplicate textures.
+
+### Must Preserve
+
+- `data/glyphs/v1/glyph_vocabulary_v1.json` canonical shape/stroke identity
+- visible handwritten stroke flow
+- direct-written magical character impression
+- current Magic/Anime + Blue/Blue-Purple magic language
+- 48/64/96px UI readability
+
+### Must Not Introduce
+
+- talisman / hanging tag / paper charm
+- collectible-card framing
+- pictogram-first replacement of the letters
+- new glyph ID or new mechanic
+- baked functional text/numbers
+
+### Before Image Generation
+
+Work must first present and get approval for the exact **runtime consumer slot contract + six-glyph text brief**. This handoff does not authorize generation.
+
+## 9. IMG-01 Integration contract to prepare after image approval
+
+`CODEX-IMG-01 · Slice Glyph Integration`
+
+Goal: approved six glyph assets are consumed by the actual Task6/Task7 UI without altering spell transaction authority.
+
+Expected implementation shape:
+
+```text
+glyph_id
+→ one shared runtime asset resolver
+→ Task6 recognized glyph visual
+→ GlyphCard visual
+→ FIVE_POINT_STAR center/outer glyph visual
+→ later Task8 reuse
+```
+
+Expected runtime paths:
+
+```text
+assets/art/ui/glyphs/glyph_heat.png
+assets/art/ui/glyphs/glyph_protect.png
+assets/art/ui/glyphs/glyph_flow.png
+assets/art/ui/glyphs/glyph_focus.png
+assets/art/ui/glyphs/glyph_disperse.png
+assets/art/ui/glyphs/glyph_burst.png
+
+assets/manifests/glyph_heat.json
+...
+```
+
+Codex Non-Scope:
+
+- recognition algorithm redesign
+- Mana/inventory authority changes
+- Stage2/Stage3 transaction changes
+- new spell-name algorithm
+- auto target / auto cast
+
+Acceptance after integration:
+
+- correct glyph ID maps to correct visual
+- Task6 and Task7 consume the same glyph source
+- source card and circuit no longer rely on name text alone to represent the letter
+- state changes remain semantic and readable without texture explosion
+- 1280×720 and 1920×1080 runtime screenshots exist
+- existing tests and spell reservation/commit semantics do not regress
+
+## 10. Codex Integration Queue
+
+After each Image Goal reaches `Approved + Notion Registered + Implementation Ready`:
+
+1. `CODEX-IMG-01` Slice Glyph Integration
+2. `CODEX-IMG-02` Environment Base Integration
+3. `CODEX-IMG-03` Frostbloom State Integration
+4. `CODEX-IMG-04` Maren Dialogue Integration
+5. `CODEX-IMG-05` Protagonist Portrait Integration
+6. `CODEX-IMG-06` Greenhouse Spirit Animation Integration
+7. `CODEX-IMG-07` Companion Integration
+8. `CODEX-IMG-08` Field SD Integration
+9. `CODEX-IMG-09` Main/Title Integration
+
+Codex does not create the visual design by default. GPT/Work owns need analysis, text brief, generation/review, user approval and image-side handoff. Codex owns import/resource/scene/state/animation/runtime/test/evidence integration.
+
+## 11. Do Not Pre-produce
+
+- all 24 possible icons
+- all 12 possible VFX modules
+- all 8 legacy background overlays
+- peer/general NPC portrait library without an actual first-session consumer
+- companion growth stages
+- Guardian permanent battle body
+- 3D exploration family
+- mob-wave enemy family
+- Grimoire full illustration if Live UI suffices
+- Store art before playable proof
+
+## 12. Evidence Ceiling
+
+Do not claim any of the following without fresh execution evidence:
+
+```text
+RUNTIME_VISUAL_COMPLETE
+HUMAN_PASS
+DEVICE_PASS
+PERFORMANCE_PASS
+FULL_VERTICAL_SLICE_PASS
+WINDOWS_EXPORT_PASS
+ANDROID_EXPORT_OR_DEVICE_PASS
+```
+
+Current values remain `NOT_PROVEN / NOT_RUN`.
+
+## 13. Work Resume Prompt
+
+Use this as the first instruction in the GRIMOIRE Work workspace if a concise restart is useful:
+
+> GRIMOIRE 이미지 작업을 이어간다. 먼저 current Notion Home, AGENTS.md, ACTIVE_CONTEXT, `GRIMOIRE_GPT_WORK_IMAGE_GOAL_HANDOFF_2026-08-26.md`, `GRIMOIRE_IMAGE_GOAL_QUEUE_2026-08-26.json`, live GitHub main/open PR, latest Base main을 fresh-read해. 과거 메모리는 정본보다 낮게 둔다. 현재 NEXT는 IMG-01 Slice Magic Glyph Runtime Set 6종(HEAT/PROTECT/FLOW/FOCUS/DISPERSE/BURST)이다. 이미지부터 생성하지 말고 Task6/Task7 actual consumer slot/path/manifest 계약과 정확한 6종 텍스트 브리프를 먼저 제시한 뒤 STOP해서 내 승인을 기다려. 설명용 시트는 만들지 않는다.
+
+## 14. Stop Condition
+
+이 handoff 이후 첫 Work action은 **IMG-01 설계/브리프 검토**다. 이미지 생성, Godot 구현, Task8 복구는 자동으로 시작하지 않는다.

--- a/docs/planning/sync/GR-SYNC-20260826-39-GPT-WORK-IMAGE-GOAL-HANDOFF.md
+++ b/docs/planning/sync/GR-SYNC-20260826-39-GPT-WORK-IMAGE-GOAL-HANDOFF.md
@@ -1,0 +1,82 @@
+# GR-SYNC-20260826-39 · GPT Work Image Goal Handoff
+
+```yaml
+sync_id: GR-SYNC-20260826-39-GPT-WORK-IMAGE-GOAL-HANDOFF
+handoff_id: GR-WORK-HANDOFF-20260826-01
+project: GRIMOIRE
+scope: VISUAL_IMAGE_GOAL_HANDOFF_TO_CHATGPT_WORK
+source_project_main: 27749d2b3a552193283182143fe772e18f0ef45f
+source_base_main: 06669fe9c6a3ccd6f3b0d19c5757540bfdcc0623
+open_pr_readback: "#166 draft README-only unrelated/read-only"
+google_sheet: MIGRATION_ONLY_NO_NEW_CANON_WRITE
+image_generation: NOT_AUTHORIZED_BY_HANDOFF
+godot_implementation: NOT_AUTHORIZED_BY_HANDOFF
+human_validation: NOT_RUN
+device_validation: NOT_RUN
+performance_validation: NOT_RUN
+full_vertical_slice: NOT_RUN
+```
+
+## Purpose
+
+Move the current GRIMOIRE image-planning continuation into ChatGPT Work without treating chat memory as canon and without converting explanatory/reference visuals into production assets.
+
+## Fresh-read observations
+
+- GRIMOIRE latest completed `main` remained `27749d2b3a552193283182143fe772e18f0ef45f` at handoff start.
+- Open PR set contained Draft PR #166 only; it remains unrelated/read-only.
+- Base latest completed `main` was `06669fe9c6a3ccd6f3b0d19c5757540bfdcc0623`, whose latest Work/memory rule keeps persistent memory below project canon and requires fresh project readback.
+- Google Sheet `71_이미지기획_생성목록` still contains historical image-planning rows and remains migration-only.
+- Notion Home still exposes `글자 → 주문 → 대상 → 시전` and the current Visual lock.
+
+## Handoff artifacts
+
+- `docs/planning/GRIMOIRE_GPT_WORK_IMAGE_GOAL_HANDOFF_2026-08-26.md`
+- `docs/planning/visual/GRIMOIRE_IMAGE_GOAL_QUEUE_2026-08-26.json`
+- Notion `GRIMOIRE · GPT Work Image Goal Handoff · 2026-08-26`
+- Notion `Runtime Image Consumer Checklist · 2026-08-26` updated to point to the Work handoff and the six-glyph Slice runtime set.
+
+## Glyph correction
+
+Existing `GM-VISUAL-PRODUCTION-CHECKLIST-20260826-01` preserved a three-glyph Asset-Spec history (`FLOW / FOCUS / DISPERSE`). The current Slice runtime vocabulary and actual Task6/Task7 consumers require six glyphs:
+
+```text
+HEAT / PROTECT / FLOW / FOCUS / DISPERSE / BURST
+```
+
+The user explicitly approved proceeding on this six-glyph runtime basis. The new Image Goal Queue carries this correction without deleting historical provenance.
+
+## Current Goal Queue
+
+```text
+IMG-01 P0 Slice Magic Glyph Runtime Set
+IMG-02 P1 First-Session Environment Base Pack
+IMG-03 P1 Frostbloom Environment State Pack
+IMG-04 P1 Maren Dialogue Portrait Pack
+IMG-05 P1 Protagonist Portrait Pack
+IMG-06 P1 Greenhouse Spirit Combat Pack
+IMG-07 P1 Main Companion Initial Runtime Pack
+IMG-08 P1 Field SD Character Pack
+IMG-09 P2 Main/Title Runtime Pack
+IMG-10 P3 Store Key Art
+```
+
+## Immediate next action
+
+`IMG-01` only.
+
+```text
+fresh consumer read
+→ exact Task6/Task7 glyph visual slot/path/manifest contract
+→ six-glyph text brief
+→ STOP
+→ explicit user generation approval
+```
+
+No image is generated and no Godot/Task8 product code is modified by this sync.
+
+## Sync state
+
+`PR_PENDING_AT_DOCUMENT_CREATION`.
+
+After merge, read back exact `main`, update the Notion handoff/Home pointer, and do not upgrade any runtime/Human/device evidence beyond what was actually observed.

--- a/docs/planning/visual/GRIMOIRE_IMAGE_GOAL_QUEUE_2026-08-26.json
+++ b/docs/planning/visual/GRIMOIRE_IMAGE_GOAL_QUEUE_2026-08-26.json
@@ -1,0 +1,223 @@
+{
+  "schema_version": 1,
+  "project": "GRIMOIRE: 세계를 다시 쓰는 법",
+  "handoff_id": "GR-WORK-HANDOFF-20260826-01",
+  "queue_id": "GR-IMAGE-GOAL-QUEUE-20260826-01",
+  "status": "GPT_WORK_HANDOFF_READY",
+  "created_for": "CHATGPT_WORK",
+  "source_project_main": "27749d2b3a552193283182143fe772e18f0ef45f",
+  "source_base_main": "06669fe9c6a3ccd6f3b0d19c5757540bfdcc0623",
+  "authority": {
+    "project_agents": "AGENTS.md",
+    "active_context": "docs/ACTIVE_CONTEXT.md",
+    "visual_coverage": "docs/planning/visual/GRIMOIRE_VISUAL_ASSET_COVERAGE_2026-08-26.json",
+    "runtime_consumer_checklist": "docs/planning/visual/GRIMOIRE_VISUAL_PRODUCTION_CHECKLIST_2026-08-26.json",
+    "player_flow": "docs/planning/SPELL_WORKFLOW_PLAYER_FACING_SIMPLIFICATION_2026-08-26.md",
+    "asset_manifest_schema": "docs/planning/ASSET_MANIFEST_SCHEMA.json",
+    "glyph_vocabulary": "data/glyphs/v1/glyph_vocabulary_v1.json"
+  },
+  "work_mode": {
+    "target_surface": "CHATGPT_WORK",
+    "memory_policy": "PERSISTENT_ASSISTIVE_CONTEXT_ONLY_CANON_REMAINS_HIGHER_AUTHORITY",
+    "fresh_read_required_each_material_work_unit": true,
+    "first_read_order": [
+      "GRIMOIRE Notion Home",
+      "GRIMOIRE AGENTS.md",
+      "GRIMOIRE docs/ACTIVE_CONTEXT.md",
+      "this Image Goal Queue",
+      "Runtime Image Consumer Checklist",
+      "live GitHub main/open PR/runtime consumers",
+      "latest Base completed main and relevant visual/Work rules",
+      "Google Sheet migration-only unique drift when needed"
+    ]
+  },
+  "approved_player_flow": {
+    "decision_id": "GM-SPELL-WORKFLOW-UI-V2-01",
+    "flow": ["글자", "주문", "대상", "시전"],
+    "spell_build": "글자 선택·작성 + FIVE_POINT_STAR 회로 조합 + 완성 주문 이름 확인",
+    "spell_cast": "게임 장면에서 대상 지정 + 필요한 최종 Preview + 명시 시전",
+    "internal_terms_remain_runtime_authority": ["Stock", "PreparedSpell", "Stage2", "Stage3", "Main", "Auxiliary"]
+  },
+  "known_drift_corrections": [
+    {
+      "decision_id": "GM-VISUAL-PRODUCTION-CHECKLIST-20260826-01",
+      "field": "GR-RA-01-GLYPH-BASE count/base_names",
+      "previous_record": {"count": 3, "base_names": ["flow", "focus", "disperse"]},
+      "current_handoff_value": {"count": 6, "base_names": ["heat", "protect", "flow", "focus", "disperse", "burst"]},
+      "basis": [
+        "data/glyphs/v1/glyph_vocabulary_v1.json slice = HEAT/PROTECT/FLOW/FOCUS/DISPERSE/BURST",
+        "Task6 recognition tests consume all six Slice glyphs",
+        "Task7 loadout/circuit consumers already use Main and Support Slice glyph IDs",
+        "user explicitly approved proceeding with the six-glyph runtime basis on 2026-08-26"
+      ],
+      "rule": "The older 3-glyph row remains historical Asset-Spec provenance; Work must use six Slice runtime glyphs for IMG-01 unless a newer explicit user decision supersedes it."
+    }
+  ],
+  "existing_runtime_reuse": [
+    "assets/art/ui/common/academy_corner_ornament.svg",
+    "assets/art/ui/common/icon_mana.svg",
+    "assets/art/ui/common/icon_phase_diamond.svg",
+    "assets/art/ui/common/icon_typed_stock.svg",
+    "assets/art/ui/common/icon_warning_diamond.svg",
+    "src/ui/components/star_circuit_board.gd procedural FIVE_POINT_STAR",
+    "Component Sheets A-D / semantic live UI family"
+  ],
+  "goal_queue": [
+    {
+      "order": 1,
+      "goal_id": "IMG-01",
+      "name": "Slice Magic Glyph Runtime Set",
+      "priority": "P0",
+      "consumer_kind": "GAME_RUNTIME",
+      "consumers": [
+        "src/ui/spell_workflow/glyph_drawing_screen.tscn",
+        "src/ui/spell_workflow/components/glyph_card.tscn",
+        "src/ui/spell_workflow/circuit_placement_screen.tscn",
+        "src/ui/components/star_circuit_board.tscn",
+        "Task8 Spell Use future thin UI consumer"
+      ],
+      "required_assets": ["glyph_heat", "glyph_protect", "glyph_flow", "glyph_focus", "glyph_disperse", "glyph_burst"],
+      "planned_export": "512x512 PNG RGBA or equivalent approved vector source with deterministic runtime export",
+      "planned_folder": "assets/art/ui/glyphs/",
+      "state_policy": "recognized/selected/invalid/insufficient/committed states use Material/Outline/Modulate/Semantic Mark before texture duplication",
+      "must_preserve": ["canonical stroke identity", "direct-written magical letter feeling", "Magic/Anime + Blue/Blue-Purple magic language", "small-size silhouette distinction"],
+      "must_not_introduce": ["talisman", "hanging tag", "collectible card framing", "pictogram-first redesign", "baked functional text", "new glyph IDs"],
+      "status": "TEXT_BRIEF_AND_RUNTIME_SLOT_CONTRACT_PENDING",
+      "next_gate": "Define one shared glyph_id-to-asset resolver plus exact Task6/Task7 visual slots and manifest paths before any image generation."
+    },
+    {
+      "order": 2,
+      "goal_id": "IMG-02",
+      "name": "First-Session Environment Base Pack",
+      "priority": "P1",
+      "consumer_kind": "PLANNED_GAME_SURFACE",
+      "consumers": ["Class/Safe Precedent", "Guided Field Practicum", "Greenhouse Investigation/Return", "Greenhouse Battle"],
+      "required_assets": ["bg_school_common", "bg_greenhouse_field_base", "bg_greenhouse_battle_arena"],
+      "planned_export": "2560x1440 WebP Lossless",
+      "status": "CONSUMER_SCENE_SLOT_PENDING"
+    },
+    {
+      "order": 3,
+      "goal_id": "IMG-03",
+      "name": "Frostbloom Environment State Pack",
+      "priority": "P1",
+      "consumer_kind": "PLANNED_GAME_SURFACE",
+      "consumers": ["Greenhouse incident state", "Battle consequence state", "Post-result return"],
+      "required_assets_cap": 3,
+      "candidate_assets": ["greenhouse_pressure_warning", "greenhouse_damage", "greenhouse_resolved"],
+      "rule": "If Godot Light/Material/Particles produce the state clearly, creating a new overlay is unnecessary and counts as a successful reuse decision.",
+      "status": "BLOCKED_BY_IMG_02_AND_RUNTIME_EFFECT_REUSE_TEST"
+    },
+    {
+      "order": 4,
+      "goal_id": "IMG-04",
+      "name": "Maren Dialogue Portrait Pack",
+      "priority": "P1",
+      "consumer_kind": "PLANNED_GAME_SURFACE",
+      "consumer": "First-session Dialogue UI",
+      "required_assets": ["neutral", "instructive", "stern", "approving"],
+      "planned_export": "1024x1536 PNG RGBA",
+      "status": "BLOCKED_BY_CURRENT_CHARACTER_IDENTITY_BRIEF"
+    },
+    {
+      "order": 5,
+      "goal_id": "IMG-05",
+      "name": "Protagonist Portrait Pack",
+      "priority": "P1",
+      "consumer_kind": "PLANNED_GAME_SURFACE",
+      "consumers": ["Dialogue UI", "Battle portrait slot when implemented"],
+      "required_assets_cap": 4,
+      "candidate_states": ["neutral", "focused", "concerned", "relieved"],
+      "planned_export": "1024x1536 PNG RGBA",
+      "status": "BLOCKED_BY_PROTAGONIST_VISUAL_IDENTITY_OWNER"
+    },
+    {
+      "order": 6,
+      "goal_id": "IMG-06",
+      "name": "Greenhouse Spirit Combat Pack",
+      "priority": "P1",
+      "consumer_kind": "PLANNED_GAME_SURFACE",
+      "consumer": "Frostbloom Greenhouse Battle",
+      "required_packets": ["idle_unstable", "pressure_telegraph_attack", "surge_environment_telegraph_attack", "instability_reaction_calm_resolve"],
+      "frame_cap": 50,
+      "planned_export": "512x512 PNG RGBA frames",
+      "status": "BLOCKED_BY_BATTLE_CONSUMER_SCENE"
+    },
+    {
+      "order": 7,
+      "goal_id": "IMG-07",
+      "name": "Main Companion Initial Runtime Pack",
+      "priority": "P1",
+      "consumer_kind": "PLANNED_GAME_SURFACE",
+      "consumers": ["Field", "Dialogue reaction", "Battle status/reaction", "Result"],
+      "required_packets": ["idle", "move", "reaction_neutral_curious_alarmed_pleased"],
+      "frame_cap": 20,
+      "reaction_icon_cap": 4,
+      "planned_export": "256x256 PNG RGBA",
+      "status": "BLOCKED_BY_CURRENT_COMPANION_CANON_RECHECK"
+    },
+    {
+      "order": 8,
+      "goal_id": "IMG-08",
+      "name": "Field SD Character Pack",
+      "priority": "P1",
+      "consumer_kind": "PLANNED_GAME_SURFACE",
+      "consumer": "Simple 2D Field movement/interaction",
+      "actor_cap": 3,
+      "rule": "Do not pre-produce directions or high-frame animation until the actual Field Scene and clip requirements exist.",
+      "status": "BLOCKED_BY_FIELD_SCENE_AND_CLIP_CONTRACT"
+    },
+    {
+      "order": 9,
+      "goal_id": "IMG-09",
+      "name": "Main/Title Runtime Pack",
+      "priority": "P2",
+      "consumer_kind": "PLANNED_GAME_SURFACE",
+      "consumer": "Main/Title Screen",
+      "required_assets_cap": 2,
+      "candidate_assets": ["Logo 01 runtime export", "supporting composite only if BG reuse is insufficient"],
+      "status": "DEFER_UNTIL_PRODUCT_ROOT_EXISTS"
+    },
+    {
+      "order": 10,
+      "goal_id": "IMG-10",
+      "name": "Store Key Art",
+      "priority": "P3",
+      "consumer_kind": "PRODUCT_DISTRIBUTION",
+      "consumer": "Store/Marketing surface",
+      "required_assets_cap": 1,
+      "status": "DEFER_UNTIL_PLAYABLE_PROOF_AND_PLATFORM_SPEC_RECHECK"
+    }
+  ],
+  "codex_integration_queue": [
+    "CODEX-IMG-01 Slice Glyph Integration",
+    "CODEX-IMG-02 Environment Base Integration",
+    "CODEX-IMG-03 Frostbloom State Integration",
+    "CODEX-IMG-04 Maren Dialogue Integration",
+    "CODEX-IMG-05 Protagonist Portrait Integration",
+    "CODEX-IMG-06 Greenhouse Spirit Animation Integration",
+    "CODEX-IMG-07 Companion Integration",
+    "CODEX-IMG-08 Field SD Integration",
+    "CODEX-IMG-09 Main/Title Integration"
+  ],
+  "image_generation_gate": {
+    "handoff_itself_authorizes_generation": false,
+    "required_sequence": ["fresh canon/consumer read", "goal text brief", "STOP", "explicit user generation approval", "exactly one result", "STOP", "user approve or revise"],
+    "batch_generation_from_queue": false
+  },
+  "implementation_gate": {
+    "handoff_itself_authorizes_godot_implementation": false,
+    "required_before_codex_integration": ["generated image reviewed", "user approved", "Notion registered", "implementation-ready file/export/provenance prepared", "CODEX-IMG goal issued"]
+  },
+  "evidence_ceiling": {
+    "product_stage": "PARTIAL_FOUNDATION",
+    "runtime_visual_complete": "NOT_PROVEN",
+    "human": "NOT_RUN",
+    "device": "NOT_RUN",
+    "performance": "NOT_RUN",
+    "full_vertical_slice": "NOT_RUN",
+    "windows_export": "NOT_RUN",
+    "android_export_device": "NOT_RUN"
+  },
+  "resume_instruction": "In ChatGPT Work, start with IMG-01 only. First reconcile the six-glyph runtime consumer contract and exact asset slots/paths. Do not generate an image until the IMG-01 text brief is shown to and explicitly approved by the user."
+}


### PR DESCRIPTION
## Summary
- add GR-WORK-HANDOFF-20260826-01 as the ChatGPT Work continuation entrypoint
- add the consumer-first Remaining Image Goal queue and Codex Integration queue
- record the approved Slice glyph correction from 3 historical Asset-Spec glyphs to 6 actual runtime Slice glyphs: HEAT/PROTECT/FLOW/FOCUS/DISPERSE/BURST
- keep image generation and Godot/Task8 implementation explicitly gated

## Fresh-read boundary
- project main at handoff start: `27749d2b3a552193283182143fe772e18f0ef45f`
- latest Base observed: `06669fe9c6a3ccd6f3b0d19c5757540bfdcc0623`
- open PR #166 remains unrelated/read-only
- Google Sheet remains migration-only

## Files
- `docs/planning/GRIMOIRE_GPT_WORK_IMAGE_GOAL_HANDOFF_2026-08-26.md`
- `docs/planning/visual/GRIMOIRE_IMAGE_GOAL_QUEUE_2026-08-26.json`
- `docs/planning/sync/GR-SYNC-20260826-39-GPT-WORK-IMAGE-GOAL-HANDOFF.md`

## Non-scope
- no image generation
- no Godot product code/scene/resource mutation
- no Task8 recovery or implementation
- no Human/device/performance/full-slice evidence promotion
- no Google Sheet canon write
- do not touch PR #166
