### PR TITLE
docs: reconcile Task9 authority and visual consumers

### DIFF
--- a/docs/DEVELOPMENT_GATES.md
+++ b/docs/DEVELOPMENT_GATES.md
@@ -1,15 +1,15 @@
 # GRIMOIRE 개발·기획 게이트
 
 ```yaml
-active_contract: PROJECT_TOTAL_PLANNING_IMPLEMENTATION_AND_DELIVERY_INSTRUCTION_v4.5
-contract_binding_decision: GM-CONTRACT-V4-5-BINDING-01
-contract_binding_sync: GR-SYNC-20260811-02-CONTRACT-V4-5-R2-BINDING
-historical_contract_binding: GM-CONTRACT-V4-4-BINDING-01
+active_contract: PROJECT_TOTAL_PLANNING_IMPLEMENTATION_AND_DELIVERY_INSTRUCTION_v4.8
+contract_binding_decision: GM-CONTRACT-V4-8-BINDING-01
+contract_binding_sync: GR-SYNC-20260826-36-V4-8-R5-4-VISUAL-COVERAGE
+historical_contract_binding: GM-CONTRACT-V4-5-BINDING-01
 project_main_authority: LIVE_GITHUB_DEFAULT_BRANCH_READBACK
-current_state_sync: GR-SYNC-20260821-34-CANON-AUTHORITY-REALITY-SYNC
+current_state_sync: TASK9_MERGED_MAIN_DOCUMENTATION_READBACK
 dedicated_local_environment_predecessor_sync: GR-SYNC-20260811-20-PROJECT-DEDICATED-LOCAL-ENVIRONMENT
-task8_continuation_sync: GR-SYNC-20260812-21-TASK8-HANDOFF-BCP
-task8_current_reverify: docs/planning/TASK8_REMOTE_LOCAL_REVERIFY_2026-08-21.md
+task8_continuation_sync: GR-SYNC-20260812-21-TASK8-HANDOFF-BCP_HISTORICAL
+task8_current_reverify: docs/planning/TASK8_CURRENT_MAIN_RECONCILIATION_2026-08-27.md
 base_snapshot_policy: ALWAYS_REFETCH_CURRENT_MAIN_BEFORE_WORK
 base_project_pin: v9.4.3
 planning: COMPLETE_FROSTBLOOM_FIRST_SESSION
@@ -22,17 +22,19 @@ repo_wide_actions_full_sha: PASS
 repo_wide_actions_supply_chain: REPO_WIDE_ACTIONS_FULL_SHA_PINNING_PASS
 spell_workflow_predecessor_sync: GR-SYNC-20260811-01-SPELL-WORKFLOW-TASK7-CURRENT-STATE
 product_decision: GM-SPELL-WORKFLOW-UI-V2-01
-latest_product_main: fcb5dbe1cbbb23ef195633b1f6680f45d46c5a3f
-spell_workflow_predecessor_status: TASK7_MERGED_MAIN_VERIFIED
-spell_workflow_status: TASK8_LOCAL_REFINEMENT_GREEN_UNMERGED_MERGE_GATES_PENDING
-compatibility_next_gate: TASK8_RECEIPT_HERA_REVIEW_PR
-next_product_gate: TASK8_PR_PREP_REVERIFY_PENDING
-task8_recovery_subgate: TASK8_LOCAL_WORKTREE_DELTA_RECOVERY_REQUIRED
+latest_product_main: db038a4fd964ca037bfe97f6aee5d0cc7d0daf93
+spell_workflow_predecessor_status: TASK8_MERGED_MAIN_VERIFIED
+spell_workflow_status: TASK9_MERGED_MAIN_AUTOMATED_VERTICAL_SLICE_READY
+compatibility_next_gate: TASK8_HISTORICAL_RECOVERY_CLOSED
+next_product_gate: TASK9_USER_VERTICAL_SLICE_VALIDATION_PENDING
+task8_recovery_subgate: TASK8_CURRENT_MAIN_LOCAL_VALIDATION_PASS
 task8_local_git_head_baseline: 8c611f601aa98397ed1558e92ab207e0e8347a9b
 task8_product_commit: 68211069eb3b778fb43e68f3fbd049c8a0ac2733
 task8_remote_product_branch: codex/task8-spell-use-reconcile-v320-20260827
-task8_remote_product_pr: 190
-parallel_open_pr: PR151_DO_NOT_TOUCH
+task8_remote_product_pr: 190_MERGED_MAIN_VERIFIED
+task9_product_commit: db038a4fd964ca037bfe97f6aee5d0cc7d0daf93
+task9_product_pr: 192_MERGED_MAIN_VERIFIED
+parallel_open_pr: LIVE_GITHUB_READBACK_REQUIRED
 preserved_runtime_decision: GM-STAR-CIRCUIT-MASTERY-BALANCE-01
 circuit_topology: FIVE_POINT_STAR
 tool_authority_decision: GM-GODOT-AUTHORING-GUT-TEST-AUTHORITY-01
@@ -47,7 +49,7 @@ gut_formal_adoption: GUT_FORMALLY_ADOPTED
 hera_status: HERA_V1_0_0_EXACT_PAIR_LIVE_CANARY_PASS
 hera_authority: LIVE_QA_AND_OBSERVABILITY_ONLY
 windows_android_shared_core: WINDOWS_ANDROID_SHARED_CORE_STRUCTURAL_PASS
-three_screen_runtime: THREE_SCREEN_RUNTIME_AWAITING_TASKS_2_9
+three_screen_runtime: TASK9_PRODUCT_ROOT_AUTOMATED_VERTICAL_SLICE_READY
 human_validation: NOT_RUN
 device_validation: NOT_RUN
 performance_validation: NOT_RUN
@@ -85,7 +87,7 @@ stock_scope: TYPED_GLYPH_ONLY
 
 ## Gate 2 — Current Spell Workflow implementation boundary
 
-Tasks 3–7은 병합 완료다.
+Tasks 3–9는 병합 완료다. Task8 recovery text below is historical provenance; current execution starts at the Task9 human vertical-slice gate.
 
 | Task | PR | Merge | Result |
 |---|---:|---|---|
@@ -94,15 +96,24 @@ Tasks 3–7은 병합 완료다.
 | 5 | #106 | `275ba48eb9c07ce24d4b17b2c57de66c98923e1a` | MERGED_MAIN_VERIFIED |
 | 6 | #108 | `4a9daf0ed8de7bb39173a71e6ada9324d5a462b7` | MERGED_MAIN_VERIFIED |
 | 7 | #110 | `fcb5dbe1cbbb23ef195633b1f6680f45d46c5a3f` | TASK7_MERGED_MAIN_VERIFIED |
+| 8 | #190 | `e954b7fb863d31387d3383b654c60b52ea7b9d89` | TASK8_MERGED_MAIN_VERIFIED |
+| 9 | #192 | `db038a4fd964ca037bfe97f6aee5d0cc7d0daf93` | TASK9_MERGED_MAIN_AUTOMATED_VERTICAL_SLICE_READY |
 
-Task8은 Task5 Stage3의 thin UI consumer다. 다음 compatibility locator는 기존 consumer를 위해 유지한다.
+```yaml
+current_runtime_entry: res://src/ui/spell_workflow/spell_workflow_product_root.tscn
+current_runtime_role: DEVELOPMENT_PRODUCT_ROOT_ENTRY
+current_gate: TASK9_USER_VERTICAL_SLICE_VALIDATION_PENDING
+automated_evidence: AVAILABLE_DO_NOT_PROMOTE_TO_HUMAN_DEVICE_PERFORMANCE_OR_EXPORT_PASS
+```
+
+Task8은 Task5 Stage3의 thin UI consumer였으며, 다음 compatibility locator는 기존 consumer 검색을 위해 역사적으로 유지한다.
 
 ```text
 TASK8_LOCAL_REFINEMENT_GREEN_UNMERGED_MERGE_GATES_PENDING
 TASK8_RECEIPT_HERA_REVIEW_PR
 ```
 
-Parent gate는 계속 `TASK8_PR_PREP_REVERIFY_PENDING`이다. 그러나 fresh remote/local reverify 결과 실제 첫 실행 subgate는 다음으로 좁혀졌다.
+이전 Parent gate와 local recovery state는 Task8 병합 전의 역사 관찰값이다.
 
 ```yaml
 current_execution_subgate: TASK8_LOCAL_WORKTREE_DELTA_RECOVERY_REQUIRED
