### PR TITLE
feat(task8): recover spell use screen

### DIFF
--- a/docs/superpowers/plans/2026-08-27-task8-spell-use-reconciliation.md
+++ b/docs/superpowers/plans/2026-08-27-task8-spell-use-reconciliation.md
@@ -1,0 +1,207 @@
+# Task8 Spell Use Reconciliation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Recover the approved Task8 target-and-cast screen as a thin player-facing consumer of the current `SpellWorkflowCoordinator` authority.
+
+**Architecture:** `SpellUseScreen` owns only rendering, explicit player intent, focus order, and stale-preview clearing. It delegates prepared-spell selection, target preview, confirmation gating, and exactly-once use to `SpellWorkflowCoordinator`; `ContextTargetSelector` and `CommitBar` provide the current shared presentation primitives. The historical primary candidate is reference evidence only: every persistent `.gd`/`.tscn` artifact is newly authored through the exact connected Godot editor after a focused failing test.
+
+**Tech Stack:** Godot 4.7.2, GDScript, GUT 9.7.1, Godot AI editor bridge, Hera read-only QA, the project headless runner.
+
+**Spec:** `docs/planning/TASK8_LOCAL_RECOVERY_EXECUTOR_PACKET_2026-08-24.md`, GitHub Issue #111, `docs/planning/SPELL_WORKFLOW_PLAYER_FACING_SIMPLIFICATION_2026-08-26.md`
+
+## Global Constraints
+
+- Current product flow is `글자 → 주문 → 대상 → 시전`; Task8 implements only the target-and-cast portion.
+- Preserve `SpellWorkflowCoordinator` and existing atomic-use services as the sole gameplay authority.
+- No automatic target selection, automatic cast, new transaction/use ID, Mana/inventory/result mutation, rollback, or Stage2 rewrite.
+- The caller supplies the opaque `use_transaction_id`; the screen must fail closed when it is absent.
+- Target changes or invalid targets clear stale preview truth and disable confirmation.
+- First explicit action requests confirmation; the second calls `confirm_use(use_transaction_id)` exactly once; failures retain context.
+- Use `ContextTargetSelector` after behavior parity is tested and `CommitBar` only as player-intent UI. Do not use `ForecastCard` unless the current authoritative payload supplies each semantic field it displays.
+- New GDScript starts with a Korean role header comment. Persistent `.gd` and `.tscn` writes use the exact connected Godot editor only.
+- Preserve all current runner suites and add exactly one Task8 suite. No IMG-02 environment asset binding is in this task.
+- Human, device, performance, export, and full vertical-slice validation remain `NOT_RUN` unless actually run.
+
+---
+
+## File Structure
+
+- `src/ui/spell_workflow/spell_use_screen.gd` — thin Task8 UI controller; no gameplay mutation authority.
+- `src/ui/spell_workflow/spell_use_screen.tscn` — responsive composition using current shared target/commit components and a thin result panel.
+- `tests/gut/integration/test_spell_use_screen.gd` — focused GUT behavior and accessibility regression contract.
+- `tests/integration/test_spell_use_screen.gd` — runner-compatible integration contract, kept deliberately thin and behavior-identical to the focused GUT cases.
+- `tests/test_runner.gd` — registers only the runner-compatible Task8 suite in addition to every existing suite.
+- `docs/planning/TASK8_*` — bounded implementation receipt and status correction after verified work only.
+
+### Task 1: Establish the focused red contract
+
+**Files:**
+- Create: `tests/gut/integration/test_spell_use_screen.gd`
+- Create: `tests/integration/test_spell_use_screen.gd`
+- Modify: `tests/test_runner.gd`
+
+**Interfaces:**
+- Consumes: `SpellWorkflowCoordinator.select_prepared_spell(spell_id) -> bool`, `prepare_target_preview(target_keyword, target, payload) -> Dictionary`, `request_use_confirmation() -> bool`, and `confirm_use(use_transaction_id) -> Dictionary`.
+- Produces: tests requiring explicit target choice, stale-preview invalidation, two-stage caller-supplied confirmation, failure-context retention, and logical focus order.
+
+- [ ] **Step 1: Create one failing test for explicit target preview.**
+
+```gdscript
+func test_target_choice_requires_coordinator_preview_before_commit() -> void:
+    var screen := _configured_screen(&"use-opaque-1")
+    assert_false(screen.can_confirm())
+    screen.select_target(&"incident.root", _valid_target(), _payload())
+    assert_eq(screen.current_preview()["status"], &"FINAL_PREVIEW_READY")
+    assert_true(screen.can_confirm())
+```
+
+- [ ] **Step 2: Run the focused suite through the connected editor and confirm it fails because `SpellUseScreen` is absent.**
+
+Expected: a load/instantiate failure naming `res://src/ui/spell_workflow/spell_use_screen.gd`, not an unrelated project error.
+
+- [ ] **Step 3: Add the remaining red tests before production code.**
+
+```gdscript
+func test_invalid_target_clears_previous_preview_and_blocks_commit() -> void:
+    # A valid preview followed by INVALID_TARGET leaves no selectable preview.
+
+func test_first_commit_requests_confirmation_and_second_uses_caller_id_once() -> void:
+    # `confirm_use` receives &"use-opaque-1" exactly once.
+
+func test_empty_transaction_id_fails_closed_without_commit() -> void:
+    # A missing caller-supplied ID cannot reach gameplay authority.
+
+func test_cancel_retains_context_and_emits_only_cancellation_intent() -> void:
+    # No Mana, inventory, or rollback behavior occurs in the screen.
+```
+
+- [ ] **Step 4: Create the runner-compatible integration suite before production code and register it after the existing Task7 workflow suites.**
+
+```gdscript
+"res://tests/integration/test_spell_use_screen.gd",
+```
+
+- [ ] **Step 5: Re-run the focused GUT suite and the current project runner; record the expected RED result for the absent Spell Use screen.**
+
+### Task 2: Re-author the minimal thin UI controller
+
+**Files:**
+- Create: `src/ui/spell_workflow/spell_use_screen.gd`
+
+**Interfaces:**
+- Consumes: caller-owned coordinator and `use_transaction_id` via `configure(coordinator, use_transaction_id)`.
+- Produces: `render_prepared_spell_summary(summary)`, `set_target_choices(target_choices)`, `select_target(target_keyword, target, payload)`, `current_preview()`, `request_confirmation()`, `confirm(transaction_id)`, and `cancel()`.
+
+- [ ] **Step 1: Write only the smallest GDScript that lets the first red test instantiate the screen.**
+
+```gdscript
+# 주문 쓰기 화면은 기존 Coordinator의 대상·시전 권한을 표시하고 의도만 전달한다.
+class_name SpellUseScreen
+extends Control
+
+signal cancel_requested
+
+var _coordinator = null
+var _use_transaction_id: StringName = &""
+var _current_preview: Dictionary = {}
+var _confirmation_requested := false
+var _committed := false
+```
+
+- [ ] **Step 2: Implement `select_target` by calling only `prepare_target_preview`.**
+
+```gdscript
+func select_target(target_keyword: StringName, target: Dictionary, payload: Dictionary) -> Dictionary:
+    _current_preview = _coordinator.prepare_target_preview(target_keyword, target, payload)
+    if StringName(_current_preview.get("status", &"")) != &"FINAL_PREVIEW_READY":
+        _clear_preview_for_failed_target(StringName(_current_preview.get("status", &"INVALID_TARGET")))
+    return current_preview()
+```
+
+- [ ] **Step 3: Run the focused suite and confirm the target-preview test passes while unimplemented confirmation tests still fail.**
+
+- [ ] **Step 4: Implement confirmation as the two explicit coordinator calls.**
+
+```gdscript
+func request_confirmation() -> bool:
+    if _current_preview.is_empty() or _committed:
+        return false
+    _confirmation_requested = _coordinator.request_use_confirmation()
+    return _confirmation_requested
+
+func confirm(transaction_id: StringName) -> Dictionary:
+    if transaction_id.is_empty() or transaction_id != _use_transaction_id or not _confirmation_requested or _committed:
+        return {"status": &"USE_CONFIRMATION_REQUIRED"}
+    var result := _coordinator.confirm_use(transaction_id)
+    if StringName(result.get("status", &"")) == &"USED":
+        _committed = true
+    return result
+```
+
+- [ ] **Step 5: Run the focused suite and confirm every Task8 behavior test passes.**
+
+### Task 3: Compose the current shared UI scene
+
+**Files:**
+- Create: `src/ui/spell_workflow/spell_use_screen.tscn`
+- Modify: `src/ui/spell_workflow/spell_use_screen.gd`
+
+**Interfaces:**
+- Consumes: `ContextTargetSelector.target_selected(target_id)` and `CommitBar.edit_requested`/`commit_requested`.
+- Produces: a keyboard-accessible summary → target choice → final preview → confirmation/cancel hierarchy.
+
+- [ ] **Step 1: Extend the red test to assert scene nodes and focus order.**
+
+```gdscript
+func test_information_hierarchy_orders_summary_choices_preview_confirm_and_cancel() -> void:
+    assert_eq(_screen.focus_order(), ["PreparedSpellSummary", "TargetSelector", "FinalPreview", "CommitBar", "CancelButton"])
+```
+
+- [ ] **Step 2: Create the scene through the connected Godot editor using current shared component scenes.**
+
+```text
+SpellUseScreen (Control)
+└── Content (VBoxContainer)
+    ├── PreparedSpellSummary (Label)
+    ├── TargetSelector (ContextTargetSelector instance)
+    ├── FinalPreview (VBoxContainer with authoritative values only)
+    ├── CommitBar (CommitBar instance)
+    └── CancelButton (Button)
+```
+
+- [ ] **Step 3: Bind component signals to player-intent methods; never call services directly from component callbacks.**
+
+- [ ] **Step 4: Re-run focused Task8 tests and the current Task6/Task7 workflow screen tests.**
+
+### Task 4: Reconcile regression coverage and evidence
+
+**Files:**
+- Modify: `docs/planning/TASK8_*` only after exact evidence exists.
+
+**Interfaces:**
+- Consumes: focused Task8 suite, coordinator/atomic-use suites, current full runner, Godot editor diagnostics, and Hera read-only output.
+- Produces: truthful task evidence without promoting unrun human/device/performance/full-slice gates.
+
+- [ ] **Step 1: Run exact connected-editor Task8 tests and record counts/failures.**
+- [ ] **Step 2: Run coordinator, state, and atomic spell-use predecessor regressions.**
+- [ ] **Step 3: Run `tests/test_runner.gd` once after all final edits and require the added Task8 suite plus every existing suite.**
+- [ ] **Step 4: Use Hera only for editor/runtime diagnostics, source-delta observation, and UI smoke evidence; do not use Hera for persistent writes.**
+- [ ] **Step 5: Run `git diff --check`, exact-path adversarial review, and protected historical-worktree unchanged checks.**
+- [ ] **Step 6: Update the GitHub Issue #111 checkpoint and Notion/repository documentation with only verified results.**
+
+### Task 5: Integrate only after review gates pass
+
+**Files:**
+- Modify: reviewed Task8 files and bounded evidence docs only.
+
+- [ ] **Step 1: Run the verification-before-completion checklist and inspect the complete diff against Issue #111.**
+- [ ] **Step 2: Commit the current reconciliation branch with the focused product and evidence changes.**
+- [ ] **Step 3: Push and open a Task8 product PR; verify exact-head CI and unresolved review threads before merge.**
+- [ ] **Step 4: Merge only when applicable checks are green, then fresh-read `origin/main` and record the post-merge evidence.**
+
+## Self-Review
+
+- Scope coverage: explicit target selection, final preview, two-step cast confirmation, duplicate prevention, stale preview clearing, cancellation, focus semantics, current shared UI adoption, exact current-runner preservation, and bounded evidence are mapped to Tasks 1–5.
+- Placeholder scan: no open implementation placeholders are used; unknown semantic forecast fields are explicitly excluded instead of guessed.
+- Type consistency: the plan uses the current Coordinator signatures and current shared component signals exactly as read from the connected project.

