### PR TITLE
feat(task8): reconcile spell use screen on current main

### DIFF
--- a/docs/ACTIVE_CONTEXT.md
+++ b/docs/ACTIVE_CONTEXT.md
@@ -57,7 +57,7 @@ task8_secondary_recovery_branch: task8/spell-use-screen
 task8_secondary_recovery_head: fcb5dbe1cbbb23ef195633b1f6680f45d46c5a3f
 task8_product_commit: 68211069eb3b778fb43e68f3fbd049c8a0ac2733
 task8_remote_product_branch: codex/task8-spell-use-reconcile-v320-20260827
-task8_remote_product_pr: PENDING
+task8_remote_product_pr: 190
 open_pr_state_authority: LIVE_GITHUB_READBACK_REQUIRED
 component_sheet_pr151: MERGED_MAIN_VERIFIED
 preserved_runtime_decision: GM-STAR-CIRCUIT-MASTERY-BALANCE-01
@@ -295,7 +295,7 @@ task8_primary_recovery_head: 8c611f601aa98397ed1558e92ab207e0e8347a9b
 task8_secondary_recovery_head: fcb5dbe1cbbb23ef195633b1f6680f45d46c5a3f
 task8_product_commit: 68211069eb3b778fb43e68f3fbd049c8a0ac2733
 task8_remote_product_branch: codex/task8-spell-use-reconcile-v320-20260827
-task8_remote_product_pr: PENDING
+task8_remote_product_pr: 190
 historical_product_state: UNMERGED_LOCAL_WORKTREE_DELTA
 resume_gate: TASK8_PR_EXACT_HEAD_CI_REVIEW_MERGE_PENDING
 historical_predecessor_gate: TASK8_LOCAL_WORKTREE_DELTA_RECOVERY_REQUIRED

--- a/docs/ACTIVE_CONTEXT.md
+++ b/docs/ACTIVE_CONTEXT.md
@@ -17,13 +17,14 @@ spell_workflow_predecessor_sync: GR-SYNC-20260811-01-SPELL-WORKFLOW-TASK7-CURREN
 task8_continuation_sync: GR-SYNC-20260812-21-TASK8-HANDOFF-BCP
 task8_current_reverify: docs/planning/TASK8_REMOTE_LOCAL_REVERIFY_2026-08-21.md
 task8_preservation_observation: docs/planning/TASK8_LOCAL_CANDIDATE_PRESERVATION_OBSERVATION_2026-08-24.md
+task8_current_reconciliation_receipt: docs/planning/TASK8_CURRENT_MAIN_RECONCILIATION_2026-08-27.md
 base_snapshot_policy: ALWAYS_REFETCH_CURRENT_COMPLETED_MAIN
 adapter_policy: THIN_ADAPTER_DO_NOT_DUPLICATE_BASE_CANON
 base_project_pin: v9.4.3
 planning: COMPLETE_FROSTBLOOM_FIRST_SESSION
 implementation: PARTIAL_FOUNDATION
-current_user_work_scope: SPELL_WORKFLOW_PLAYER_FACING_SIMPLIFICATION_AND_VISUAL_ALIGNMENT
-product_implementation_authorized_by_current_user_work_scope: false
+current_user_work_scope: SPELL_WORKFLOW_PLAYER_FACING_SIMPLIFICATION_VISUAL_ALIGNMENT_AND_TASK8_RECONCILIATION
+product_implementation_authorized_by_current_user_work_scope: true
 visual_asset_coverage: docs/planning/visual/GRIMOIRE_VISUAL_ASSET_COVERAGE_2026-08-26.json
 visual_asset_coverage_status: CURRENT_PREFLIGHT_COMPLETE
 visual_generation_state: NOT_REQUESTED_AFTER_PLAYER_FLOW_APPROVAL
@@ -43,9 +44,9 @@ player_facing_ux_groups: SPELL_BUILD_AND_SPELL_CAST
 latest_product_main_for_task7_lineage: fcb5dbe1cbbb23ef195633b1f6680f45d46c5a3f
 spell_workflow_predecessor_status: TASK7_MERGED_MAIN_VERIFIED
 next_product_task: TASK8_SPELL_USE_SCREEN
-next_product_gate: TASK8_PR_PREP_REVERIFY_PENDING
+next_product_gate: TASK8_PR_EXACT_HEAD_CI_REVIEW_MERGE_PENDING
 task8_recovery_state: TASK8_LOCAL_CANDIDATE_PRESERVATION_OBSERVED_PASS