@@ -116,7 +127,7 @@ historical_product_state: UNMERGED_LOCAL_WORKTREE_DELTA
 
 `8c611f...`는 PR #131 HiGodot v3.1.4 authority reconciliation commit이다. Task8 제품 변경은 그 commit에 들어 있지 않았고 Sync21 당시 local worktree에만 존재했다. 원격 Task8/handoff 브랜치 scan에서도 `src/ui/spell_workflow/spell_use_screen.gd`는 발견되지 않았다.
 
-따라서 Task8 PR을 준비하기 전에 반드시 로컬 worktree delta 존재 여부를 먼저 확인한다.
+아래 절차는 Task8 PR 준비 당시의 보존 절차이며, 현재 Task9 gate의 실행 지시가 아니다.
 
 ```text
 로컬 delta 존재
@@ -137,7 +148,7 @@ historical_product_state: UNMERGED_LOCAL_WORKTREE_DELTA
 → stage/commit/push/PR
 ```
 
-현재 Task8은 `TASK8_MERGED_MAIN_VERIFIED`가 아니다. 상세 원격 readback은 `docs/planning/TASK8_REMOTE_LOCAL_REVERIFY_2026-08-21.md`가 소유한다.
+현재 Task8은 `TASK8_MERGED_MAIN_VERIFIED`이며, 상세 역사 원격 readback은 `docs/planning/TASK8_REMOTE_LOCAL_REVERIFY_2026-08-21.md`가 소유한다.
 
 ## Gate 3 — Sync21 local executor continuation
 

--- a/docs/planning/visual/GRIMOIRE_IMAGE_GOAL_QUEUE_2026-08-26.json
+++ b/docs/planning/visual/GRIMOIRE_IMAGE_GOAL_QUEUE_2026-08-26.json
@@ -3,9 +3,9 @@
   "project": "GRIMOIRE: 세계를 다시 쓰는 법",
   "handoff_id": "GR-WORK-HANDOFF-20260826-01",
   "queue_id": "GR-IMAGE-GOAL-QUEUE-20260826-01",
-  "status": "GPT_WORK_HANDOFF_READY",
+  "status": "TASK9_CURRENT_READBACK_HUMAN_VALIDATION_PENDING",
   "created_for": "CHATGPT_WORK",
