### PR TITLE
fix(authority): reconcile Godot AI v3.2.0 contracts

### DIFF
--- a/.github/workflows/validate-godot-authoring-gut-authority.yml
+++ b/.github/workflows/validate-godot-authoring-gut-authority.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
-      - name: Validate tracked HiGodot v3.1.4 reconciliation
+      - name: Validate tracked Godot AI vendor reconciliation
         run: python -m unittest tests.test_higodot_v3_1_4_tracked_reconciliation -v
       - name: Validate HiGodot v3.1.3 historical reconciliation
         run: python -m unittest tests.test_higodot_v3_1_3_historical_reconciliation -v

--- a/docs/ACTIVE_CONTEXT.md
+++ b/docs/ACTIVE_CONTEXT.md
@@ -61,7 +61,10 @@ open_pr_state_authority: LIVE_GITHUB_READBACK_REQUIRED
 component_sheet_pr151: MERGED_MAIN_VERIFIED
 preserved_runtime_decision: GM-STAR-CIRCUIT-MASTERY-BALANCE-01
 circuit_topology: FIVE_POINT_STAR
-higodot_release: v3.1.4
+higodot_release: v3.2.0
+higodot_tracked_vendor_release: v3.2.0
+higodot_tracked_vendor_subtree: 66a9df59a92f0029efcd35c22fea355c93e8fe49
+higodot_tracked_vendor_evidence: docs/validation/HIGODOT_V3_2_0_VENDOR_INTEGRITY.json
 higodot_historical_live_alignment: LIVE_V3_1_4_EXACT_PROJECT_SESSION_READY_OBSERVED
 higodot_current_reconciliation_readback: NOT_RUN
 higodot_expected_actual_fields: NOT_SURFACED_DO_NOT_CLAIM
@@ -339,7 +342,8 @@ learning_closure: LEARNING_CLOSURE_OPEN_COUNT = 0
 
 ## Tool authority
 
-- Historical project tool provenance: HiGodot/Godot AI `v3.1.4`, GUT `v9.7.1`, Hera `v1.0.0`.
+- Current tracked project vendor: HiGodot/Godot AI `v3.2.0`, exact plugin subtree `66a9df59a92f0029efcd35c22fea355c93e8fe49`; see `docs/validation/HIGODOT_V3_2_0_VENDOR_INTEGRITY.json`.
+- Historical project tool provenance: HiGodot/Godot AI `v3.1.2`–`v3.1.4`, GUT `v9.7.1`, Hera `v1.0.0`. Historical live receipts do not prove a current v3.2.0 session.
 - r5.4는 project-specific local Codex home/binary/port를 current invariant로 사용하지 않는다.
 - 실제 shared Godot/Godot AI runtime/session readiness는 fresh local executor/session readback 없이 주장하지 않는다.
 - historical live receipts는 현재 local readiness를 자동 증명하지 않는다.

--- a/docs/DEVELOPMENT_GATES.md
+++ b/docs/DEVELOPMENT_GATES.md
@@ -36,9 +36,11 @@ parallel_open_pr: PR151_DO_NOT_TOUCH
 preserved_runtime_decision: GM-STAR-CIRCUIT-MASTERY-BALANCE-01
 circuit_topology: FIVE_POINT_STAR
 tool_authority_decision: GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01
-higodot_release: v3.1.4
+higodot_release: v3.2.0
 higodot_vendor_integrity: PASS_EXACT_TREE_IDENTITY
-higodot_tracked_sync: GR-SYNC-20260811-19-HIGODOT-V314-TRACKED-EXACT-RECONCILIATION
+higodot_tracked_vendor_subtree: 66a9df59a92f0029efcd35c22fea355c93e8fe49
+higodot_tracked_vendor_evidence: docs/validation/HIGODOT_V3_2_0_VENDOR_INTEGRITY.json
+higodot_historical_tracked_sync: GR-SYNC-20260811-19-HIGODOT-V314-TRACKED-EXACT-RECONCILIATION
 higodot_historical_live_alignment: LIVE_V3_1_4_EXACT_PROJECT_SESSION_READY_OBSERVED
 higodot_expected_actual_fields: NOT_SURFACED_DO_NOT_CLAIM
 gut_formal_adoption: GUT_FORMALLY_ADOPTED
@@ -120,7 +122,7 @@ historical_product_state: UNMERGED_LOCAL_WORKTREE_DELTA
 로컬 delta 존재
 → 절대 reset/restore/clean 하지 않음
 → exact path / branch / HEAD / status / staged state 기록