-task8_recovery_subgate: TASK8_CLEAN_RECONCILIATION_WORKTREE_REQUIRED
+task8_recovery_subgate: TASK8_CURRENT_MAIN_LOCAL_VALIDATION_PASS
 task8_recovery_predecessor_gate: TASK8_LOCAL_WORKTREE_DELTA_RECOVERY_REQUIRED
 task8_local_git_head_baseline: 8c611f601aa98397ed1558e92ab207e0e8347a9b
 task8_local_delta_existence: OBSERVED_PRESENT
@@ -54,9 +55,9 @@ task8_primary_recovery_branch: feat/task8-spell-use-screen-v2
 task8_primary_recovery_head: 8c611f601aa98397ed1558e92ab207e0e8347a9b
 task8_secondary_recovery_branch: task8/spell-use-screen
 task8_secondary_recovery_head: fcb5dbe1cbbb23ef195633b1f6680f45d46c5a3f
-task8_product_commit: NONE
-task8_remote_product_branch: NOT_PRESENT
-task8_remote_product_pr: NONE
+task8_product_commit: 68211069eb3b778fb43e68f3fbd049c8a0ac2733
+task8_remote_product_branch: codex/task8-spell-use-reconcile-v320-20260827
+task8_remote_product_pr: PENDING
 open_pr_state_authority: LIVE_GITHUB_READBACK_REQUIRED
 component_sheet_pr151: MERGED_MAIN_VERIFIED
 preserved_runtime_decision: GM-STAR-CIRCUIT-MASTERY-BALANCE-01
@@ -66,7 +67,7 @@ higodot_tracked_vendor_release: v3.2.0
 higodot_tracked_vendor_subtree: 66a9df59a92f0029efcd35c22fea355c93e8fe49
 higodot_tracked_vendor_evidence: docs/validation/HIGODOT_V3_2_0_VENDOR_INTEGRITY.json
 higodot_historical_live_alignment: LIVE_V3_1_4_EXACT_PROJECT_SESSION_READY_OBSERVED
-higodot_current_reconciliation_readback: NOT_RUN
+higodot_current_reconciliation_readback: LIVE_V3_2_0_EXACT_PROJECT_SESSION_READY_OBSERVED
 higodot_expected_actual_fields: NOT_SURFACED_DO_NOT_CLAIM
 gut_formal_adoption: GUT_FORMALLY_ADOPTED
 hera_status: HERA_V1_0_0_EXACT_PAIR_LIVE_CANARY_PASS
@@ -85,7 +86,7 @@ android_export: NOT_RUN
 android_device: NOT_RUN
 ```
 
-`authority_sync_local_observation` / `authority_sync_godot_observation`은 이전 authority sync 당시의 역사 관찰값이다. 현재 로컬 Task8 존재·보존 상태는 별도 `task8_recovery_state`가 소유하며, 이번 기획/Visual work unit은 로컬 Godot/Task8 실행을 수행하지 않았다.
+`authority_sync_local_observation` / `authority_sync_godot_observation`은 이전 authority sync 당시의 역사 관찰값이다. 현재 Task8 reconciliation의 local/Godot 실행 증거와 보존 상태는 별도 Task8 receipt가 소유한다.
 
 ## 현재 사용자 작업 범위
 
@@ -108,10 +109,10 @@ android_device: NOT_RUN
 = 게임 장면의 대상 지정 + 필요한 최종 Preview + 명시 시전
 ```
 
-따라서 현재 범위는 `SPELL_WORKFLOW_PLAYER_FACING_SIMPLIFICATION_AND_VISUAL_ALIGNMENT`다.
+이후 사용자는 Task8 제품 구현을 명시적으로 승인했다. 따라서 현재 범위는 `SPELL_WORKFLOW_PLAYER_FACING_SIMPLIFICATION_VISUAL_ALIGNMENT_AND_TASK8_RECONCILIATION`다.
 