-  "source_project_main": "27749d2b3a552193283182143fe772e18f0ef45f",
+  "source_project_main": "ce1bd46bc82dd3edf4ed3c485935108282117793",
   "source_base_main": "06669fe9c6a3ccd6f3b0d19c5757540bfdcc0623",
   "authority": {
     "project_agents": "AGENTS.md",
@@ -83,7 +83,7 @@
       "glyph_name_label_policy": "Each glyph presentation shows a live, localizable Korean name label at the lower right of the glyph visual; for example, glyph_flow displays 흐름. The runtime PNG remains glyph-only.",
       "must_preserve": ["canonical stroke identity", "direct-written magical letter feeling", "Magic/Anime + Blue/Blue-Purple magic language", "small-size silhouette distinction"],
       "must_not_introduce": ["talisman", "hanging tag", "collectible card framing", "pictogram-first redesign", "baked functional text", "new glyph IDs"],
-      "status": "RUNTIME_INTEGRATION_MERGED_MAIN_PENDING_RUNTIME_EVIDENCE",
+      "status": "RUNTIME_INTEGRATION_MERGED_MAIN_AUTOMATED_PRODUCT_ROOT_READY_HUMAN_EVIDENCE_PENDING",
       "next_gate": "IMG-02 consumer contract and bg_school_common Brief may proceed. Keep 48/64/96px readability, 1920x1080 capture, device, and performance evidence unclaimed until freshly captured. The BURST-to-AMPLIFY compatibility alias remains visual-only; no spell-transaction semantics change without explicit acceptance criteria.",
       "implementation_evidence": {
         "github_issue": 179,
@@ -110,8 +110,8 @@
       "required_assets": ["bg_school_common", "bg_greenhouse_field_base", "bg_greenhouse_battle_arena"],
       "planned_export": "2560x1440 WebP Lossless",
       "consumer_contract": "docs/planning/visual/FROSTBLOOM_FIRST_SESSION_ENVIRONMENT_SCENE_CONTRACT_2026-08-26.md",
-      "status": "ALL_REQUIRED_SOURCE_CANDIDATES_PERSISTED_PENDING_RUNTIME_EXPORT_FIT",
-      "next_gate": "REVIEW_THE_THREE_SOURCE_CANDIDATES_FOR_RUNTIME_EXPORT_FIT; DO_NOT_CREATE_INCIDENT_OR_BATTLE_STATE_OVERLAYS_UNTIL_RUNTIME_EFFECT_REUSE_IS_EVALUATED"
+      "status": "SOURCE_CANDIDATES_ONLY_NO_CURRENT_MAIN_BINDING",
+      "next_gate": "DEFINE_AND_MERGE_AN_ACTUAL_GODOT_CONSUMER_AND_TEXTURE_BINDING_BEFORE_RUNTIME_EXPORT_FIT_REVIEW; DO_NOT_CREATE_INCIDENT_OR_BATTLE_STATE_OVERLAYS_UNTIL_RUNTIME_EFFECT_REUSE_IS_EVALUATED"
     },
     {
       "order": 3,

--- a/docs/planning/visual/GRIMOIRE_VISUAL_ASSET_COVERAGE_2026-08-26.json
+++ b/docs/planning/visual/GRIMOIRE_VISUAL_ASSET_COVERAGE_2026-08-26.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "project": "GRIMOIRE: 세계를 다시 쓰는 법",
   "requirement_set_id": "GR-VISUAL-ASSET-COVERAGE-20260826-01",
-  "status": "CURRENT_PREFLIGHT_COMPLETE_AWAITING_NEXT_SINGLE_VISUAL_GENERATION_APPROVAL",
+  "status": "TASK9_CURRENT_RUNTIME_READBACK_HUMAN_VALIDATION_PENDING",
   "contract": {
     "name": "PROJECT_TOTAL_PLANNING_IMPLEMENTATION_AND_DELIVERY_INSTRUCTION",
     "version": "4.8",
@@ -10,8 +10,23 @@
     "policy": "VISUAL_REQUIREMENT_DELETE_TEST_THEN_VISUAL_ASSET_COVERAGE_AND_ART_STYLE_LOCK"
   },
   "project_stage": "DEMO_FIRST_VERTICAL_SLICE__PARTIAL_FOUNDATION",
-  "active_work_scope": "VISUAL_IMAGE_ASSET_PLANNING_ONLY",
-  "product_implementation_authorized_by_current_work_scope": false,
+  "active_work_scope": "TASK9_AUTOMATED_VERTICAL_SLICE_AUTHORITY_AND_VISUAL_CONSUMER_RECONCILIATION",
+  "product_implementation_authorized_by_current_work_scope": true,
+  "current_runtime_readback": {
+    "readback_date": "2026-08-27",
+    "project_main": "ce1bd46bc82dd3edf4ed3c485935108282117793",
+    "main_scene": "res://src/ui/spell_workflow/spell_workflow_product_root.tscn",
+    "main_scene_role": "DEVELOPMENT_PRODUCT_ROOT_ENTRY",
+    "task9_status": "MERGED_MAIN_AUTOMATED_VERTICAL_SLICE_READY",
+    "next_product_gate": "TASK9_USER_VERTICAL_SLICE_VALIDATION_PENDING",
+    "glyph_runtime_asset_count": 6,
+    "glyph_consumer_state": "CURRENT_RUNTIME",
+    "glyph_assets": ["glyph_heat.png", "glyph_protect.png", "glyph_flow.png", "glyph_focus.png", "glyph_disperse.png", "glyph_burst.png"],
+    "glyph_runtime_consumer": "src/ui/spell_workflow/spell_workflow_product_root.tscn via glyph_visual_resolver.gd",
+    "img02_state": "SOURCE_CANDIDATES_ONLY_NO_CURRENT_MAIN_BINDING",
+    "img02_source_candidates": "PERSISTED_UNBOUND_ON_CURRENT_MAIN",
+    "unrun_evidence": ["HUMAN_NOT_RUN", "DEVICE_NOT_RUN", "PERFORMANCE_NOT_RUN", "WINDOWS_EXPORT_NOT_RUN", "ANDROID_EXPORT_NOT_RUN", "FULL_VERTICAL_SLICE_NOT_RUN"]
+  },
   "evidence_ceiling": {
     "runtime_visual_complete": "NOT_PROVEN",
     "human_usability": "NOT_RUN",
@@ -21,7 +36,7 @@
   },
   "fresh_sources": {
     "base_main": "edb3b3376603c9f6b00d64af3126304f8c9946bf",
-    "project_main": "829094fd87433e14fe42b23f9b7bec6321f5048d",
+    "project_main": "ce1bd46bc82dd3edf4ed3c485935108282117793",
     "visual_direction": "docs/planning/visual/GRIMOIRE_VISUAL_DIRECTION_APPROVAL_2026-08-25.json",
     "representative_screens": "docs/planning/visual/GRIMOIRE_REPRESENTATIVE_SCREENS_2026-08-25.json",
     "locked_reference": "docs/planning/visual/ART_STYLE_01_LOCKED_REFERENCE_MANIFEST.json",
@@ -115,14 +130,14 @@
       "type": "CORE_LOOP_UI_SCREEN",
       "purpose": "Make direct glyph input, recognition/retry, and source ownership understandable",
       "implementation_consumer": "TASK6_GLYPH_DRAWING_WORKFLOW_SCREEN",
-      "existing_asset_or_reference": "Task6 merged implementation + Spell Workflow UI direction + semantic UI pack",
+      "existing_asset_or_reference": "Task6 + Task9 merged implementation, six approved runtime glyph PNGs, and semantic UI pack",
       "delete_test": "Without a clear drawing state the game's direct-writing promise is not understandable.",
       "consequence_if_missing": "Core fantasy and input recovery become opaque.",
       "priority": "P0",
       "action": "ADAPT",
       "coverage_status": "COVERED_EXISTING",
       "state_family_status": "PARTIAL",
-      "note": "Do not spend the next image slot here; current implementation/reference already gives stronger coverage than the Stage2 Stock/Circuit gap."
+      "note": "Task9 Product Root consumes the six-glyph resolver path. New glyph generation is not a current gap; human small-size readability remains unverified."
     },
     {
       "visual_id": "GR-VIS-005-TYPED-GLYPH-VAULT-STOCK",
@@ -134,9 +149,9 @@
       "consequence_if_missing": "Core resource semantics and player planning are misread.",
       "priority": "P0",
       "action": "ADAPT",
-      "coverage_status": "GAP_BLOCKING",
+      "coverage_status": "COVERED_EXISTING",
       "state_family_status": "PARTIAL",
-      "note": "Must visually distinguish exact Vault source, typed Stock source, reserved source, consumed source, and unavailable source without relying on color alone."
+      "note": "Task9 carries the source-selection flow. Preserve semantic redundancy; human comprehension validation remains pending."
     },
     {
       "visual_id": "GR-VIS-006-FIVE-POINT-STAR-PREPARED-SPELL",
@@ -147,38 +162,38 @@
       "delete_test": "Without a representative Stage2 composition, the central spell-design differentiator remains visually ambiguous.",
       "consequence_if_missing": "The product can look like a generic spell menu rather than direct semantic circuit design.",
       "priority": "P0",
-      "action": "CREATE",
-      "coverage_status": "GAP_BLOCKING",
+      "action": "REUSE",
+      "coverage_status": "COVERED_EXISTING",
       "state_family_status": "PARTIAL",
-      "note": "Chosen as the next exactly-one visual brief because it closes the largest approved-reference gap without inventing Task8 behavior."
+      "note": "Task9 Product Root now presents the merged circuit path. A representative sheet is not a runtime asset and is not a current production requirement."
     },
     {
       "visual_id": "GR-VIS-007-SPELL-USE-TARGET-FINAL-PREVIEW",
       "type": "CORE_LOOP_UI_SCREEN",
       "purpose": "Show explicit target keyword, final expected result/risk preview, Mana spend, and explicit use",
-      "implementation_consumer": "TASK8_SPELL_USE_SCREEN_THIN_UI_CONSUMER_OF_TASK5",
-      "existing_asset_or_reference": "Task5 Stage3 authority exists; Task8 remote product screen does not exist on current main",
+      "implementation_consumer": "TASK9_PRODUCT_ROOT / src/ui/spell_workflow/spell_use_screen.tscn",
+      "existing_asset_or_reference": "Task8 recovery implementation is merged through Task9 Product Root on current main",
       "delete_test": "Final use must remain explicit and understandable, but a final visual should not outrun the missing current Task8 product screen.",
       "consequence_if_missing": "Commit risk/cost can become opaque; generating too early can create rework against the eventual consumer.",
       "priority": "P0",
-      "action": "DEFER",
-      "coverage_status": "DEFERRED_BY_DECISION",
+      "action": "REUSE",
+      "coverage_status": "COVERED_EXISTING",
       "state_family_status": "NOT_REVIEWED",
-      "note": "Prepare after the Stage2 representative visual or when Task8 implementation is explicitly authorized/reconciled."
+      "note": "The explicit target and two-step cast flow exists in Task9. It still requires human, device, and performance evidence."
     },
     {
       "visual_id": "GR-VIS-008-FROSTBLOOM-ENVIRONMENT",
       "type": "ENVIRONMENT_MASTER_AND_STATE_OVERLAYS",
       "purpose": "Anchor Frostbloom greenhouse location, readable hazards, and before/after world state",
       "implementation_consumer": "FROSTBLOOM_FIRST_SESSION_SCENES",
-      "existing_asset_or_reference": "Approved greenhouse battle/dialogue visual references and legacy Asset Spec background caps",
+      "existing_asset_or_reference": "Approved references plus three persisted IMG-02 source candidates; none is bound by a current-main Godot scene",
       "delete_test": "Generic backgrounds would preserve mechanics but erase place identity and weaken cause/effect readability.",
       "consequence_if_missing": "Weak world memory and unclear environmental consequences.",
       "priority": "P1",
       "action": "CREATE",
       "coverage_status": "GAP_NONBLOCKING",
       "state_family_status": "PARTIAL",
-      "note": "Prefer one reusable greenhouse master plus state overlays instead of many unique full backgrounds."
+      "note": "Source candidates are not runtime exports or scene consumers. Keep them unbound until a concrete Godot scene and Texture binding are merged."
     },
     {
       "visual_id": "GR-VIS-009-FIRST-SESSION-CHARACTERS",
@@ -336,13 +351,13 @@
         "tradeoff": "Task8 product screen is not on current main, so a final visual now has higher rework risk."
       }
     ],
-    "selected": "B",
-    "selection_reason": "Highest current comprehension gap, directly corrects an approved rework finding, reuses merged Task7/Stage2 semantics, and does not require product implementation authorization.",
-    "generation_authority": "NOT_GRANTED_YET_TEXT_BRIEF_STOP_REQUIRED"
+    "selected": "NONE",
+    "selection_reason": "Task9 now covers the glyph, circuit, target, and cast runtime flow. No new image has a current-main consumer gap.",
+    "generation_authority": "NO_NEW_IMAGE_UNTIL_CONCRETE_RUNTIME_CONSUMER_GAP"
   },
   "next_single_visual_text_brief": {
     "brief_id": "GR-VISUAL-BRIEF-STAGE2-STOCK-CIRCUIT-20260826-01",
-    "status": "TEXT_BRIEF_READY_AWAITING_EXPLICIT_USER_GENERATION_APPROVAL",
+    "status": "HISTORICAL_BRIEF_SUPERSEDED_BY_TASK9_CURRENT_RUNTIME_READBACK",
     "goal": "한 화면에서 '보관된 글자/Stock을 재료로 선택하고, FIVE_POINT_STAR 회로에 배치해 Prepared Spell을 만드는 과정'을 즉시 이해시키는 대표 시안.",
     "player_question": "내가 가진 글자를 어디서 가져와 어떻게 회로에 배치하고, 언제 주문이 준비 상태가 되는가?",
     "composition": [

--- a/docs/planning/visual/GRIMOIRE_VISUAL_PRODUCTION_CHECKLIST_2026-08-26.json
+++ b/docs/planning/visual/GRIMOIRE_VISUAL_PRODUCTION_CHECKLIST_2026-08-26.json
@@ -7,7 +7,17 @@
   "correction_source": "우린 '설명용 시트'가 아니라 실제 게임 소비처가 있는 이미지 기준으로 만드는거야.",
   "supersedes": "2026-08-26 initial checklist that mixed representative/explanatory images with runtime assets",
   "contract_revision": "2026-08-26-r5.4-superset-final",
-  "baseline_project_main": "61d9a34b04534bc987851ef1b12382b1229e999b",
+  "baseline_project_main": "ce1bd46bc82dd3edf4ed3c485935108282117793",
+  "current_runtime_readback": {
+    "readback_date": "2026-08-27",
+    "main_scene": "res://src/ui/spell_workflow/spell_workflow_product_root.tscn",
+    "task9_status": "MERGED_MAIN_AUTOMATED_VERTICAL_SLICE_READY",
+    "next_product_gate": "TASK9_USER_VERTICAL_SLICE_VALIDATION_PENDING",
+    "glyph_runtime_asset_count": 6,
+    "glyph_consumer_state": "CURRENT_RUNTIME",
+    "img02_state": "SOURCE_CANDIDATES_ONLY_NO_CURRENT_MAIN_BINDING",
+    "evidence_boundary": "HUMAN_DEVICE_PERFORMANCE_EXPORT_AND_FULL_VERTICAL_SLICE_NOT_RUN"
+  },
   "baseline_base_main": "edb3b3376603c9f6b00d64af3126304f8c9946bf",
   "purpose": "게임의 Godot Scene/UI/System이 실제로 소비하는 Runtime Image/Texture/VFX 자산만 생산 목록으로 관리한다. 설명용 시트, 대표 화면 시안, 기획 보드는 생산 자산으로 계산하지 않는다.",
   "authority": {
@@ -37,19 +47,19 @@
   "runtime_asset_families": [
     {
       "asset_group_id": "GR-RA-01-GLYPH-BASE",
-      "name": "기본 마법 글자 Runtime Asset 3종",
-      "consumer_state": "APPROVED_PRODUCT_CONSUMER",
-      "consumers": ["src/ui/spell_workflow/glyph_drawing_screen.tscn", "src/ui/spell_workflow/circuit_placement_screen.tscn", "Task8 Spell Use future thin UI consumer"],
+      "name": "기본 마법 글자 Runtime Asset 6종",
+      "consumer_state": "CURRENT_RUNTIME",
+      "consumers": ["src/ui/spell_workflow/glyph_drawing_screen.tscn", "src/ui/spell_workflow/circuit_placement_screen.tscn", "src/ui/spell_workflow/spell_use_screen.tscn", "src/ui/spell_workflow/spell_workflow_product_root.tscn"],
       "runtime_role": "글자 인식 결과/보관 글자/회로 배치/완성 주문 Preview에서 직접 쓰인 마법 문자 표현",
-      "asset_spec": {"count_cap": 3, "base_names": ["flow", "focus", "disperse"], "canvas": "512x512 vector_or_rgba", "states": ["raw_stroke", "recognized", "selected", "invalid_grammar", "insufficient_condition", "committed"], "state_policy": "상태별 별도 PNG 복제보다 material/outline/color/icon mark 우선"},
+      "asset_spec": {"count_cap": 6, "base_names": ["heat", "protect", "flow", "focus", "disperse", "burst"], "canvas": "512x512 PNG RGBA", "states": ["raw_stroke", "recognized", "selected", "invalid_grammar", "insufficient_condition", "committed"], "state_policy": "상태별 별도 PNG 복제보다 material/outline/color/icon mark 우선"},
       "visual_rule": "DIRECT_WRITTEN_MAGICAL_LETTER; 부적/패찰/수집카드 금지",
-      "production_readiness": "CONSUMER_SCENES_EXIST_TEXTURE_BINDING_AND_EXACT_RUNTIME_PATH_PENDING",
-      "next_action": "Task6/Task7의 실제 asset slot 및 manifest path를 먼저 고정한 뒤 Runtime Asset 3종을 제작"
+      "production_readiness": "MERGED_MAIN_PRODUCT_ROOT_RUNTIME_CONSUMED",
+      "next_action": "새 glyph 이미지는 만들지 않는다. Task9 사용성 검증에서 48/64/96px 판독 증거를 별도로 확보한다."
     },
     {
       "asset_group_id": "GR-RA-02-BASE-ICONS",
       "name": "공용 Runtime Icon Set",
-      "consumer_state": "APPROVED_PRODUCT_CONSUMER",
+      "consumer_state": "SOURCE_CANDIDATES_ONLY_NO_CURRENT_MAIN_BINDING",
       "consumers": ["Field UI", "Dialogue UI", "Writing UI", "Battle UI", "Result UI", "Grimoire UI", "Main UI"],
       "runtime_role": "HP/Mana/불안정도/환경/경고/글자 의미/동반자/가디언/조작/마도서/결과 상태 표시",
       "asset_spec": {"count_cap": 24, "candidate_icons": ["HP", "Mana", "Instability", "Environment", "Attack Timer", "Slow", "Pause", "Warning", "Flow", "Focus", "Disperse", "Calm", "Prepared", "Connected", "Companion", "Guardian", "Undo", "Clear", "Cancel", "Confirm", "Grimoire", "Result", "Save", "Settings"], "variant_policy": "색 Variant를 별도 Texture로 복제하지 않음"},
@@ -70,7 +80,7 @@
         {"id": "BG-03", "name": "Greenhouse Battle Arena", "consumer": "동일 사건 별도 전투장"}
       ],
       "count_cap": 3,
-      "production_readiness": "SCENE_CONSUMERS_APPROVED_PRODUCT_ROOT_NOT_YET_ON_MAIN"
+      "production_readiness": "THREE_SOURCE_CANDIDATES_PERSISTED_UNBOUND_ON_CURRENT_MAIN"
     },
     {
       "asset_group_id": "GR-RA-04-BACKGROUND-STATE-OVERLAYS",
@@ -183,10 +193,10 @@
   ],
   "production_order_rule": "화면 순서가 아니라 consumer readiness 순서로 만든다: CURRENT_RUNTIME gap → consumer Scene 존재 + asset slot 확정 → approved product consumer + implementation 임박 → 그 외 defer.",
   "next_action": {
-    "action": "RUNTIME_CONSUMER_MAP_REVIEW",
+    "action": "TASK9_USER_VERTICAL_SLICE_VALIDATION",
     "image_generation_authorized": false,
-    "first_candidate_group": "GR-RA-01-GLYPH-BASE",
-    "condition": "Task6/Task7에서 실제 glyph Texture/Vector slot과 runtime path/manifest가 확정된 뒤에만 첫 Runtime Asset 생성"
+    "first_candidate_group": "NONE",
+    "condition": "현재 main 소비처가 없는 이미지는 생성·내보내기·정본 등록하지 않는다. IMG-02는 새 Godot consumer와 Texture binding 계약이 추가된 뒤에만 재검토한다."
   },
   "evidence_ceiling": {
     "current_product_stage": "PARTIAL_FOUNDATION",

--- a/docs/superpowers/plans/2026-08-27-current-authority-visual-consumer-reconciliation.md
+++ b/docs/superpowers/plans/2026-08-27-current-authority-visual-consumer-reconciliation.md
@@ -1,0 +1,60 @@
+# Current Authority & Visual Consumer Reconciliation Plan
+
+> **For agentic workers:** Use `superpowers:executing-plans` task by task. This is a documentation-and-structured-state correction only.
+
+**Goal:** Make the durable routing and visual-consumer records say what current `main` actually runs after Task9.
+
+**Design:** Read runtime facts first, make the authority test reject stale Task8/POC values, repair only primary records, regenerate derived views, then make narrow Notion current-state callouts. Historical documents remain as provenance rather than being rewritten as current truth.
+
+**Spec:** `docs/superpowers/specs/2026-08-27-current-authority-visual-consumer-reconciliation-design.md`
+
+## Task 1: Red authority contract
+
+**Files:**
+- Modify `tests/test_current_authority_reality_contract.py`
+
+- [ ] Change the expected next gate and runtime-state expectations to Task9.
+- [ ] Add assertions for six glyph runtime assets and the explicit unbound IMG-02 source-candidate status.
+- [ ] Run this focused test and record the expected failure against the stale primary records.
+
+## Task 2: Primary structured records
+
+**Files:**
+- Modify `skills/PROJECT_BASE_ADAPTER.json`
+- Modify `skills/SKILL_REGISTRY.json`
+- Modify `docs/DEVELOPMENT_GATES.md`
+- Modify `docs/planning/visual/GRIMOIRE_VISUAL_ASSET_COVERAGE_2026-08-26.json`
+- Modify `docs/planning/visual/GRIMOIRE_VISUAL_PRODUCTION_CHECKLIST_2026-08-26.json`
+- Modify `docs/planning/visual/GRIMOIRE_IMAGE_GOAL_QUEUE_2026-08-26.json`
+
+- [ ] Preserve Task8 as recovery provenance but make Task9 the current gate.
+- [ ] Record Product Root as the active runtime entry.
+- [ ] Record six glyph files as current runtime consumers.
+- [ ] Record IMG-02 only as persisted source candidates with no runtime binding on current `main`.
+- [ ] Update registry SHA in the primary adapter after the registry is complete.
+
+## Task 3: Derived views and green contracts
+
+**Files:**
+- Generated: `skills/PROJECT_SKILL_SNAPSHOT.json`
+- Generated: `skills/BASE_V9_ADAPTER.json`
+- Generated: `skills/PROJECT_BASE_SKILL_ADAPTER.json`
+- Modify `tests/test_current_authority_reality_contract.py`
+
+- [ ] Regenerate views with `tools/generate_project_operating_views.py`.
+- [ ] Run the focused authority contract to green.
+- [ ] Run the generator check and JSON syntax checks.
+
+## Task 4: Human-facing sync
+
+- [ ] Add a bounded current-state callout to Notion Visual Coverage and Image Handoff.
+- [ ] Read both pages back to verify the callouts.
+- [ ] Create a GitHub Issue and submit this isolated correction for review/merge only after all local checks pass.
+
+## Verification
+
+- `python -m unittest tests.test_current_authority_reality_contract`
+- `python tools/generate_project_operating_views.py --check`
+- JSON parse validation for edited JSON files
+- `git diff --check`
+- Fresh headless Godot product-root check only as a regression readback; it is not human/device/performance evidence.

--- a/docs/superpowers/specs/2026-08-27-current-authority-visual-consumer-reconciliation-design.md
+++ b/docs/superpowers/specs/2026-08-27-current-authority-visual-consumer-reconciliation-design.md
@@ -1,0 +1,51 @@
+# Current Authority & Visual Consumer Reconciliation Design
+
+## Goal
+
+Align the project’s structured operating views and active visual-consumer records with the already merged Task9 Product Root. This is a correction slice: it does not add gameplay, generate images, or promote automated evidence to human validation.
+
+## Fresh-read checklist
+
+| Check | Confirmed current fact |
+|---|---|
+| Core fun | The player writes a glyph, builds one spell, chooses a target, explicitly casts, and receives one result. |
+| Core system | `FIVE_POINT_STAR`, one Main, zero to five Auxiliary glyphs, explicit target selection, and exactly-once cast remain unchanged. |
+| Runtime entry | `project.godot` opens `res://src/ui/spell_workflow/spell_workflow_product_root.tscn`. |
+| Product state | Task9 is merged on `main` (`db038a4`); the next gate is `TASK9_USER_VERTICAL_SLICE_VALIDATION_PENDING`. |
+| Automated ceiling | Automated product-root evidence exists. Human, device, performance, export, and full first-session validation remain `NOT_RUN`. |
+| Visual asset reality | Six approved glyph PNGs are in the runtime path and consumed by the Product Root workflow. IMG-02 source candidates are persisted but have no current runtime binding on `main`. |
+
+## SWOT
+
+| Area | Evidence-backed assessment |
+|---|---|
+| Strength | A real Product Root and the six-glyph resolver are merged and deterministic checks exist. |
+| Weakness | `PROJECT_BASE_ADAPTER`, `SKILL_REGISTRY`, development-gate text, and visual inventory still point at the superseded Task8/three-glyph/POC state. |
+| Opportunity | Correct structured routing now so the next GPT Work or Codex unit reads Task9 and the real image-consumer boundary immediately. |
+| Threat | Treating IMG-02 source candidates or automated checks as finished runtime/human evidence would create false authority and rework. |
+
+## Scope
+
+### In scope
+
+- Update the adapter and project registry to the Task9 current gate and Product Root runtime state.
+- Regenerate derived operating views from their source adapter.
+- Replace stale current assertions with a failing-then-passing authority contract test.
+- Correct active development and visual runtime-consumer records while retaining historical provenance.
+- Sync the bounded, human-facing Notion Visual Coverage and Image Handoff pages with a current-state callout.
+
+### Out of scope
+
+- Godot scene/script authoring or gameplay behavior changes.
+- New image/audio/VFX generation, IMG-02 export, or binding images to a scene.
+- Rewriting or merging the user’s divergent local IMG-02 commits.
+- Human, device, performance, export, or full vertical-slice claims.
+
+## Acceptance criteria
+
+1. The primary adapter and registry both name `TASK9_USER_VERTICAL_SLICE_VALIDATION_PENDING` and the Product Root entry scene.
+2. The generated views exactly derive from the adapter and pass the operating-view generator check.
+3. Tests fail before the structured-state repair and pass after it.
+4. Visual records distinguish six currently consumed glyphs from three IMG-02 source candidates that are not bound on current `main`.
+5. Notion visual records present the same bounded current state, without deleting historical handoff evidence.
+6. Validation report clearly preserves every unrun human/device/performance/export gate.

--- a/skills/BASE_V9_ADAPTER.json
+++ b/skills/BASE_V9_ADAPTER.json
@@ -10,7 +10,7 @@
     "repository": "alsdmlals4-eng/Base"
   },
   "canonical_source": "skills/PROJECT_BASE_ADAPTER.json",
-  "canonical_source_sha256": "b22923dbc9b5634246933e6994d6eeb30c0889a8dacaa5987fefa3fa3c814fb0",
+  "canonical_source_sha256": "c3328c3a0d77cafc33e72b93553b806dde644668165d418ca019964c8385867e",
   "generated": true,
   "legacy_sheet": {
     "id": "19FftrZ4WzB-CXa9Q-y25iKMhmEs1Ip4Ea3ramf2xKqM",
@@ -21,7 +21,7 @@
   },
   "maturity": {
     "level": 3,
-    "next_gate": "TASK8_PR_PREP_REVERIFY_PENDING",
+    "next_gate": "TASK9_USER_VERTICAL_SLICE_VALIDATION_PENDING",
     "planning": "COMPLETE_FROSTBLOOM_FIRST_SESSION",
     "status": "PARTIAL_FOUNDATION"
   },
@@ -53,7 +53,7 @@
     "full_vertical_slice": "NOT_RUN",
     "human": "NOT_RUN",
     "performance": "NOT_RUN",
-    "runtime": "STAR_CIRCUIT_AUTOMATED_POC_PASS_FULL_SLICE_NOT_RUN"
+    "runtime": "TASK9_AUTOMATED_PRODUCT_ROOT_PASS_HUMAN_VALIDATION_PENDING"
   },
   "view_name": "BASE_V9_ADAPTER.json",
   "workspace_authority": {

--- a/skills/PROJECT_BASE_ADAPTER.json
+++ b/skills/PROJECT_BASE_ADAPTER.json
@@ -83,10 +83,11 @@
     "human_validation": "NOT_RUN",
     "implementation": "PARTIAL_FOUNDATION",
     "mobile_device_validation": "NOT_RUN",
-    "next_product_gate": "TASK8_PR_PREP_REVERIFY_PENDING",
+    "next_product_gate": "TASK9_USER_VERTICAL_SLICE_VALIDATION_PENDING",
     "performance_validation": "NOT_RUN",
     "planning": "COMPLETE_FROSTBLOOM_FIRST_SESSION",
-    "runtime_validation": "STAR_CIRCUIT_AUTOMATED_POC_PASS_FULL_SLICE_NOT_RUN"
+    "runtime_validation": "TASK9_AUTOMATED_PRODUCT_ROOT_PASS_HUMAN_VALIDATION_PENDING",
+    "task9_status": "MERGED_MAIN_AUTOMATED_VERTICAL_SLICE_READY"
   },
   "entrypoints": {
     "active_context": "docs/ACTIVE_CONTEXT.md",
@@ -175,7 +176,7 @@
   "project_registry": {
     "hash_definition": "RAW_FILE_BYTES_SHA256",
     "path": "skills/SKILL_REGISTRY.json",
-    "sha256": "e705e7bb71e8836f057c662ddfdb87dd89fe92cf95fc143337781304aa90f3c1"
+    "sha256": "eec9dbf667358ed4d2e541f6ee5e75d0a44e8b1ce89ade790a15c0c29b67f7bb"
   },
   "protected_baseline": {
     "authority_ref": "refs/remotes/origin/main",
@@ -320,7 +321,7 @@
     "full_vertical_slice": "NOT_RUN",
     "generated_views": "CURRENT",
     "generator_check": "REQUIRED",
-    "godot_runtime": "STAR_CIRCUIT_AUTOMATED_POC_PASS_FULL_SLICE_NOT_RUN",
+    "godot_runtime": "TASK9_AUTOMATED_PRODUCT_ROOT_PASS_HUMAN_VALIDATION_PENDING",
     "godot_static": "AVAILABLE_PROJECT_CREATED",
     "human": "NOT_RUN",
     "json_parse": "REQUIRED",

--- a/skills/PROJECT_BASE_SKILL_ADAPTER.json
+++ b/skills/PROJECT_BASE_SKILL_ADAPTER.json
@@ -17,7 +17,7 @@
     "version": "9.4.3"
   },
   "canonical_source": "skills/PROJECT_BASE_ADAPTER.json",
-  "canonical_source_sha256": "b22923dbc9b5634246933e6994d6eeb30c0889a8dacaa5987fefa3fa3c814fb0",
+  "canonical_source_sha256": "c3328c3a0d77cafc33e72b93553b806dde644668165d418ca019964c8385867e",
   "current_truth_sources": [
     "docs/ACTIVE_CONTEXT.md",
     "AGENTS.md",
@@ -209,7 +209,7 @@
     "full_vertical_slice": "NOT_RUN",
     "generated_views": "CURRENT",
     "generator_check": "REQUIRED",
-    "godot_runtime": "STAR_CIRCUIT_AUTOMATED_POC_PASS_FULL_SLICE_NOT_RUN",
+    "godot_runtime": "TASK9_AUTOMATED_PRODUCT_ROOT_PASS_HUMAN_VALIDATION_PENDING",
     "godot_static": "AVAILABLE_PROJECT_CREATED",
     "human": "NOT_RUN",
     "json_parse": "REQUIRED",

--- a/skills/PROJECT_SKILL_SNAPSHOT.json
+++ b/skills/PROJECT_SKILL_SNAPSHOT.json
@@ -97,7 +97,7 @@
     }
   ],
   "canonical_source": "skills/PROJECT_BASE_ADAPTER.json",
-  "canonical_source_sha256": "b22923dbc9b5634246933e6994d6eeb30c0889a8dacaa5987fefa3fa3c814fb0",
+  "canonical_source_sha256": "c3328c3a0d77cafc33e72b93553b806dde644668165d418ca019964c8385867e",
   "effective_routes": {
     "analyzing-and-refining-game-concepts": {
       "route_id": "analyzing-and-refining-game-concepts",
@@ -238,7 +238,7 @@
   "project_registry": {
     "hash_definition": "RAW_FILE_BYTES_SHA256",
     "path": "skills/SKILL_REGISTRY.json",
-    "sha256": "e705e7bb71e8836f057c662ddfdb87dd89fe92cf95fc143337781304aa90f3c1"
+    "sha256": "eec9dbf667358ed4d2e541f6ee5e75d0a44e8b1ce89ade790a15c0c29b67f7bb"
   },
   "project_routes": [
     {

--- a/skills/SKILL_REGISTRY.json
+++ b/skills/SKILL_REGISTRY.json
@@ -113,11 +113,11 @@
     "codex": "OPTIONAL_EXECUTOR",
     "device_validation": "NOT_RUN",
     "full_vertical_slice": "NOT_RUN",
-    "godot": "CREATED_STAR_RUNTIME_POC",
+    "godot": "TASK9_AUTOMATED_PRODUCT_ROOT_PASS_HUMAN_VALIDATION_PENDING",
     "human_validation": "NOT_RUN",
     "performance_validation": "NOT_RUN",
     "planning": "COMPLETE_FROSTBLOOM_FIRST_SESSION",
-    "spell_workflow": "TASK8_PR_PREP_REVERIFY_PENDING"
+    "spell_workflow": "TASK9_USER_VERTICAL_SLICE_VALIDATION_PENDING"
   },
   "execution_contracts": {
     "active_context": "docs/ACTIVE_CONTEXT.md",
@@ -157,8 +157,8 @@
     "main_scene": "res://src/ui/spell_workflow/spell_workflow_product_root.tscn",
     "main_scene_role": "DEVELOPMENT_PRODUCT_ROOT_ENTRY",
     "name": "GRIMOIRE: 세계를 다시 쓰는 법",
-    "next_product_gate": "TASK8_PR_PREP_REVERIFY_PENDING",
-    "parallel_design_gate": "COMPONENT_SHEET_PR151_DO_NOT_TOUCH",
+    "next_product_gate": "TASK9_USER_VERTICAL_SLICE_VALIDATION_PENDING",
+    "parallel_design_gate": "COMPONENT_SHEET_PR151_MERGED_MAIN_VERIFIED",
     "planning_status": "COMPLETE_FROSTBLOOM_FIRST_SESSION",
     "primary_platform": "Mobile",
     "product_stage": "DEMO_FIRST_VERTICAL_SLICE",

--- a/tests/test_base_v9_adoption.py
+++ b/tests/test_base_v9_adoption.py
@@ -29,7 +29,8 @@ class BaseV943AdoptionTests(unittest.TestCase):
         self.assertEqual("MIGRATION_ONLY_UNTIL_REMOVAL", adapter["gdd_sheet"]["role"])
         self.assertEqual("NO_NEW_CANON_WRITES", adapter["gdd_sheet"]["write_policy"])
         self.assertEqual("Mobile", adapter["project"]["primary_platform"])
-        self.assertEqual("TASK8_PR_PREP_REVERIFY_PENDING", adapter["current_state"]["next_product_gate"])
+        self.assertEqual("TASK9_USER_VERTICAL_SLICE_VALIDATION_PENDING", adapter["current_state"]["next_product_gate"])
+        self.assertEqual("MERGED_MAIN_AUTOMATED_VERTICAL_SLICE_READY", adapter["current_state"]["task9_status"])
         self.assertEqual("PARTIAL_FOUNDATION", adapter["current_state"]["implementation"])
         self.assertEqual("NOT_RUN", adapter["current_state"]["human_validation"])
 
@@ -48,7 +49,7 @@ class BaseV943AdoptionTests(unittest.TestCase):
         self.assertEqual(adapter["project"]["primary_platform"], skill_view["platforms"]["primary"])
         self.assertEqual("PRIMARY_VALIDATION_REQUIRED", skill_view["platforms"]["touch_input"])
         self.assertEqual("BOUNDED_APPROVED_WORKSTREAM_ONLY", skill_view["asset_and_license"]["mass_asset_generation"])
-        self.assertEqual("STAR_CIRCUIT_AUTOMATED_POC_PASS_FULL_SLICE_NOT_RUN", base_view["validation"]["runtime"])
+        self.assertEqual("TASK9_AUTOMATED_PRODUCT_ROOT_PASS_HUMAN_VALIDATION_PENDING", base_view["validation"]["runtime"])
         self.assertEqual("NOT_RUN", base_view["validation"]["human"])
         self.assertEqual("NOT_RUN", base_view["validation"]["device"])
         self.assertEqual("NOT_RUN", base_view["validation"]["performance"])

--- a/tests/test_current_authority_reality_contract.py
+++ b/tests/test_current_authority_reality_contract.py
@@ -37,10 +37,12 @@ class CurrentAuthorityRealityContractTests(unittest.TestCase):
         self.assertEqual("res://src/ui/spell_workflow/spell_workflow_product_root.tscn", project["main_scene"])
         self.assertEqual("DEVELOPMENT_PRODUCT_ROOT_ENTRY", project["main_scene_role"])
         self.assertEqual("PARTIAL_FOUNDATION", current["implementation"])
-        self.assertEqual("TASK8_PR_PREP_REVERIFY_PENDING", current["next_product_gate"])
+        self.assertEqual("TASK9_USER_VERTICAL_SLICE_VALIDATION_PENDING", current["next_product_gate"])
+        self.assertEqual("MERGED_MAIN_AUTOMATED_VERTICAL_SLICE_READY", current["task9_status"])
+        self.assertEqual("TASK9_AUTOMATED_PRODUCT_ROOT_PASS_HUMAN_VALIDATION_PENDING", current["runtime_validation"])
         self.assertEqual("NOT_RUN", current["human_validation"])
         self.assertEqual("NOT_RUN", current["mobile_device_validation"])
-        self.assertIn("FULL_SLICE_NOT_RUN", current["runtime_validation"])
+        self.assertEqual("NOT_RUN", current["full_vertical_slice"])
 
     def test_domain_split_authority_and_sheet_retirement_are_explicit(self) -> None:
         authority = self.adapter["workspace_authority"]
@@ -64,11 +66,32 @@ class CurrentAuthorityRealityContractTests(unittest.TestCase):
         self.assertEqual("Mobile", project["primary_platform"])
         self.assertEqual("PC", project["follow_up_platform"])
         self.assertEqual("PARTIAL_FOUNDATION", project["implementation_status"])
-        self.assertEqual("TASK8_PR_PREP_REVERIFY_PENDING", project["next_product_gate"])
+        self.assertEqual("TASK9_USER_VERTICAL_SLICE_VALIDATION_PENDING", project["next_product_gate"])
         self.assertEqual("DEMO_FIRST_VERTICAL_SLICE_PARTIAL_FOUNDATION", project["execution_profile"])
-        self.assertEqual("CREATED_STAR_RUNTIME_POC", coverage["godot"])
+        self.assertEqual("TASK9_AUTOMATED_PRODUCT_ROOT_PASS_HUMAN_VALIDATION_PENDING", coverage["godot"])
+        self.assertEqual("TASK9_USER_VERTICAL_SLICE_VALIDATION_PENDING", coverage["spell_workflow"])
         self.assertEqual("COMPLETE_FROSTBLOOM_FIRST_SESSION", coverage["planning"])
         self.assertEqual("APPROVED_SPEC", coverage["asset_spec_01"])
+
+    def test_visual_runtime_inventory_distinguishes_merged_glyphs_from_unbound_img02_sources(self) -> None:
+        coverage = load_json("docs/planning/visual/GRIMOIRE_VISUAL_ASSET_COVERAGE_2026-08-26.json")
+        checklist = load_json("docs/planning/visual/GRIMOIRE_VISUAL_PRODUCTION_CHECKLIST_2026-08-26.json")
+        queue = load_json("docs/planning/visual/GRIMOIRE_IMAGE_GOAL_QUEUE_2026-08-26.json")
+
+        current = coverage["current_runtime_readback"]
+        self.assertEqual("TASK9_USER_VERTICAL_SLICE_VALIDATION_PENDING", current["next_product_gate"])
+        self.assertEqual("res://src/ui/spell_workflow/spell_workflow_product_root.tscn", current["main_scene"])
+        self.assertEqual(6, current["glyph_runtime_asset_count"])
+        self.assertEqual("CURRENT_RUNTIME", current["glyph_consumer_state"])
+        self.assertEqual("SOURCE_CANDIDATES_ONLY_NO_CURRENT_MAIN_BINDING", current["img02_state"])
+
+        glyph_family = next(item for item in checklist["runtime_asset_families"] if item["asset_group_id"] == "GR-RA-01-GLYPH-BASE")
+        self.assertEqual("CURRENT_RUNTIME", glyph_family["consumer_state"])
+        self.assertEqual(6, glyph_family["asset_spec"]["count_cap"])
+        self.assertEqual(["heat", "protect", "flow", "focus", "disperse", "burst"], glyph_family["asset_spec"]["base_names"])
+
+        img02 = next(item for item in queue["goal_queue"] if item["goal_id"] == "IMG-02")
+        self.assertEqual("SOURCE_CANDIDATES_ONLY_NO_CURRENT_MAIN_BINDING", img02["status"])
 
     def test_generated_views_derive_current_reality_from_adapter(self) -> None:
         project = self.adapter["project"]


### PR DESCRIPTION
Closes #194

## What changed
- Reconciles the project adapter, registry, and generated views with the merged Task9 Product Root and its current human validation gate.
- Updates development and visual-runtime records: six glyph assets are current runtime consumers; IMG-02 remains unbound source candidates.
- Adds a red→green current-authority contract and a scoped reconciliation design/plan.
- Adds bounded current-state readbacks to the Notion Visual Coverage and Image Handoff pages.

## Verification
- `python -m unittest tests.test_base_v91_operating_contract tests.test_current_authority_reality_contract` → 13 passing
- `python tools/generate_project_operating_views.py --check` → pass
- JSON parse validation → 5 files pass
- Godot 4.7.1 headless `tests/test_runner.gd` → 47 suites, 1,968 assertions, 0 failures
- `git diff --cached --check` → pass

## Evidence boundary
No gameplay/Godot source changes, no new image generation/export, and no human/device/performance/export/full-slice claims.