--- a/src/ui/spell_workflow/spell_use_screen.gd
+++ b/src/ui/spell_workflow/spell_use_screen.gd
@@ -1,0 +1,136 @@
+# 주문 쓰기 화면은 기존 Coordinator의 대상·시전 권한을 표시하고 의도만 전달한다.
+class_name SpellUseScreen
+extends Control
+
+signal cancel_requested
+
+var _coordinator = null
+var _use_transaction_id: StringName = &""
+var _current_preview: Dictionary = {}
+var _confirmation_requested := false
+var _committed := false
+var _target_choices_by_id: Dictionary = {}
+
+
+func configure(coordinator, use_transaction_id: StringName = &"") -> void:
+    _coordinator = coordinator
+    _use_transaction_id = use_transaction_id
+    _current_preview.clear()
+    _confirmation_requested = false
+    _committed = false
+    _target_choices_by_id.clear()
+
+
+func select_target(target_keyword: StringName, target: Dictionary, payload: Dictionary) -> Dictionary:
+    if _coordinator == null:
+        return {"status": &"SPELL_SELECTION_REQUIRED"}
+    var preview: Dictionary = _coordinator.prepare_target_preview(target_keyword, target, payload)
+    if StringName(preview.get("status", &"")) != &"FINAL_PREVIEW_READY":
+        _current_preview.clear()
+        _render_preview_status(StringName(preview.get("status", &"INVALID_TARGET")), {}, false)
+        return preview.duplicate(true)
+    _current_preview = preview.duplicate(true)
+    _render_preview_status(&"FINAL_PREVIEW_READY", _current_preview, true)
+    return current_preview()
+
+
+func _ready() -> void:
+    var selector = get_node_or_null("Content/TargetSelector")
+    if selector != null and selector.has_signal("target_selected") and not selector.target_selected.is_connected(_on_target_selected):
+        selector.target_selected.connect(_on_target_selected)
+    var commit_bar = get_node_or_null("Content/CommitBar")
+    if commit_bar != null and commit_bar.has_signal("commit_requested") and not commit_bar.commit_requested.is_connected(_on_commit_requested):
+        commit_bar.commit_requested.connect(_on_commit_requested)
+    if commit_bar != null and commit_bar.has_signal("edit_requested") and not commit_bar.edit_requested.is_connected(_on_edit_requested):
+        commit_bar.edit_requested.connect(_on_edit_requested)
+    var cancel_button = get_node_or_null("Content/CancelButton") as Button
+    if cancel_button != null and not cancel_button.pressed.is_connected(_on_cancel_pressed):
+        cancel_button.pressed.connect(_on_cancel_pressed)
+
+
+func set_target_choices(target_choices: Array) -> void:
+    _target_choices_by_id.clear()
+    var selector_choices: Array[Dictionary] = []
+    for candidate_variant in target_choices:
+        var candidate: Dictionary = Dictionary(candidate_variant)
+        var choice_id := StringName(candidate.get("id", &""))
+        if choice_id.is_empty() or not candidate.has("label") or not candidate.has("hint") or not candidate.has("target_keyword") or not candidate.has("target") or not candidate.has("payload"):
+            continue
+        _target_choices_by_id[choice_id] = candidate.duplicate(true)
+        selector_choices.append({"id": choice_id, "label": str(candidate["label"]), "hint": str(candidate["hint"])})
+    var selector = get_node_or_null("Content/TargetSelector")
+    if selector != null and selector.has_method("configure_targets"):
+        selector.configure_targets(selector_choices)
+
+
+func _on_target_selected(choice_id: StringName) -> void:
+    if not _target_choices_by_id.has(choice_id):
+        return
+    var choice: Dictionary = Dictionary(_target_choices_by_id[choice_id])
+    select_target(
+        StringName(choice.get("target_keyword", &"")),
+        Dictionary(choice.get("target", {})),
+        Dictionary(choice.get("payload", {})),
+    )
+
+
+func _render_preview_status(status: StringName, preview_result: Dictionary, can_commit: bool) -> void:
+    var status_label = get_node_or_null("Content/FinalPreview/Status") as Label
+    if status_label != null:
+        status_label.text = str(status)
+    var preview: Dictionary = Dictionary(preview_result.get("preview", {}))
+    var commit_bar = get_node_or_null("Content/CommitBar")
+    if commit_bar != null and commit_bar.has_method("configure"):
+        commit_bar.configure(
+            str(preview.get("target_keyword", "—")),
+            maxi(0, int(preview.get("estimated_mana", 0))),
+            can_commit,
+            _confirmation_requested,
+        )
+
+
+func current_preview() -> Dictionary:
+    return _current_preview.duplicate(true)
+
+
+func request_confirmation() -> bool:
+    if _coordinator == null or _current_preview.is_empty() or _committed:
+        return false
+    _confirmation_requested = _coordinator.request_use_confirmation()
+    if _confirmation_requested:
+        _render_preview_status(&"FINAL_PREVIEW_READY", _current_preview, true)
+    return _confirmation_requested
+
+
+func confirm(transaction_id: StringName) -> Dictionary:
+    if _coordinator == null or transaction_id.is_empty() or transaction_id != _use_transaction_id:
+        return {"status": &"USE_CONFIRMATION_REQUIRED"}
+    if not _confirmation_requested or _committed:
+        return {"status": &"USE_CONFIRMATION_REQUIRED"}
+    var result: Dictionary = _coordinator.confirm_use(transaction_id)
+    if StringName(result.get("status", &"")) == &"USED":
+        _committed = true
+    return result.duplicate(true)
+
+
+func cancel() -> void:
+    cancel_requested.emit()
+
+
+func _on_edit_requested() -> void:
+    if _committed:
+        return
+    _confirmation_requested = false
+    if not _current_preview.is_empty():
+        _render_preview_status(&"FINAL_PREVIEW_READY", _current_preview, true)
+
+
+func _on_commit_requested() -> void:
+    if not _confirmation_requested:
+        request_confirmation()
+        return
+    confirm(_use_transaction_id)
+
+
+func _on_cancel_pressed() -> void:
+    cancel()