-- Task8/Godot 제품 구현: **NOT_AUTHORIZED_BY_CURRENT_WORK_SCOPE**
-- `TASK8_SPELL_USE_SCREEN`: 다음 제품 task locator일 뿐 현재 구현 권한이 아님
+- Task8/Godot 제품 구현: **AUTHORIZED_FOR_CURRENT-MAIN_RECONCILIATION**
+- `TASK8_SPELL_USE_SCREEN`: current main에서 thin UI consumer로 복구·검증·PR 준비 중
 - 이미지 생성: **NOT_REQUESTED_AFTER_PLAYER_FLOW_APPROVAL**
 - Google Sheet 신규 canon write: **FORBIDDEN / MIGRATION_ONLY**
 - unrelated open PR: **READ_ONLY**
@@ -292,21 +293,21 @@ product_branch_local_historical: feat/task8-spell-use-screen-v2
 task8_local_git_head_baseline: 8c611f601aa98397ed1558e92ab207e0e8347a9b
 task8_primary_recovery_head: 8c611f601aa98397ed1558e92ab207e0e8347a9b
 task8_secondary_recovery_head: fcb5dbe1cbbb23ef195633b1f6680f45d46c5a3f
-task8_product_commit: NONE
-task8_remote_product_branch: NOT_PRESENT
-task8_remote_product_pr: NONE
+task8_product_commit: 68211069eb3b778fb43e68f3fbd049c8a0ac2733
+task8_remote_product_branch: codex/task8-spell-use-reconcile-v320-20260827
+task8_remote_product_pr: PENDING
 historical_product_state: UNMERGED_LOCAL_WORKTREE_DELTA
-resume_gate: TASK8_PR_PREP_REVERIFY_PENDING
+resume_gate: TASK8_PR_EXACT_HEAD_CI_REVIEW_MERGE_PENDING
 historical_predecessor_gate: TASK8_LOCAL_WORKTREE_DELTA_RECOVERY_REQUIRED
 recovery_state: TASK8_LOCAL_CANDIDATE_PRESERVATION_OBSERVED_PASS
