### PR TITLE
fix: show glyph previews in star harness

### DIFF
--- a/src/ui/star_circuit_harness.gd
+++ b/src/ui/star_circuit_harness.gd
@@ -549,6 +549,13 @@ func _active_auxiliary_slots() -> Array[int]:
 func _update_visual_state(state: StringName, cause_vertex: int = -1) -> void:
     var active_slots := _active_auxiliary_slots()
     var board := get_node_or_null("SafeArea/StarBoard")
+    var auxiliary_glyphs: Dictionary = {}
+    for slot in range(_auxiliary_indices.size()):
+        var glyph_index := _auxiliary_indices[slot]
+        if glyph_index >= 0:
+            auxiliary_glyphs[slot] = GLYPH_IDS[glyph_index]
+    if board != null and board.has_method("set_glyph_visuals"):
+        board.call("set_glyph_visuals", GLYPH_IDS[_main_index], auxiliary_glyphs)
     if board != null and board.has_method("set_visual_state"):
         board.call("set_visual_state", state, active_slots.size(), cause_vertex, active_slots)
     _set_label("SafeArea/PhaseBadge/Content/Label", _phase_label(state))

--- a/tests/integration/test_star_ui_kit_scene.gd
+++ b/tests/integration/test_star_ui_kit_scene.gd
@@ -65,6 +65,24 @@ func run(case) -> void:
     harness.initialize_demo()
     case.assert_true(harness.theme != null, "Harness applies one shared Theme during deterministic initialization")
 
+    var glyph_board = harness.get_node_or_null("SafeArea/StarBoard")
+    case.assert_true(glyph_board != null, "Harness has a board for glyph previews")
+    case.assert_true(glyph_board != null and glyph_board.has_method("glyph_visual_snapshot"), "Harness board exposes glyph visual snapshot")
+    if glyph_board != null and glyph_board.has_method("glyph_visual_snapshot"):
+        var harness_glyph_visuals: Dictionary = glyph_board.glyph_visual_snapshot()
+        var center_texture := glyph_board.get_node_or_null("GlyphVisuals/CenterGlyphTexture") as TextureRect
+        var aux_zero_texture := glyph_board.get_node_or_null("GlyphVisuals/AuxGlyphTexture0") as TextureRect
+        var aux_one_texture := glyph_board.get_node_or_null("GlyphVisuals/AuxGlyphTexture1") as TextureRect
+        var center_name := glyph_board.get_node_or_null("GlyphVisuals/CenterGlyphNameLabel") as Label
+        var aux_zero_name := glyph_board.get_node_or_null("GlyphVisuals/AuxGlyphNameLabel0") as Label
+        case.assert_equal(&"HEAT", harness_glyph_visuals.get("main_glyph_id", &""), "Harness binds the default HEAT Main glyph to the board")
+        case.assert_equal(&"FLOW", Dictionary(harness_glyph_visuals.get("auxiliary_by_slot", {})).get(0, &""), "Harness binds the default FLOW Aux glyph to the board")
+        case.assert_true(center_texture != null and center_texture.texture != null, "Harness renders the HEAT glyph texture")
+        case.assert_true(aux_zero_texture != null and aux_zero_texture.texture != null, "Harness renders the FLOW glyph texture")
+        case.assert_true(aux_one_texture != null and aux_one_texture.texture == null, "Harness leaves the empty A1 glyph slot unbound")
+        case.assert_equal("열기", center_name.text if center_name != null else "", "Harness renders the Korean Main glyph label")
+        case.assert_equal("흐름", aux_zero_name.text if aux_zero_name != null else "", "Harness renders the Korean Aux glyph label")
+
     var main_slot := harness.get_node_or_null("SafeArea/CenterGlyph") as Button
     case.assert_true(main_slot != null, "Main glyph slot remains available")
     if main_slot != null:


### PR DESCRIPTION
## Summary
- Binds the harness's existing Main/Aux glyph state to `StarCircuitBoard.set_glyph_visuals`.
- Renders approved HEAT/FLOW PNGs and live Korean labels in the default runtime demonstration.
- Adds an integration test that would fail if the display-only binding is removed.

## Scope
Display-only runtime harness correction. No change to reservations, mana, target selection, or explicit commit semantics.

## Validation
- `python tools/generate_project_operating_views.py --check`
- `python -m unittest tests.test_base_v91_operating_contract tests.test_current_authority_reality_contract` (12 tests)
- Godot 4.7.2 headless SceneTree (44 suites, 1,896 assertions, 0 failures)
- `git diff --check`

Fixes #181