### PR TITLE
fix(ci): retry invalid Godot engine archives

### DIFF
--- a/docs/superpowers/plans/2026-08-27-godot-toolchain-archive-retry.md
+++ b/docs/superpowers/plans/2026-08-27-godot-toolchain-archive-retry.md
@@ -1,0 +1,29 @@
+# Godot Toolchain Archive Retry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Retry a transient invalid Godot engine archive before failing CI.
+
+**Architecture:** `install_engine` owns the download-plus-extraction boundary, so it retries that boundary rather than treating downloaded bytes as valid. `download_file` retains its generic transport and integrity responsibilities.
+
+**Tech Stack:** Python 3.12 standard library, unittest, zipfile.
+
+**Spec:** `docs/superpowers/specs/2026-08-27-godot-toolchain-archive-retry-design.md`
+
+## Global Constraints
+
+- Keep Godot `4.7.1-stable` and the official downloads endpoint unchanged.
+- Retry only transient engine archive extraction failure, at most three total attempts.
+- Preserve safe ZIP traversal checks and fail closed after the final attempt.
+
+### Task 1: Test archive-level retry
+
+**Files:**
+- Modify: `tests/test_godot_toolchain_setup.py`
+- Modify: `tools/setup_godot_toolchain.py`
+
+- [x] Add a failing test with a fake downloader that writes non-ZIP bytes first and a ZIP containing the expected executable second. Assert the installation succeeds in two calls.
+- [x] Run `python -m unittest tests.test_godot_toolchain_setup.GodotToolchainSetupTests.test_install_engine_retries_invalid_archive_then_installs` and confirm it fails with `BadZipFile` before implementation.
+- [x] Add a three-attempt `install_engine` loop which downloads, safely extracts, locates, and copies only a valid executable; discard failed temporary attempt artifacts and raise an actionable `RuntimeError` after the final attempt.
+- [x] Run `python -m unittest tests.test_godot_toolchain_setup` and confirm it passes.
+- [x] Commit the test, implementation, and these two documents with `fix(ci): retry invalid Godot engine archives`.

--- a/docs/superpowers/specs/2026-08-27-godot-toolchain-archive-retry-design.md
+++ b/docs/superpowers/specs/2026-08-27-godot-toolchain-archive-retry-design.md
@@ -1,0 +1,30 @@
+# Godot Toolchain Archive Retry Design
+
+Issue: #199
+
+## Goal
+
+Prevent a transient non-ZIP response from the official Godot engine endpoint from immediately failing otherwise unrelated CI jobs.
+
+## Confirmed problem
+
+On 2026-08-27, independent `component-contract`, `godot-toolchain`, and `star-runtime-poc` jobs downloaded a file that failed `zipfile.ZipFile` with `BadZipFile`. A separate probe of the same official endpoint returned a valid ZIP signature. The current engine installer downloads once and only discovers archive invalidity during extraction.
+
+## Scope
+
+- Keep the pinned Godot version and official endpoint unchanged.
+- Retry engine download-plus-extraction at most three times when the downloaded archive is invalid or extraction fails.
+- Remove only the per-attempt temporary extraction directory and archive before retrying.
+- Raise an actionable error after the final failed attempt.
+- Add focused Python coverage for invalid-first/valid-second and all-invalid archive sequences.
+
+## Exclusions
+
+- No Godot scene, runtime, asset, export-template, or CI-workflow changes.
+- No alternate third-party mirror or integrity-policy weakening.
+
+## Acceptance criteria
+
+1. A fake invalid first archive followed by a valid archive installs the expected executable in two attempts.
+2. Repeated invalid archives fail after the bounded retry count and do not leave an installed executable.
+3. Existing toolchain tests remain green.

--- a/tests/test_godot_toolchain_setup.py
+++ b/tests/test_godot_toolchain_setup.py
@@ -13,6 +13,7 @@ from tools.setup_godot_toolchain import (
     build_engine_url,
     build_templates_url,
     download_file,
+    install_engine,
     install_templates,
     resolve_platform,
     safe_extract_zip,
@@ -138,6 +139,45 @@ class GodotToolchainSetupTests(unittest.TestCase):
             )
             self.assertEqual(3, captured.get("max_attempts"))
             self.assertEqual("ok", (template_root / "dummy.txt").read_text(encoding="utf-8"))