-current_execution_subgate: TASK8_CLEAN_RECONCILIATION_WORKTREE_REQUIRED
+current_execution_subgate: TASK8_PR_EXACT_HEAD_CI_REVIEW_MERGE_PENDING
 ```
 
 `8c611f...`는 당시 local Git baseline이지 Task8 product commit이 아니다. 과거 `15 tests / 90 assertions / 0 failures`, predecessor `42 suites / 1,588 assertions / 0 failures`, `HERA_SOURCE_DELTA_NONE_OBSERVED`는 그때 관찰한 uncommitted worktree의 역사 evidence다.
 
 2026-08-24 사용자 PC read-only recovery probe로 두 로컬 Task8 후보가 실제 존재함을 확인했고, 이어 병합된 preservation tool을 실행해 외부 snapshot으로 보존했다. 직접 반환된 receipt는 `TASK8_CANDIDATES_PRESERVED`, `source_unchanged=true`, `source_content_unchanged=true`이며 primary 11 files, secondary 33 files가 snapshot에 기록됐다.
 
-따라서 `TASK8_LOCAL_WORKTREE_DELTA_RECOVERY_REQUIRED`와 candidate-preservation gate는 닫혔다. compatibility consumer 검색을 위해 locator 문자열은 보존하지만 current gate로 재해석하지 않는다. 보존 성공을 current-main 호환성이나 fresh HiGodot/GUT/Hera PASS로 승격하지 않는다.
+따라서 `TASK8_LOCAL_WORKTREE_DELTA_RECOVERY_REQUIRED`와 candidate-preservation gate는 닫혔다. compatibility consumer 검색을 위해 locator 문자열은 보존하지만 current gate로 재해석하지 않는다. 2026-08-27 current-main reconciliation은 새 clean worktree와 live Godot AI v3.2.0 세션에서 `6821106`으로 재작성·검증됐으며, exact-head CI·review·merge는 아직 남아 있다. 상세 증거는 `docs/planning/TASK8_CURRENT_MAIN_RECONCILIATION_2026-08-27.md`가 소유한다.
 
 제품 구현이 다시 명시적으로 승인되면 역사 worktree에 pull/rebase/clean을 하지 않고 fresh `origin/main`에서 별도 clean reconciliation worktree를 만든다. 이후 exact-project HiGodot readback을 거쳐 primary v2를 우선 복구하고 secondary는 parity evidence로만 비교한다.
 
@@ -391,10 +392,7 @@ PR #151 `feat(ui): build GRIMOIRE component sheets A-D`는 **병합 완료**된 
 TASK8_PR_PREP_REVERIFY_PENDING
 TASK8_CLEAN_RECONCILIATION_WORKTREE_REQUIRED
 TASK8_PR_EXACT_HEAD_CI_REVIEW_MERGE_PENDING
-HIGODOT_CURRENT_RECONCILIATION_READBACK_NOT_RUN
-FRESH_TASK8_TESTS_NOT_RUN
-FRESH_FULL_RUNNER_NOT_RUN
-HERA_SOURCE_DELTA_NOT_RUN
+TASK8_CURRENT_MAIN_LOCAL_VALIDATION_PASS_PR_PENDING
 HIGODOT_EXPECTED_VERSION_FIELD_NOT_SURFACED
 AUDIO_VAULT_PATH_UNVERIFIED
 AUDIO_RIGHTS_UNVERIFIED

--- a/docs/planning/TASK8_CURRENT_MAIN_RECONCILIATION_2026-08-27.md
+++ b/docs/planning/TASK8_CURRENT_MAIN_RECONCILIATION_2026-08-27.md
@@ -1,0 +1,42 @@
+# Task8 Current-Main Reconciliation Receipt — 2026-08-27
+
+## Scope
+
+- GitHub Issue: #111
+- Approved player flow: `글자 → 주문 → 대상 → 시전`
+- Commit: `68211069eb3b778fb43e68f3fbd049c8a0ac2733`
+- Branch: `codex/task8-spell-use-reconcile-v320-20260827`
+- Base: `origin/main@1e8662217e13dbfce6a41749f850db66b000d64b`
+
+The user explicitly authorized product implementation after the preserved historical Task8 candidates had been verified. The historical worktrees remain untouched. This reconciliation was authored in a separate clean worktree through a live Godot AI v3.2.0 editor session.
+
+## Implemented boundary
+
+`SpellUseScreen` is a thin UI consumer of the existing `SpellWorkflowCoordinator` authority.
+
+- Explicit target choice only calls `prepare_target_preview`.
+- An invalid target clears the rendered preview and disables commit.
+- First commit action calls `request_use_confirmation`.
+- Second explicit action forwards the caller-owned opaque use ID to `confirm_use` exactly once.
+- Stale, missing, mismatched, or duplicate confirmation fails closed.
+- Edit cancels a pending confirmation; cancel emits intent only.
+- The screen does not calculate Mana, mutate inventory/results, create use IDs, or auto-select/cast.
+
+## Fresh evidence
+
+| Check | Result |
+| --- | --- |
+| Live Godot AI v3.2.0 session | ready; current Task8 scene opened and authored |
+| Runtime scene | started without task-related errors; all five player-flow nodes visible |
+| Custom runner | 45 suites, 1,934 assertions, 0 failures |
+| GUT integration | 2 scripts, 2 tests, 9 asserts, all passed |
+| Python authority contracts | 13 tests passed |
+| Hera exact-worktree diagnostics | clean; 0 errors, 0 warnings; expected 19-node scene tree |
+| `git diff --check` for staged Task8 source | passed |
+
+The GUI Godot binary does not expose custom-runner stdout to the shell; the same Godot 4.7.2 console binary produced the recorded runner and GUT results above.
+
+## Still pending
+
+- Exact-head remote CI, PR review, merge, and merged-main readback.
+- Human usability, device, performance, export, and full vertical-slice validation remain `NOT_RUN`.

--- a/docs/planning/TASK8_CURRENT_MAIN_RECONCILIATION_2026-08-27.md
+++ b/docs/planning/TASK8_CURRENT_MAIN_RECONCILIATION_2026-08-27.md
@@ -7,6 +7,7 @@
 - Commit: `68211069eb3b778fb43e68f3fbd049c8a0ac2733`
 - Branch: `codex/task8-spell-use-reconcile-v320-20260827`
 - Base: `origin/main@1e8662217e13dbfce6a41749f850db66b000d64b`
+- Pull request: #190
 
 The user explicitly authorized product implementation after the preserved historical Task8 candidates had been verified. The historical worktrees remain untouched. This reconciliation was authored in a separate clean worktree through a live Godot AI v3.2.0 editor session.
 

--- a/src/ui/spell_workflow/spell_use_screen.gd
+++ b/src/ui/spell_workflow/spell_use_screen.gd
@@ -1,0 +1,114 @@
+# 주문 쓰기 화면은 기존 Coordinator의 대상·시전 권한을 표시하고 의도만 전달한다.
+class_name SpellUseScreen
+extends Control
+
+signal cancel_requested
+
+var _coordinator = null
+var _use_transaction_id: StringName = &""
+var _current_preview: Dictionary = {}
+var _confirmation_requested := false
+var _committed := false
+var _target_choices_by_id: Dictionary = {}
+
+func configure(coordinator, use_transaction_id: StringName = &"") -> void:
+    _coordinator = coordinator
+    _use_transaction_id = use_transaction_id
+    _current_preview.clear()
+    _confirmation_requested = false
+    _committed = false
+    _target_choices_by_id.clear()
+
+func select_target(target_keyword: StringName, target: Dictionary, payload: Dictionary) -> Dictionary:
+    if _coordinator == null:
+        return {"status": &"SPELL_SELECTION_REQUIRED"}
+    var preview: Dictionary = _coordinator.prepare_target_preview(target_keyword, target, payload)
+    if StringName(preview.get("status", &"")) != &"FINAL_PREVIEW_READY":
+        _current_preview.clear()
+        _render_preview_status(StringName(preview.get("status", &"INVALID_TARGET")), {}, false)
+        return preview.duplicate(true)
+    _current_preview = preview.duplicate(true)
+    _render_preview_status(&"FINAL_PREVIEW_READY", _current_preview, true)
+    return current_preview()
+
+func _ready() -> void:
+    var selector = get_node_or_null("Content/TargetSelector")
+    if selector != null and selector.has_signal("target_selected") and not selector.target_selected.is_connected(_on_target_selected):
+        selector.target_selected.connect(_on_target_selected)
+    var commit_bar = get_node_or_null("Content/CommitBar")
+    if commit_bar != null and commit_bar.has_signal("commit_requested") and not commit_bar.commit_requested.is_connected(_on_commit_requested):
+        commit_bar.commit_requested.connect(_on_commit_requested)
+    if commit_bar != null and commit_bar.has_signal("edit_requested") and not commit_bar.edit_requested.is_connected(_on_edit_requested):
+        commit_bar.edit_requested.connect(_on_edit_requested)
+    var cancel_button = get_node_or_null("Content/CancelButton") as Button
+    if cancel_button != null and not cancel_button.pressed.is_connected(_on_cancel_pressed):
+        cancel_button.pressed.connect(_on_cancel_pressed)
+
+func set_target_choices(target_choices: Array) -> void:
+    _target_choices_by_id.clear()
+    var selector_choices: Array[Dictionary] = []
+    for candidate_variant in target_choices:
+        var candidate: Dictionary = Dictionary(candidate_variant)
+        var choice_id := StringName(candidate.get("id", &""))
+        if choice_id.is_empty() or not candidate.has("label") or not candidate.has("hint") or not candidate.has("target_keyword") or not candidate.has("target") or not candidate.has("payload"):
+            continue
+        _target_choices_by_id[choice_id] = candidate.duplicate(true)
+        selector_choices.append({"id": choice_id, "label": str(candidate["label"]), "hint": str(candidate["hint"])})
+    var selector = get_node_or_null("Content/TargetSelector")
+    if selector != null and selector.has_method("configure_targets"):
+        selector.configure_targets(selector_choices)
+
+func _on_target_selected(choice_id: StringName) -> void:
+    if not _target_choices_by_id.has(choice_id):
+        return
+    var choice: Dictionary = Dictionary(_target_choices_by_id[choice_id])
+    select_target(StringName(choice.get("target_keyword", &"")), Dictionary(choice.get("target", {})), Dictionary(choice.get("payload", {})))
+
+func _render_preview_status(status: StringName, preview_result: Dictionary, can_commit: bool) -> void:
+    var status_label = get_node_or_null("Content/FinalPreview/Status") as Label
+    if status_label != null:
+        status_label.text = str(status)
+    var preview: Dictionary = Dictionary(preview_result.get("preview", {}))
+    var commit_bar = get_node_or_null("Content/CommitBar")
+    if commit_bar != null and commit_bar.has_method("configure"):
+        commit_bar.configure(str(preview.get("target_keyword", "—")), maxi(0, int(preview.get("estimated_mana", 0))), can_commit, _confirmation_requested)
+
+func current_preview() -> Dictionary:
+    return _current_preview.duplicate(true)
+
+func request_confirmation() -> bool:
+    if _coordinator == null or _current_preview.is_empty() or _committed:
+        return false
+    _confirmation_requested = _coordinator.request_use_confirmation()
+    if _confirmation_requested:
+        _render_preview_status(&"FINAL_PREVIEW_READY", _current_preview, true)
+    return _confirmation_requested
+
+func confirm(transaction_id: StringName) -> Dictionary:
+    if _coordinator == null or transaction_id.is_empty() or transaction_id != _use_transaction_id:
+        return {"status": &"USE_CONFIRMATION_REQUIRED"}
+    if not _confirmation_requested or _committed:
+        return {"status": &"USE_CONFIRMATION_REQUIRED"}
+    var result: Dictionary = _coordinator.confirm_use(transaction_id)
+    if StringName(result.get("status", &"")) == &"USED":
+        _committed = true
+    return result.duplicate(true)
+
+func cancel() -> void:
+    cancel_requested.emit()
+
+func _on_edit_requested() -> void:
+    if _committed:
+        return
+    _confirmation_requested = false
+    if not _current_preview.is_empty():
+        _render_preview_status(&"FINAL_PREVIEW_READY", _current_preview, true)
+
+func _on_commit_requested() -> void:
+    if not _confirmation_requested:
+        request_confirmation()
+        return
+    confirm(_use_transaction_id)
+
+func _on_cancel_pressed() -> void:
+    cancel()

--- a/src/ui/spell_workflow/spell_use_screen.gd.uid
+++ b/src/ui/spell_workflow/spell_use_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://cp5n0p7lxl57x

--- a/src/ui/spell_workflow/spell_use_screen.tscn
+++ b/src/ui/spell_workflow/spell_use_screen.tscn
@@ -1,0 +1,42 @@
+[gd_scene format=3 uid="uid://qfvh1n7f5veh"]
+
+[ext_resource type="Script" uid="uid://cp5n0p7lxl57x" path="res://src/ui/spell_workflow/spell_use_screen.gd" id="1_j56eg"]
+[ext_resource type="PackedScene" path="res://src/ui/components/context_target_selector.tscn" id="2_tst33"]
+[ext_resource type="PackedScene" path="res://src/ui/components/commit_bar.tscn" id="3_2e13p"]
+
+[node name="SpellUseScreen" type="Control" unique_id=781477627]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("1_j56eg")
+
+[node name="Content" type="VBoxContainer" parent="." unique_id=1843004507]
+layout_mode = 0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 32.0
+offset_top = 32.0
+offset_right = -32.0
+offset_bottom = -32.0
+
+[node name="PreparedSpellSummary" type="Label" parent="Content" unique_id=804969587]
+layout_mode = 2
+text = "COMPLETED SPELL"
+
+[node name="TargetSelector" parent="Content" unique_id=59880927 instance=ExtResource("2_tst33")]
+layout_mode = 2
+
+[node name="FinalPreview" type="VBoxContainer" parent="Content" unique_id=1382989766]
+layout_mode = 2
+
+[node name="Status" type="Label" parent="Content/FinalPreview" unique_id=31193571]
+layout_mode = 2
+text = "SELECT A TARGET"
+
+[node name="CommitBar" parent="Content" unique_id=655457358 instance=ExtResource("3_2e13p")]
+layout_mode = 2
+
+[node name="CancelButton" type="Button" parent="Content" unique_id=284549868]
+layout_mode = 2
+text = "CANCEL"

--- a/tests/gut/integration/test_spell_use_screen.gd
+++ b/tests/gut/integration/test_spell_use_screen.gd
@@ -1,0 +1,29 @@
+# Task8 주문 쓰기 화면이 기존 사용 권한을 중복하지 않는지 검증한다.
+extends GutTest
+
+const SpellUseScreen = preload("res://src/ui/spell_workflow/spell_use_screen.gd")
+
+class FakeCoordinator:
+    extends RefCounted
+    var confirm_calls: Array[StringName] = []
+
+    func prepare_target_preview(_target_keyword: StringName, _target: Dictionary, _payload: Dictionary) -> Dictionary:
+        return {"status": &"FINAL_PREVIEW_READY", "preview": {"estimated_mana": 7}}
+
+    func request_use_confirmation() -> bool:
+        return true
+
+    func confirm_use(use_transaction_id: StringName) -> Dictionary:
+        confirm_calls.append(use_transaction_id)
+        return {"status": &"USED"}
+
+func test_explicit_two_step_confirmation_uses_caller_id_once() -> void:
+    var screen = SpellUseScreen.new()
+    var coordinator = FakeCoordinator.new()
+    screen.configure(coordinator, &"opaque-use-id")
+    screen.select_target(&"incident.root", {"target_valid": true}, {})
+    assert_true(screen.request_confirmation())
+    assert_eq(screen.confirm(&"opaque-use-id").get("status", &""), &"USED")
+    assert_eq(screen.confirm(&"opaque-use-id").get("status", &""), &"USE_CONFIRMATION_REQUIRED")
+    assert_eq(coordinator.confirm_calls, [&"opaque-use-id"])
+    screen.free()

--- a/tests/gut/integration/test_spell_use_screen.gd.uid
+++ b/tests/gut/integration/test_spell_use_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://th1rr36upmhp

--- a/tests/integration/test_spell_use_screen.gd
+++ b/tests/integration/test_spell_use_screen.gd
@@ -1,0 +1,86 @@
+# Task8 주문 쓰기 화면의 명시적 대상 선택과 시전 경계를 검증한다.
+extends RefCounted
+
+const SCREEN_SCENE_PATH := "res://src/ui/spell_workflow/spell_use_screen.tscn"
+
+class FakeCoordinator:
+    extends RefCounted
+    var preview_calls: Array[Dictionary] = []
+    var confirmation_requests := 0
+    var confirmed_ids: Array[StringName] = []
+
+    func prepare_target_preview(target_keyword: StringName, target: Dictionary, payload: Dictionary) -> Dictionary:
+        preview_calls.append({"target_keyword": target_keyword, "target": target.duplicate(true), "payload": payload.duplicate(true)})
+        if not bool(target.get("target_valid", false)):
+            return {"status": &"INVALID_TARGET"}
+        return {"status": &"FINAL_PREVIEW_READY", "preview": {"estimated_mana": 7, "target_keyword": target_keyword}}
+
+    func request_use_confirmation() -> bool:
+        confirmation_requests += 1
+        return true
+
+    func confirm_use(use_transaction_id: StringName) -> Dictionary:
+        confirmed_ids.append(use_transaction_id)
+        return {"status": &"USED", "use_transaction_id": use_transaction_id}
+
+func run(case) -> void:
+    var packed_scene = load(SCREEN_SCENE_PATH)
+    case.assert_true(packed_scene != null and packed_scene.can_instantiate(), "Task8 Spell Use scene must instantiate")
+    if packed_scene == null or not packed_scene.can_instantiate():
+        return
+    var screen = packed_scene.instantiate()
+    for node_name in ["PreparedSpellSummary", "TargetSelector", "FinalPreview", "CommitBar", "CancelButton"]:
+        case.assert_true(screen.find_child(node_name, true, false) != null, "screen exposes player flow node: %s" % node_name)
+    var coordinator = FakeCoordinator.new()
+    screen.configure(coordinator, &"use-opaque-1")
+    screen._ready()
+    var preview: Dictionary = screen.select_target(&"incident.root", {"target_valid": true}, {"known_improvement": "stabilize"})
+    case.assert_equal(&"FINAL_PREVIEW_READY", preview.get("status", &""), "a valid explicit target receives the Coordinator preview")
+    case.assert_equal(1, coordinator.preview_calls.size(), "screen delegates target preview exactly once")
+    var commit_bar = screen.find_child("CommitBar", true, false)
+    case.assert_true(bool(commit_bar.visual_snapshot().get("can_commit", false)), "valid preview enables intent-level commit only")
+    var invalid_preview: Dictionary = screen.select_target(&"incident.invalid", {"target_valid": false}, {})
+    case.assert_equal(&"INVALID_TARGET", invalid_preview.get("status", &""), "invalid selection reports authority status")
+    case.assert_true(screen.current_preview().is_empty(), "invalid target clears stale preview truth")
+    screen.select_target(&"incident.root", {"target_valid": true}, {})
+    case.assert_true(screen.request_confirmation(), "first explicit use action requests confirmation")
+    case.assert_equal(1, coordinator.confirmation_requests, "screen delegates confirmation request once")
+    commit_bar.edit_requested.emit()
+    case.assert_false(bool(commit_bar.visual_snapshot().get("confirmation_required", true)), "edit cancels confirmation before a new target decision")
+    case.assert_equal(&"USE_CONFIRMATION_REQUIRED", screen.confirm(&"use-opaque-1").get("status", &""), "edit prevents a stale confirmation from casting")
+    case.assert_true(screen.request_confirmation(), "cast requires a new explicit confirmation after edit")
+    case.assert_equal(&"USE_CONFIRMATION_REQUIRED", screen.confirm(&"wrong-id").get("status", &""), "mismatched caller ID fails closed")
+    case.assert_equal(0, coordinator.confirmed_ids.size(), "mismatched ID never reaches authority")
+    case.assert_equal(&"USED", screen.confirm(&"use-opaque-1").get("status", &""), "second explicit action invokes existing use authority")
+    case.assert_equal([&"use-opaque-1"], coordinator.confirmed_ids, "opaque caller ID reaches authority once")
+    case.assert_equal(&"USE_CONFIRMATION_REQUIRED", screen.confirm(&"use-opaque-1").get("status", &""), "duplicate confirmation fails closed")
+    screen.queue_free()
+
+    var selection_screen = packed_scene.instantiate()
+    var selection_coordinator = FakeCoordinator.new()
+    case.assert_true(selection_screen.has_method("set_target_choices"), "screen accepts caller-supplied explicit target choices")
+    selection_screen.configure(selection_coordinator, &"use-opaque-2")
+    selection_screen._ready()
+    selection_screen.set_target_choices([{
+        "id": &"root-choice",
+        "label": "Root",
+        "hint": "Stabilize the incident",
+        "target_keyword": &"incident.root",
+        "target": {"target_valid": true},
+        "payload": {"known_improvement": "stabilize"},
+    }])
+    var selector = selection_screen.find_child("TargetSelector", true, false)
+    case.assert_equal(1, selector.visual_snapshot().get("targets", []).size(), "shared selector displays caller-supplied choices")
+    selector.target_selected.emit(&"root-choice")
+    case.assert_equal(&"FINAL_PREVIEW_READY", selection_screen.current_preview().get("status", &""), "selector emits only explicit caller choice to Coordinator preview")
+    case.assert_equal(1, selection_coordinator.preview_calls.size(), "selector does not infer or auto-select a target")
+    var selection_commit_bar = selection_screen.find_child("CommitBar", true, false)
+    selection_commit_bar.commit_requested.emit()
+    case.assert_equal(1, selection_coordinator.confirmation_requests, "first shared commit action asks existing authority for confirmation")
+    selection_commit_bar.commit_requested.emit()
+    case.assert_equal([&"use-opaque-2"], selection_coordinator.confirmed_ids, "second shared commit action forwards the configured opaque ID once")
+    var cancel_counts: Array[int] = [0]
+    selection_screen.cancel_requested.connect(func(): cancel_counts[0] += 1)
+    selection_screen.cancel()
+    case.assert_equal(1, cancel_counts[0], "explicit cancel emits player intent without gameplay mutation")
+    selection_screen.queue_free()

--- a/tests/integration/test_spell_use_screen.gd.uid
+++ b/tests/integration/test_spell_use_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://du6fm1n1cosa1

--- a/tests/test_runner.gd
+++ b/tests/test_runner.gd
@@ -47,6 +47,7 @@ const SUITES: Array[String] = [
     "res://tests/integration/test_frostbloom_star_ux_map.gd",
     "res://tests/integration/test_glyph_drawing_workflow_screen.gd",
     "res://tests/integration/test_circuit_placement_workflow_screen.gd",
+    "res://tests/integration/test_spell_use_screen.gd",
 ]
 
 


### PR DESCRIPTION
## Summary\n- Restores Task8 as a thin target-and-cast consumer of the existing Stage3 coordinator.\n- Preserves explicit target choice, two-step confirmation, and caller-owned opaque use IDs.\n- Adds current-main runner and GUT regression coverage plus a reconciliation receipt.\n\nCloses #111\n\n## Verification\n- Godot 4.7.2 console custom runner: 45 suites, 1,934 assertions, 0 failures\n- GUT integration: 2 scripts, 2 tests, 9 asserts, all passed\n- Python authority contracts: 13 passed\n- Live Godot AI v3.2.0 runtime/Hera diagnostics: clean 19-node scene, 0 errors/warnings\n\n## Not claimed\nHuman/device/performance/export/full vertical-slice validation remains NOT_RUN.