-→ fresh HiGodot 3.1.4 exact-project readiness
+→ fresh exact-project HiGodot version/readiness readback
 → focused Task8 GUT
 → predecessor regression
 → git diff --check
@@ -164,9 +166,9 @@ exact requested GRIMOIRE project/worktree
 → HERA_SOURCE_DELTA: NONE
 ```
 
-- HiGodot/Godot AI `v3.1.4`: `SOLE_PERSISTENT_GODOT_AUTHORING_AUTHORITY`.
-- tracked plugin subtree: `69010571e11123dfc4e09483f80cb9e6ca93511a`, `PASS_EXACT_TREE_IDENTITY`.
-- historical Sync20 live session: `task8-spell-use-screen-v2@3cfa`, `LIVE_V3_1_4_EXACT_PROJECT_SESSION_READY_OBSERVED`.
+- HiGodot/Godot AI `v3.2.0` tracked vendor: `SOLE_PERSISTENT_GODOT_AUTHORING_AUTHORITY`.
+- tracked plugin subtree: `66a9df59a92f0029efcd35c22fea355c93e8fe49`, `PASS_EXACT_TREE_IDENTITY`; evidence: `docs/validation/HIGODOT_V3_2_0_VENDOR_INTEGRITY.json`.
+- historical Sync20 live session: `task8-spell-use-screen-v2@3cfa`, `LIVE_V3_1_4_EXACT_PROJECT_SESSION_READY_OBSERVED`. It is history, not proof of a v3.2.0 session.
 - `expected_version` field는 surfaced되지 않았으므로 `NOT_SURFACED_DO_NOT_CLAIM`.
 - direct tool-state evidence limit: `HIGODOT_AUTHORING_RECEIPT_UNVERIFIED_FOR_DIRECT_LOCAL_TOOL_STATE_COMMIT`.
 - GUT `v9.7.1`: deterministic GDScript test authority.

--- a/docs/superpowers/plans/2026-08-27-godot-ai-v320-authority-reconciliation.md
+++ b/docs/superpowers/plans/2026-08-27-godot-ai-v320-authority-reconciliation.md
@@ -1,0 +1,120 @@
+# Godot AI v3.2.0 Authority Reconciliation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the already-tracked official Godot AI v3.2.0 vendor tree and the active project authority contracts agree without rewriting v3.1.x provenance.
+
+**Architecture:** Keep `addons/godot_ai` unchanged: it already equals the official v3.2.0 plugin subtree. Add a new v3.2.0 provenance record, promote only current mutable authority surfaces and their semantic contract tests, and leave v3.1.2–v3.1.4 files as history. The Task8 product branch remains untouched and is revalidated only after this baseline PR lands.
+
+**Tech Stack:** Git, Python `unittest`, Markdown/JSON contracts, Godot project metadata, GitHub Actions.
+
+**Spec:** GitHub Issue #188 — Reconcile tracked Godot AI v3.2.0 with current authority contracts.
+
+## Global Constraints
+
+- Do not modify `addons/godot_ai/**`, `project.godot`, Task5–Task8 product code, scenes, or tests.
+- Official evidence is tag `v3.2.0` commit `42c44e4d02ca1836a0e1866361509d3a14d83b0c` and plugin subtree `66a9df59a92f0029efcd35c22fea355c93e8fe49`.
+- Preserve v3.1.2–v3.1.4 records as `HISTORICAL_PROVENANCE`; do not relabel their past sessions or receipts as v3.2.0 evidence.
+- Do not upgrade human, device, performance, or full-slice validation claims.
+- Persistent Godot authoring remains Godot AI/HiGodot-only; this task is documentation and contract verification, not engine authoring.
+
+---
+
+### Task 1: Define the v3.2.0 current-vendor contract
+
+**Files:**
+- Create: `docs/validation/HIGODOT_V3_2_0_VENDOR_INTEGRITY.json`
+- Modify: `tests/test_higodot_v3_1_4_tracked_reconciliation.py`
+- Test: `tests/test_higodot_v3_1_4_tracked_reconciliation.py`
+
+**Consumes:** current tracked addon tree and the official v3.2.0 tag/tree evidence from Issue #188.
+
+**Produces:** an explicit current `v3.2.0` exact-tree contract while retaining the existing v3.1.4 history test.
+
+- [x] **Step 1: Write the failing current-tree assertion**
+
+Add a test named `test_tracked_plugin_is_exact_official_v320_tree` that asserts `version="3.2.0"` and exact tree `66a9df59a92f0029efcd35c22fea355c93e8fe49`.
+
+- [x] **Step 2: Run the focused test to verify RED**
+
+Run: `python -m unittest tests.test_higodot_v3_1_4_tracked_reconciliation.HiGodotV314TrackedReconciliationTests.test_tracked_plugin_is_exact_official_v320_tree -v`
+
+Expected: FAIL because the v3.2.0 contract test does not yet exist.
+
+- [x] **Step 3: Add the minimal current-vendor evidence and test constants**
+
+Create the JSON record with release/tag/subtree identity, the main commit introducing the vendor tree, and explicit limits that historical live session/receipt claims remain v3.1.4 history. Keep the existing v3.1.4 evidence assertions unchanged.
+
+- [x] **Step 4: Run the focused test to verify GREEN**
+
+Run: `python -m unittest tests.test_higodot_v3_1_4_tracked_reconciliation -v`
+
+Expected: PASS with the historical v3.1.4 assertions and the new current v3.2.0 exact-tree assertion.
+
+### Task 2: Promote current authority surfaces without rewriting history
+
+**Files:**
+- Modify: `docs/ACTIVE_CONTEXT.md`
+- Modify: `docs/DEVELOPMENT_GATES.md`
+- Modify: `.github/workflows/validate-godot-authoring-gut-authority.yml`
+- Modify: `tests/test_godot_authoring_gut_authority_contract.py`
+- Test: `tests/test_godot_authoring_gut_authority_contract.py`
+
+**Consumes:** Task 1’s v3.2.0 evidence; current project source-of-truth rules.
+
+**Produces:** current owner documents that identify v3.2.0 as tracked-vendor authority while Sync20 and its v3.1.4 live-session fields remain history-only.
+
+- [x] **Step 1: Write failing assertions for the new current authority**
+
+Change the active tracked-plugin assertion to require `3.2.0`, tree `66a9df59a92f0029efcd35c22fea355c93e8fe49`, and the v3.2.0 evidence file. Retain Sync20's v3.1.4 live-session assertions as historical provenance.
+
+- [x] **Step 2: Run the focused test to verify RED**
+
+Run: `python -m unittest tests.test_godot_authoring_gut_authority_contract.GodotAuthoringGutAuthorityContractTests.test_sync20_machine_state_records_current_tool_authority -v`
+
+Expected: FAIL because the tracked-plugin assertion still requires v3.1.4.
+
+- [x] **Step 3: Update only current mutable surfaces**
+
+Set current tracked-vendor fields to v3.2.0 and the exact v3.2.0 tree. Name `v3.1.4` evidence and Sync20's live session as historical provenance; do not alter Sync20 JSON or manufacture a v3.2.0 live-session or authoring-receipt claim.
+
+- [x] **Step 4: Run focused contract tests to verify GREEN**
+
+Run: `python -m unittest tests.test_godot_authoring_gut_authority_contract -v`
+
+Expected: PASS; historical v3.1.x evidence tests remain intact.
+
+### Task 3: Freshness and exact-head validation
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-08-27-godot-ai-v320-authority-reconciliation.md`
+
+**Consumes:** Task 1 and Task 2 changes.
+
+**Produces:** reproducible proof that current consumers agree and Task8 stays outside the diff.
+
+- [x] **Step 1: Verify version propagation and historical preservation**
+
+Run: `rg -n 'v3\\.2\\.0|3\\.2\\.0|v3\\.1\\.4|3\\.1\\.4' AGENTS.md START_HERE.md docs tests .github`
+
+Expected: v3.2.0 occurs in current vendor authority and tests; v3.1.4 remains in history-only evidence and explicitly historical references.
+
+- [x] **Step 2: Run the authority workflow’s local commands**
+
+Run every `python -m unittest` module referenced by `.github/workflows/validate-godot-authoring-gut-authority.yml`.
+
+Expected: all modules pass from the exact branch head.
+
+- [x] **Step 3: Run reference freshness and diff checks**
+
+Run a manual impact map and version scan because this project has no `.github/reference-freshness.json` configuration: `rg -n 'v3\\.2\\.0|3\\.2\\.0|v3\\.1\\.4|3\\.1\\.4' AGENTS.md START_HERE.md docs tests .github`.
+
+Run: `git diff --check c0b4d45f52204b59844eda9fcd0b2b2bdda9a127...HEAD`
+
+Expected: no blocking stale active reference or whitespace error; v3.1.4 matches are history-only; Task8 paths do not appear in the diff.
+
+- [x] **Step 4: Record results in this plan and commit**
+
+Mark only actually completed steps, then run `git status --short`, stage only the listed authority contract files, and commit with `fix(authority): reconcile Godot AI v3.2.0 contracts`.
+
+**Recorded results (2026-08-27):** The new v3.2.0 evidence test failed first because its evidence record did not exist, then passed. The active-context assertion failed first because current tracked-vendor metadata was absent, then passed. All 15 modules from `validate-godot-authoring-gut-authority.yml` passed locally after the reconciliation. The repository has no `.github/reference-freshness.json`; manual impact mapping and version scan classified v3.1.4 matches as historical evidence or historical locators, and renamed the active CI step to version-neutral wording. Task8 product paths are absent from this branch diff.

--- a/docs/validation/HIGODOT_V3_2_0_VENDOR_INTEGRITY.json
+++ b/docs/validation/HIGODOT_V3_2_0_VENDOR_INTEGRITY.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": 1,
+  "decision_id": "GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01",
+  "reconciliation_issue": 188,
+  "release": "v3.2.0",
+  "official_repository": "hi-godot/godot-ai",
+  "official_tag_commit": "42c44e4d02ca1836a0e1866361509d3a14d83b0c",
+  "official_plugin_subtree": "66a9df59a92f0029efcd35c22fea355c93e8fe49",
+  "project_plugin_path": "addons/godot_ai",
+  "project_tracked_plugin_subtree": "66a9df59a92f0029efcd35c22fea355c93e8fe49",
+  "official_plugin_cfg_version": "3.2.0",
+  "project_plugin_cfg_version": "3.2.0",
+  "comparison_scope_rule": "COMPARE_PLUGIN_SUBTREE_TO_PLUGIN_SUBTREE",
+  "tracked_vendor_integrity": "PASS_EXACT_TREE_IDENTITY",
+  "tracked_vendor_synced": true,
+  "observed_project_main": "c0b4d45f52204b59844eda9fcd0b2b2bdda9a127",
+  "vendor_introduction_commit": "ef70dd20db71d853ffa1eb4b68e674037952b71a",
+  "historical_predecessors": [
+    "docs/validation/HIGODOT_V3_1_2_VENDOR_INTEGRITY.json",
+    "docs/validation/HIGODOT_V3_1_3_VENDOR_INTEGRITY.json",
+    "docs/validation/HIGODOT_V3_1_4_VENDOR_INTEGRITY.json"
+  ],
+  "claims": {
+    "official_and_project_plugin_subtree_identical": true,
+    "tracked_github_vendor_is_v3_2_0": true,
+    "live_v3_2_0_session_verified": false,
+    "v3_2_0_authoring_receipt_verified": false,
+    "historical_v3_1_x_evidence_rewritten": false
+  },
+  "evidence_limits": [
+    "This record proves the current tracked vendor tree identity only.",
+    "Historical v3.1.2 through v3.1.4 live-session and authoring-receipt records remain historical provenance.",
+    "This record does not prove a live v3.2.0 server/plugin handshake or a v3.2.0 authoring receipt.",
+    "Human, device, performance, and full vertical-slice validation remain NOT_RUN."
+  ]
+}

--- a/tests/test_godot_authoring_gut_authority_contract.py
+++ b/tests/test_godot_authoring_gut_authority_contract.py
@@ -18,6 +18,7 @@ UNRESOLVED = ROOT / "docs/planning/CURRENT_UNRESOLVED_GATES.md"
 HIGODOT_V312_EVIDENCE = ROOT / "docs/validation/HIGODOT_V3_1_2_VENDOR_INTEGRITY.json"
 HIGODOT_V313_EVIDENCE = ROOT / "docs/validation/HIGODOT_V3_1_3_VENDOR_INTEGRITY.json"
 HIGODOT_V314_EVIDENCE = ROOT / "docs/validation/HIGODOT_V3_1_4_VENDOR_INTEGRITY.json"
+HIGODOT_V320_EVIDENCE = ROOT / "docs/validation/HIGODOT_V3_2_0_VENDOR_INTEGRITY.json"
 HERA_EVIDENCE = ROOT / "docs/validation/HERA_V1_0_0_EXACT_PAIR.json"
 ACTIVE_SURFACES = [
     ROOT / "START_HERE.md",
@@ -38,6 +39,7 @@ SYNC20_SOURCE_BASE = "6d2feba2bc49fda2d8d273248b55087853615d5d"
 LATEST_BASE_OBSERVED = "1d6cc79ad9dfa694558524ccc5ebf11ec7df7d8c"
 CURRENT_SYNC = "GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT"
 HIGODOT_V314_TREE = "69010571e11123dfc4e09483f80cb9e6ca93511a"
+HIGODOT_V320_TREE = "66a9df59a92f0029efcd35c22fea355c93e8fe49"
 HIGODOT_LIVE = "LIVE_V3_1_4_EXACT_PROJECT_SESSION_READY_OBSERVED"
 EXPECTED_FIELD_LIMIT = "NOT_SURFACED_DO_NOT_CLAIM"
 HERA_PASS = "HERA_V1_0_0_EXACT_PAIR_LIVE_CANARY_PASS"
@@ -51,6 +53,13 @@ TASK8_GATE = "TASK8_RECEIPT_HERA_REVIEW_PR"
 
 
 class GodotAuthoringGutAuthorityContractTests(unittest.TestCase):
+    def test_active_context_identifies_v320_tracked_vendor_and_preserves_v314_history(self):
+        active_context = (ROOT / "docs/ACTIVE_CONTEXT.md").read_text(encoding="utf-8")
+        self.assertIn("higodot_tracked_vendor_release: v3.2.0", active_context)
+        self.assertIn(HIGODOT_V320_TREE, active_context)
+        self.assertIn("LIVE_V3_1_4_EXACT_PROJECT_SESSION_READY_OBSERVED", active_context)
+        self.assertTrue(HIGODOT_V320_EVIDENCE.is_file(), str(HIGODOT_V320_EVIDENCE))
+
     def test_authority_design_plan_bindings_and_evidence_exist(self):
         for path in (
             LEGACY_SPEC,
@@ -67,6 +76,7 @@ class GodotAuthoringGutAuthorityContractTests(unittest.TestCase):
             HIGODOT_V312_EVIDENCE,
             HIGODOT_V313_EVIDENCE,
             HIGODOT_V314_EVIDENCE,
+            HIGODOT_V320_EVIDENCE,
             HERA_EVIDENCE,
         ):
             self.assertTrue(path.is_file(), str(path))
@@ -164,7 +174,7 @@ class GodotAuthoringGutAuthorityContractTests(unittest.TestCase):
         higodot_plugin = (ROOT / "addons/godot_ai/plugin.cfg").read_text(encoding="utf-8")
         gut_plugin = (ROOT / "addons/gut/plugin.cfg").read_text(encoding="utf-8")
         project = (ROOT / "project.godot").read_text(encoding="utf-8")
-        self.assertIn('version="3.1.4"', higodot_plugin)
+        self.assertIn('version="3.2.0"', higodot_plugin)
         self.assertIn('version="9.7.1"', gut_plugin)
         self.assertIn('res://addons/godot_ai/plugin.cfg', project)
         self.assertIn('res://addons/gut/plugin.cfg', project)

--- a/tests/test_higodot_v3_1_4_tracked_reconciliation.py
+++ b/tests/test_higodot_v3_1_4_tracked_reconciliation.py
@@ -10,6 +10,7 @@ ROOT = Path(__file__).resolve().parents[1]
 CURRENT_STATE = ROOT / "docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE_SYNC20.json"
 SYNC19_STATE = ROOT / "docs/planning/GODOT_AUTHORING_GUT_AUTHORITY_STATE.json"
 EVIDENCE = ROOT / "docs/validation/HIGODOT_V3_1_4_VENDOR_INTEGRITY.json"
+V320_EVIDENCE = ROOT / "docs/validation/HIGODOT_V3_2_0_VENDOR_INTEGRITY.json"
 SYNC = ROOT / "docs/planning/sync/GR-SYNC-20260811-19-HIGODOT-V314-TRACKED-EXACT-RECONCILIATION.md"
 CURRENT_DOCS = [
     ROOT / "START_HERE.md",
@@ -24,6 +25,8 @@ TRACKED_SYNC_ID = "GR-SYNC-20260811-19-HIGODOT-V314-TRACKED-EXACT-RECONCILIATION
 CURRENT_SYNC_ID = "GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT"
 UPSTREAM_TAG_COMMIT = "96cc8b8c3d25ce487e24801d01d5214fea150349"
 V314_TREE = "69010571e11123dfc4e09483f80cb9e6ca93511a"
+V320_TAG_COMMIT = "42c44e4d02ca1836a0e1866361509d3a14d83b0c"
+V320_TREE = "66a9df59a92f0029efcd35c22fea355c93e8fe49"
 DIRECT_TOOL_STATE_COMMIT = "257a0dba33f8288d24b1cd291bb407f4505224b4"
 SYNC20_SOURCE_BASE = "6d2feba2bc49fda2d8d273248b55087853615d5d"
 LATEST_BASE_OBSERVED = "1d6cc79ad9dfa694558524ccc5ebf11ec7df7d8c"
@@ -35,9 +38,9 @@ SESSION_ID = "task8-spell-use-screen-v2@3cfa"
 
 
 class HiGodotV314TrackedReconciliationTests(unittest.TestCase):
-    def test_tracked_plugin_is_exact_official_v314_tree(self) -> None:
+    def test_tracked_plugin_is_exact_official_v320_tree(self) -> None:
         plugin = (ROOT / "addons/godot_ai/plugin.cfg").read_text(encoding="utf-8")
-        self.assertIn('version="3.1.4"', plugin)
+        self.assertIn('version="3.2.0"', plugin)
         tree = subprocess.run(
             ["git", "rev-parse", "HEAD:addons/godot_ai"],
             cwd=ROOT,
@@ -45,7 +48,29 @@ class HiGodotV314TrackedReconciliationTests(unittest.TestCase):
             capture_output=True,
             text=True,
         ).stdout.strip()
-        self.assertEqual(V314_TREE, tree)
+        self.assertEqual(V320_TREE, tree)
+        self.assertTrue(V320_EVIDENCE.is_file(), str(V320_EVIDENCE))
+        evidence = json.loads(V320_EVIDENCE.read_text(encoding="utf-8"))
+        self.assertEqual("v3.2.0", evidence["release"])
+        self.assertEqual(V320_TAG_COMMIT, evidence["official_tag_commit"])
+        self.assertEqual(V320_TREE, evidence["official_plugin_subtree"])
+        self.assertEqual(V320_TREE, evidence["project_tracked_plugin_subtree"])
+        self.assertEqual("PASS_EXACT_TREE_IDENTITY", evidence["tracked_vendor_integrity"])
+
+    def test_v314_vendor_evidence_remains_historical(self) -> None:
+        plugin = (ROOT / "addons/godot_ai/plugin.cfg").read_text(encoding="utf-8")
+        self.assertNotIn('version="3.1.4"', plugin)
+        tree = subprocess.run(
+            ["git", "rev-parse", "HEAD:addons/godot_ai"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        self.assertNotEqual(V314_TREE, tree)
+        evidence = json.loads(EVIDENCE.read_text(encoding="utf-8"))
+        self.assertEqual("v3.1.4", evidence["release"])
+        self.assertEqual(V314_TREE, evidence["project_tracked_plugin_subtree"])
 
     def test_sync19_evidence_remains_historical(self) -> None:
         data = json.loads(EVIDENCE.read_text(encoding="utf-8"))


### PR DESCRIPTION
## 목적

current `main`에 이미 존재하는 공식 Godot AI `v3.2.0` vendor tree와 활성 authority contracts/tests의 `v3.1.4` 기대값 불일치를 바로잡습니다.

Closes #188.

## 변경 범위

- official tag `v3.2.0` (`42c44e4`) ↔ project subtree `66a9df59…` exact-tree evidence 추가
- active context 및 development gate를 current tracked vendor `v3.2.0`으로 갱신
- v3.1.2–v3.1.4는 historical provenance로 유지
- current vendor contract tests와 CI step label 갱신

## 보존한 경계

- `addons/godot_ai/**`, `project.godot`, Task5–Task8 구현은 변경하지 않았습니다.
- v3.2.0 live session/handshake 또는 authoring receipt는 주장하지 않습니다.
- human/device/performance/full-slice 상태도 승격하지 않았습니다.

## 검증

- authority workflow와 동일한 Python unittest 15개 모듈: 모두 통과
- 새 v3.2.0 evidence 및 active-context assertion: RED → GREEN 확인
- JSON parse 및 `git diff --check`: 통과
- Task8 product path가 이 diff에 없음을 확인

## 후속

이 PR 병합 후 Task8 #187을 최신 main에 맞춰 CI·review 검증을 다시 실행합니다. Notion의 현재 페이지 로드 오류가 해소되면 사람용 기록도 readback합니다.