+
+    def test_install_engine_retries_invalid_archive_then_installs(self) -> None:
+        spec = resolve_platform("Linux", "x86_64")
+        calls = 0
+
+        def fake_download(_url: str, destination: Path, **_kwargs: object) -> None:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                destination.write_bytes(b"not a zip archive")
+                return
+            with zipfile.ZipFile(destination, "w") as bundle:
+                bundle.writestr(spec.executable_name, "valid executable")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch("tools.setup_godot_toolchain.download_file", side_effect=fake_download):
+                binary = install_engine(Path(temp_dir) / "godot", spec)
+
+            self.assertEqual(2, calls)
+            self.assertTrue(binary.is_file())
+            self.assertEqual("valid executable", binary.read_text(encoding="utf-8"))
+
+    def test_install_engine_fails_after_bounded_invalid_archives(self) -> None:
+        spec = resolve_platform("Linux", "x86_64")
+        calls = 0
+
+        def fake_download(_url: str, destination: Path, **_kwargs: object) -> None:
+            nonlocal calls
+            calls += 1
+            destination.write_bytes(b"not a zip archive")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            install_root = Path(temp_dir) / "godot"
+            with patch("tools.setup_godot_toolchain.download_file", side_effect=fake_download):
+                with self.assertRaisesRegex(RuntimeError, "remained invalid after 3 attempts"):
+                    install_engine(install_root, spec)
+
+            self.assertEqual(3, calls)
+            self.assertFalse((install_root / "4.7.1-stable" / "linux" / spec.executable_name).exists())
 
     def test_unsupported_architecture_fails_clearly(self) -> None:
         with self.assertRaisesRegex(RuntimeError, "Unsupported Godot host"):

--- a/tools/setup_godot_toolchain.py
+++ b/tools/setup_godot_toolchain.py
@@ -23,6 +23,7 @@ OFFICIAL_DOWNLOAD_ENDPOINT: Final = "https://downloads.godotengine.org/"
 GODOT_TEMPLATES_SIZE: Final = 1_280_486_955
 GODOT_TEMPLATES_SHA256: Final = "86409db6200b6f8fd3230989c2d2002851f3dd18acf11d7bdbafddf5a0dd0f72"
 GODOT_TEMPLATES_DOWNLOAD_ATTEMPTS: Final = 3
+GODOT_ENGINE_DOWNLOAD_ATTEMPTS: Final = 3
 VERSION_PATTERN: Final = re.compile(r"^4\.7\.1\.stable(?:\.|$)")
 
 
@@ -179,12 +180,28 @@ def install_engine(install_root: Path, spec: PlatformSpec) -> Path:
 
     engine_root.mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory(prefix="grimoire-godot-download-") as temp_dir:
-        archive = Path(temp_dir) / spec.slug
-        extract_root = Path(temp_dir) / "engine"
-        download_file(build_engine_url(spec), archive)
-        safe_extract_zip(archive, extract_root)
-        extracted_binary = _find_executable(extract_root, spec.executable_name)
-        shutil.copy2(extracted_binary, binary)
+        temp_root = Path(temp_dir)
+        last_error: Exception | None = None
+        for attempt in range(1, GODOT_ENGINE_DOWNLOAD_ATTEMPTS + 1):
+            archive = temp_root / f"attempt-{attempt}-{spec.slug}"
+            extract_root = temp_root / f"attempt-{attempt}-engine"
+            try:
+                download_file(build_engine_url(spec), archive)
+                safe_extract_zip(archive, extract_root)
+                extracted_binary = _find_executable(extract_root, spec.executable_name)
+                shutil.copy2(extracted_binary, binary)
+                break
+            except (OSError, RuntimeError, zipfile.BadZipFile) as exc:
+                last_error = exc
+                archive.unlink(missing_ok=True)
+                shutil.rmtree(extract_root, ignore_errors=True)
+                if attempt == GODOT_ENGINE_DOWNLOAD_ATTEMPTS:
+                    raise RuntimeError(
+                        f"Godot engine archive remained invalid after {GODOT_ENGINE_DOWNLOAD_ATTEMPTS} attempts"
+                    ) from exc
+
+        if last_error is not None and not binary.is_file():
+            raise RuntimeError("Godot engine installation did not produce an executable") from last_error
 
     if os.name != "nt":
         binary.chmod(binary.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)


### PR DESCRIPTION
Closes #199\n\nRetries only the official engine download-plus-safe-extraction boundary when an invalid archive is received. Includes focused red/green unit coverage for recovery and bounded final failure.