--- a/src/ui/spell_workflow/spell_use_screen.gd.uid
+++ b/src/ui/spell_workflow/spell_use_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://dmx6nrjtunu3a

--- a/src/ui/spell_workflow/spell_use_screen.tscn
+++ b/src/ui/spell_workflow/spell_use_screen.tscn
@@ -1,0 +1,42 @@
+[gd_scene format=3 uid="uid://qfvh1n7f5veh"]
+
+[ext_resource type="Script" uid="uid://dmx6nrjtunu3a" path="res://src/ui/spell_workflow/spell_use_screen.gd" id="1_8nct5"]
+[ext_resource type="PackedScene" path="res://src/ui/components/context_target_selector.tscn" id="2_j56eg"]
+[ext_resource type="PackedScene" path="res://src/ui/components/commit_bar.tscn" id="3_tst33"]
+
+[node name="SpellUseScreen" type="Control" unique_id=633510490]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("1_8nct5")
+
+[node name="Content" type="VBoxContainer" parent="." unique_id=1508212985]
+layout_mode = 0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 32.0
+offset_top = 32.0
+offset_right = -32.0
+offset_bottom = -32.0
+
+[node name="PreparedSpellSummary" type="Label" parent="Content" unique_id=113813754]
+layout_mode = 2
+text = "COMPLETED SPELL"
+
+[node name="TargetSelector" parent="Content" unique_id=717049310 instance=ExtResource("2_j56eg")]
+layout_mode = 2
+
+[node name="FinalPreview" type="VBoxContainer" parent="Content" unique_id=356041737]
+layout_mode = 2
+
+[node name="Status" type="Label" parent="Content/FinalPreview" unique_id=957182784]
+layout_mode = 2
+text = "SELECT A TARGET"
+
+[node name="CommitBar" parent="Content" unique_id=984337452 instance=ExtResource("3_tst33")]
+layout_mode = 2
+
+[node name="CancelButton" type="Button" parent="Content" unique_id=550515003]
+layout_mode = 2
+text = "CANCEL"

