### PR TITLE
fix: reconcile IMG-02 state and test cleanup

### DIFF
--- a/docs/planning/TASK9_SPELL_WORKFLOW_PRODUCT_ROOT_2026-08-27.md
+++ b/docs/planning/TASK9_SPELL_WORKFLOW_PRODUCT_ROOT_2026-08-27.md
@@ -94,3 +94,22 @@ human_usability: NOT_RUN
 player_experience: NOT_RUN
 device_performance_export: NOT_RUN_OR_NOT_CONFIGURED
 ```
+
+## Fresh automated recheck — 2026-08-27
+
+```yaml
+exact_main: 6f2719e52c6f9dfd95769e73fbd0ae6f8e493ea4
+scope: TASK9_MACHINE_EVIDENCE_RECHECK_ONLY
+custom_runner: 47_suites_1976_assertions_0_failures_NO_EXIT_LEAK_WARNING
+gut: 8_tests_29_asserts_0_failures
+python_contracts: 46_tests_0_failures
+hera_live_observation: NOT_RUN_NO_LIVE_EDITOR
+human_device_performance_export: NOT_RUN
+```
+
+### Incident → solution → lesson
+
+1. `IMG-02` 후보·WebP 내보내기 병합 뒤 Image Goal Queue만 새 상태를 기록했고, coverage/checklist와 current-authority 검증은 이전 상태 문자열을 유지했다. 세 human/runtime 정본과 계약 테스트를 같은 **runtime 미연결** 상태로 동기화했다. 이 변경은 후보가 runtime Scene에 바인딩됐다는 뜻이 아니다.
+2. Task9 integration tests가 scene-tree 밖의 `Control` 노드를 지연 해제로 남겨 custom runner 종료 시 leak warning을 만들었다. 테스트가 만든 노드는 즉시 `free()`하도록 바꾸고 runner clean exit를 확인했다.
+
+재사용 판정은 `PROJECT_ONLY`: 두 원인은 이 프로젝트의 IMG-02 상태 owner와 Godot test fixture에 한정된 단일 발생이다. Base 승격은 독립 재발·negative case·기존 owner promotion evidence가 없어 `REJECT_OVERGENERALIZATION`으로 닫는다.

--- a/docs/planning/visual/GRIMOIRE_VISUAL_ASSET_COVERAGE_2026-08-26.json
+++ b/docs/planning/visual/GRIMOIRE_VISUAL_ASSET_COVERAGE_2026-08-26.json
@@ -23,7 +23,7 @@
     "glyph_consumer_state": "CURRENT_RUNTIME",
     "glyph_assets": ["glyph_heat.png", "glyph_protect.png", "glyph_flow.png", "glyph_focus.png", "glyph_disperse.png", "glyph_burst.png"],
     "glyph_runtime_consumer": "src/ui/spell_workflow/spell_workflow_product_root.tscn via glyph_visual_resolver.gd",
-    "img02_state": "SOURCE_CANDIDATES_ONLY_NO_CURRENT_MAIN_BINDING",
+    "img02_state": "SOURCE_CANDIDATES_READY_NO_CURRENT_MAIN_BINDING; NATIVE_RESOLUTION_WEBP_EXPORT_CANDIDATES_READY_NOT_RUNTIME_BOUND",
     "img02_source_candidates": "PERSISTED_UNBOUND_ON_CURRENT_MAIN",
     "unrun_evidence": ["HUMAN_NOT_RUN", "DEVICE_NOT_RUN", "PERFORMANCE_NOT_RUN", "WINDOWS_EXPORT_NOT_RUN", "ANDROID_EXPORT_NOT_RUN", "FULL_VERTICAL_SLICE_NOT_RUN"]
   },

--- a/docs/planning/visual/GRIMOIRE_VISUAL_PRODUCTION_CHECKLIST_2026-08-26.json
+++ b/docs/planning/visual/GRIMOIRE_VISUAL_PRODUCTION_CHECKLIST_2026-08-26.json
@@ -15,7 +15,7 @@
     "next_product_gate": "TASK9_USER_VERTICAL_SLICE_VALIDATION_PENDING",
     "glyph_runtime_asset_count": 6,
     "glyph_consumer_state": "CURRENT_RUNTIME",
-    "img02_state": "SOURCE_CANDIDATES_ONLY_NO_CURRENT_MAIN_BINDING",
+    "img02_state": "SOURCE_CANDIDATES_READY_NO_CURRENT_MAIN_BINDING; NATIVE_RESOLUTION_WEBP_EXPORT_CANDIDATES_READY_NOT_RUNTIME_BOUND",
     "evidence_boundary": "HUMAN_DEVICE_PERFORMANCE_EXPORT_AND_FULL_VERTICAL_SLICE_NOT_RUN"
   },
   "baseline_base_main": "edb3b3376603c9f6b00d64af3126304f8c9946bf",
@@ -73,14 +73,14 @@
       "consumers": ["수업/시험/축제 Field·Dialogue", "Greenhouse 현장 관찰·복귀", "Greenhouse Battle"],
       "runtime_role": "실제 Scene/Dialogue/Battle의 배경 Texture",
       "runtime_folder": "assets/art/backgrounds/",
-      "runtime_format": "2560x1440 WebP Lossless",
+      "runtime_format": "planned delivery: 2560x1440 WebP Lossless; current unbound candidate export: 1672x941 WebP Lossless",
       "assets": [
         {"id": "BG-01", "name": "School Common Base", "consumer": "수업·시험·축제 공용"},
         {"id": "BG-02", "name": "Greenhouse Field Base", "consumer": "현장 관찰·대화·복귀"},
         {"id": "BG-03", "name": "Greenhouse Battle Arena", "consumer": "동일 사건 별도 전투장"}
       ],
       "count_cap": 3,
-      "production_readiness": "THREE_SOURCE_CANDIDATES_PERSISTED_UNBOUND_ON_CURRENT_MAIN"
+      "production_readiness": "THREE_NATIVE_RESOLUTION_WEBP_CANDIDATES_PERSISTED_UNBOUND_ON_CURRENT_MAIN; REGENERATE_RATHER_THAN_BLINDLY_UPSCALE_IF_2560x1440_BECOMES_MANDATORY"
     },
     {
       "asset_group_id": "GR-RA-04-BACKGROUND-STATE-OVERLAYS",

--- a/tests/integration/test_glyph_stroke_canvas.gd
+++ b/tests/integration/test_glyph_stroke_canvas.gd
@@ -24,6 +24,7 @@ func run(case) -> void:
     case.assert_equal(1, submitted.size(), "explicit submit returns the collected stroke payload")
     canvas.clear_strokes()
     case.assert_equal(0, canvas.stroke_count(), "clear removes retry strokes")
+    canvas.free()
 
 
 func _mouse_button(position: Vector2, pressed: bool) -> InputEventMouseButton:

--- a/tests/integration/test_spell_workflow_product_root.gd
+++ b/tests/integration/test_spell_workflow_product_root.gd
@@ -41,7 +41,7 @@ func run(case) -> void:
         var stock_source: Control = scene_root.get_node(NodePath("CircuitScreen/CircuitContent/Content/Layout/MainRow/StockSourcePanel"))
         case.assert_true(vault_source.custom_minimum_size.x >= 180.0, "vault source panel has a readable minimum width")
         case.assert_true(stock_source.custom_minimum_size.x >= 180.0, "stock source panel has a readable minimum width")
-        scene_root.queue_free()
+        scene_root.free()
 
     var root = Root.new()
     var started: Dictionary = root.start_slice()
@@ -80,3 +80,4 @@ func run(case) -> void:
     case.assert_equal(&"USED", used.get("status", &""), "one confirmed cast resolves atomically")
     case.assert_equal(&"RESULT", root.visible_step(), "used result opens receipt")
     case.assert_equal(&"USE_CONFIRMATION_REQUIRED", root.confirm_cast().get("status", &""), "replayed cast fails closed")
+    root.free()

--- a/tests/test_current_authority_reality_contract.py
+++ b/tests/test_current_authority_reality_contract.py
@@ -83,7 +83,15 @@ class CurrentAuthorityRealityContractTests(unittest.TestCase):
         self.assertEqual("res://src/ui/spell_workflow/spell_workflow_product_root.tscn", current["main_scene"])
         self.assertEqual(6, current["glyph_runtime_asset_count"])
         self.assertEqual("CURRENT_RUNTIME", current["glyph_consumer_state"])
-        self.assertEqual("SOURCE_CANDIDATES_ONLY_NO_CURRENT_MAIN_BINDING", current["img02_state"])
+        self.assertEqual(
+            "SOURCE_CANDIDATES_READY_NO_CURRENT_MAIN_BINDING; "
+            "NATIVE_RESOLUTION_WEBP_EXPORT_CANDIDATES_READY_NOT_RUNTIME_BOUND",
+            current["img02_state"],
+        )
+        self.assertEqual(
+            current["img02_state"],
+            checklist["current_runtime_readback"]["img02_state"],
+        )
 
         glyph_family = next(item for item in checklist["runtime_asset_families"] if item["asset_group_id"] == "GR-RA-01-GLYPH-BASE")
         self.assertEqual("CURRENT_RUNTIME", glyph_family["consumer_state"])
@@ -91,7 +99,11 @@ class CurrentAuthorityRealityContractTests(unittest.TestCase):
         self.assertEqual(["heat", "protect", "flow", "focus", "disperse", "burst"], glyph_family["asset_spec"]["base_names"])
 
         img02 = next(item for item in queue["goal_queue"] if item["goal_id"] == "IMG-02")
-        self.assertEqual("SOURCE_CANDIDATES_ONLY_NO_CURRENT_MAIN_BINDING", img02["status"])
+        self.assertEqual(
+            "SOURCE_CANDIDATES_READY_NO_CURRENT_MAIN_BINDING; "
+            "NATIVE_RESOLUTION_WEBP_EXPORT_CANDIDATES_READY_NOT_RUNTIME_BOUND",
+            img02["status"],
+        )
 
     def test_generated_views_derive_current_reality_from_adapter(self) -> None:
         project = self.adapter["project"]


### PR DESCRIPTION
## 목적
- IMG-02 후보/내보내기 상태를 Image Goal Queue, coverage, checklist, 계약 테스트에 동일하게 반영합니다.
- Task9 테스트가 생성한 씬 밖 Control 노드를 즉시 해제해 custom runner 종료 leak warning을 제거합니다.

## 경계
- IMG-02 배경 후보는 여전히 runtime Scene에 연결되지 않았습니다.
- Human, device, performance, export 검증은 수행하지 않았습니다.
- Godot import가 생성한 `.import`/artifact 파일은 포함하지 않았습니다.

## 검증
- Python 계약 테스트 46개 통과
- custom Godot runner: 47 suites / 1,976 assertions / 0 failures, 종료 leak warning 없음
- GUT: 8 tests / 29 asserts / 0 failures
- JSON parse, generated-view check, diff --check 통과

## 학습 판정
- 이번 두 문제는 프로젝트 단일 발생이므로 `PROJECT_ONLY`; Base 승격은 `REJECT_OVERGENERALIZATION`입니다.