--- a/tests/gut/integration/test_spell_use_screen.gd
+++ b/tests/gut/integration/test_spell_use_screen.gd
@@ -1,0 +1,33 @@
+# Task8 주문 쓰기 화면이 기존 사용 권한을 중복하지 않는지 검증한다.
+extends GutTest
+
+const SpellUseScreen = preload("res://src/ui/spell_workflow/spell_use_screen.gd")
+
+
+class FakeCoordinator:
+    extends RefCounted
+
+    var confirm_calls: Array[StringName] = []
+
+    func prepare_target_preview(_target_keyword: StringName, _target: Dictionary, _payload: Dictionary) -> Dictionary:
+        return {"status": &"FINAL_PREVIEW_READY", "preview": {"estimated_mana": 7}}
+
+    func request_use_confirmation() -> bool:
+        return true
+
+    func confirm_use(use_transaction_id: StringName) -> Dictionary:
+        confirm_calls.append(use_transaction_id)
+        return {"status": &"USED"}
+
+
+func test_explicit_two_step_confirmation_uses_caller_id_once() -> void:
+    var screen = SpellUseScreen.new()
+    var coordinator = FakeCoordinator.new()
+    screen.configure(coordinator, &"opaque-use-id")
+    screen.select_target(&"incident.root", {"target_valid": true}, {})
+
+    assert_true(screen.request_confirmation())
+    assert_eq(screen.confirm(&"opaque-use-id").get("status", &""), &"USED")
+    assert_eq(screen.confirm(&"opaque-use-id").get("status", &""), &"USE_CONFIRMATION_REQUIRED")
+    assert_eq(coordinator.confirm_calls, [&"opaque-use-id"])
+    screen.free()

--- a/tests/gut/integration/test_spell_use_screen.gd.uid
+++ b/tests/gut/integration/test_spell_use_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://dohghoclyuf1g

--- a/tests/integration/test_spell_use_screen.gd
+++ b/tests/integration/test_spell_use_screen.gd
@@ -1,0 +1,116 @@
+# Task8 주문 쓰기 화면의 명시적 대상 선택과 시전 경계를 검증한다.
+extends RefCounted
+
+const SCREEN_SCENE_PATH := "res://src/ui/spell_workflow/spell_use_screen.tscn"
+
+
+class FakeCoordinator:
+    extends RefCounted
+
+    var preview_calls: Array[Dictionary] = []
+    var confirmation_requests := 0
+    var confirmed_ids: Array[StringName] = []
+
+    func prepare_target_preview(target_keyword: StringName, target: Dictionary, payload: Dictionary) -> Dictionary:
+        preview_calls.append({"target_keyword": target_keyword, "target": target.duplicate(true), "payload": payload.duplicate(true)})
+        if not bool(target.get("target_valid", false)):
+            return {"status": &"INVALID_TARGET"}
+        return {
+            "status": &"FINAL_PREVIEW_READY",
+            "preview": {"estimated_mana": 7, "success_percent": 82, "target_keyword": target_keyword},
+        }
+
+    func request_use_confirmation() -> bool:
+        confirmation_requests += 1
+        return true
+
+    func confirm_use(use_transaction_id: StringName) -> Dictionary:
+        confirmed_ids.append(use_transaction_id)
+        return {"status": &"USED", "use_transaction_id": use_transaction_id}
+
+
+func run(case) -> void:
+    var packed_scene = load(SCREEN_SCENE_PATH)
+    case.assert_true(packed_scene != null and packed_scene.can_instantiate(), "Task8 Spell Use scene must instantiate")
+    if packed_scene == null or not packed_scene.can_instantiate():
+        return
+    var screen = packed_scene.instantiate()
+    for node_name in ["PreparedSpellSummary", "TargetSelector", "FinalPreview", "CommitBar", "CancelButton"]:
+        case.assert_true(screen.find_child(node_name, true, false) != null, "screen exposes player flow node: %s" % node_name)
+    var coordinator = FakeCoordinator.new()
+    case.assert_true(screen.has_method("configure"), "screen accepts the caller-owned coordinator and opaque ID")
+    case.assert_true(screen.has_method("select_target"), "screen exposes explicit target intent")
+    case.assert_true(screen.has_method("current_preview"), "screen exposes only its rendered preview state")
+    case.assert_true(screen.has_method("request_confirmation"), "screen exposes a confirmation request before any use")
+    case.assert_true(screen.has_method("confirm"), "screen exposes explicit caller-ID confirmation")
+    if not screen.has_method("configure") or not screen.has_method("select_target") or not screen.has_method("current_preview") or not screen.has_method("request_confirmation") or not screen.has_method("confirm"):
+        screen.queue_free()
+        return
+    screen.configure(coordinator, &"use-opaque-1")
+    screen._ready()
+    var preview: Dictionary = screen.select_target(
+        &"incident.root",
+        {"target_valid": true, "label": "Root"},
+        {"known_improvement": "stabilize"}
+    )
+    case.assert_equal(&"FINAL_PREVIEW_READY", preview.get("status", &""), "a valid explicit target receives the Coordinator preview")
+    var status_label = screen.find_child("Status", true, false) as Label
+    var main_commit_bar = screen.find_child("CommitBar", true, false)
+    case.assert_equal("FINAL_PREVIEW_READY", status_label.text if status_label != null else "", "authoritative preview state is visible as text")
+    case.assert_true(bool(main_commit_bar.visual_snapshot().get("can_commit", false)), "valid preview enables only the intent-level commit control")
+    case.assert_equal(1, coordinator.preview_calls.size(), "screen delegates target preview exactly once")
+    var invalid_preview: Dictionary = screen.select_target(
+        &"incident.invalid",
+        {"target_valid": false, "label": "Invalid"},
+        {}
+    )
+    case.assert_equal(&"INVALID_TARGET", invalid_preview.get("status", &""), "invalid selection reports the authority status")
+    case.assert_true(screen.current_preview().is_empty(), "invalid target clears stale preview truth")
+    case.assert_equal(2, coordinator.preview_calls.size(), "invalid target still delegates validation to the Coordinator once")
+    screen.select_target(&"incident.root", {"target_valid": true, "label": "Root"}, {})
+    case.assert_true(screen.request_confirmation(), "first explicit use action requests confirmation")
+    case.assert_true(bool(main_commit_bar.visual_snapshot().get("confirmation_required", false)), "confirmation state becomes textually distinct before final use")
+    case.assert_equal(1, coordinator.confirmation_requests, "screen delegates confirmation request exactly once")
+    main_commit_bar.edit_requested.emit()
+    case.assert_false(bool(main_commit_bar.visual_snapshot().get("confirmation_required", true)), "edit cancels confirmation before a new target decision")
+    case.assert_equal(&"USE_CONFIRMATION_REQUIRED", screen.confirm(&"use-opaque-1").get("status", &""), "edit prevents a stale confirmation from casting")
+    case.assert_true(screen.request_confirmation(), "cast requires a new explicit confirmation after edit")
+    case.assert_equal(&"USE_CONFIRMATION_REQUIRED", screen.confirm(&"wrong-id").get("status", &""), "mismatched caller ID fails closed")
+    case.assert_equal(0, coordinator.confirmed_ids.size(), "mismatched ID never reaches gameplay authority")
+    case.assert_equal(&"USED", screen.confirm(&"use-opaque-1").get("status", &""), "second explicit action invokes existing use authority")
+    case.assert_equal([&"use-opaque-1"], coordinator.confirmed_ids, "opaque caller ID reaches existing authority once")
+    case.assert_equal(&"USE_CONFIRMATION_REQUIRED", screen.confirm(&"use-opaque-1").get("status", &""), "duplicate confirmation fails closed")
+    case.assert_equal(1, coordinator.confirmed_ids.size(), "duplicate confirmation never calls authority twice")
+    screen.queue_free()
+
+    var selection_screen = packed_scene.instantiate()
+    var selection_coordinator = FakeCoordinator.new()
+    case.assert_true(selection_screen.has_method("set_target_choices"), "screen accepts caller-supplied explicit target choices")
+    if selection_screen.has_method("set_target_choices"):
+        selection_screen.configure(selection_coordinator, &"use-opaque-2")
+        selection_screen._ready()
+        selection_screen.set_target_choices([{
+            "id": &"root-choice",
+            "label": "Root",
+            "hint": "Stabilize the incident",
+            "target_keyword": &"incident.root",
+            "target": {"target_valid": true},
+            "payload": {"known_improvement": "stabilize"},
+        }])
+        var selector = selection_screen.find_child("TargetSelector", true, false)
+        case.assert_equal(1, selector.visual_snapshot().get("targets", []).size(), "shared selector displays caller-supplied choices")
+        selector.target_selected.emit(&"root-choice")
+        case.assert_equal(&"FINAL_PREVIEW_READY", selection_screen.current_preview().get("status", &""), "selector emits only explicit caller choice to Coordinator preview")
+        case.assert_equal(1, selection_coordinator.preview_calls.size(), "selector does not infer or auto-select a target")
+        var commit_bar = selection_screen.find_child("CommitBar", true, false)
+        case.assert_true(selection_screen.has_signal("cancel_requested"), "screen exposes a non-mutating cancel intent")
+        case.assert_true(selection_screen.has_method("cancel"), "screen exposes an explicit cancellation method")
+        commit_bar.commit_requested.emit()
+        case.assert_equal(1, selection_coordinator.confirmation_requests, "first shared commit action asks existing authority for confirmation")
+        commit_bar.commit_requested.emit()
+        case.assert_equal([&"use-opaque-2"], selection_coordinator.confirmed_ids, "second shared commit action forwards the configured opaque ID once")
+        var cancel_counts: Array[int] = [0]
+        selection_screen.cancel_requested.connect(func(): cancel_counts[0] += 1)
+        selection_screen.cancel()
+        case.assert_equal(1, cancel_counts[0], "explicit cancel emits player intent without gameplay mutation")
+    selection_screen.queue_free()

--- a/tests/integration/test_spell_use_screen.gd.uid
+++ b/tests/integration/test_spell_use_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://cp2d3rmvn56p7

--- a/tests/test_runner.gd
+++ b/tests/test_runner.gd
@@ -47,6 +47,7 @@ const SUITES: Array[String] = [
     "res://tests/integration/test_frostbloom_star_ux_map.gd",
     "res://tests/integration/test_glyph_drawing_workflow_screen.gd",
     "res://tests/integration/test_circuit_placement_workflow_screen.gd",
+    "res://tests/integration/test_spell_use_screen.gd",
 ]
 
 


### PR DESCRIPTION
Closes #111 only after this PR's required review and CI gates complete; this draft does not claim merge or device/full-slice validation.

## Scope
- Adds the standalone Task8 Spell Use screen for explicit target choice → final preview → two-step cast confirmation.
- Delegates target preview, confirmation, and use exclusively to `SpellWorkflowCoordinator`.
- Reuses `ContextTargetSelector` and `CommitBar`; `ForecastCard` is intentionally not used because the current payload does not provide its complete semantic contract.
- Registers one current-runner Task8 integration suite and adds one focused GUT suite.

## Safety boundaries
- No automatic target or cast.
- No new transaction ID, Mana, inventory, result, or rollback authority.
- Edit cancels a pending confirmation; invalid target clears stale preview; duplicate confirmation fails closed.
- Historical Task8 worktrees remain unchanged; snapshot hash comparison reported zero mismatches (11 primary, 33 secondary copied files).

## Fresh evidence
- Godot headless project runner: 45 suites, 1,945 assertions, 0 failures.
- GUT 9.7.1: 4 scripts, 8 tests, 29 asserts, 0 failures.
- Exact Godot editor: Task8 scene runs; editor diagnostics 0 errors / 0 warnings.
- Hera read-only smoke: clean, Task8 scene tree read successfully.

## Evidence ceiling
- Human, mobile device, performance, export, and full vertical-slice validation are not run.
- The standalone Task8 scene is not yet mounted into the development harness; no claim of full end-to-end player flow is made here.