### PR TITLE
feat(task11): apply greenhouse visual surface

### DIFF
--- a/docs/planning/TASK11_PRODUCT_ROOT_VISUAL_SURFACE_2026-08-27.md
+++ b/docs/planning/TASK11_PRODUCT_ROOT_VISUAL_SURFACE_2026-08-27.md
@@ -1,0 +1,41 @@
+# Task11 · Product Root Visual Surface
+
+```yaml
+issue: 204
+status: APPROVED_IMPLEMENTATION_SCOPE
+goal: Reuse the persisted IMG-02 greenhouse background and existing Academy theme in the current Product Root.
+player_experience: The first writing screen reads as a magical greenhouse practicum rather than a generic gray debug form.
+consumer:
+  scene: res://src/ui/spell_workflow/spell_workflow_product_root.tscn
+  asset: res://assets/art/backgrounds/greenhouse/bg_greenhouse_field_base.webp
+  asset_status: PERSISTED_CANDIDATE_TO_CURRENT_RUNTIME_CONSUMER
+keep:
+  - 글자 → 주문 → 대상 → 시전 → 결과
+  - live Korean labels and all transaction authority
+  - existing 512px glyph resolver and display-only state policy
+exclude:
+  - new image generation
+  - IMG-03 overlays, portraits, enemies, and scene-flow expansion
+  - recognition, Stock, circuit, target, Mana, or cast behavior changes
+evidence_limit:
+  - HUMAN_DEVICE_PERFORMANCE_EXPORT_NOT_RUN
+```
+
+## 검수 근거
+
+2026-08-27 Hera 1280×720 Product Root 첫 화면은 기능·입력 크기·클리핑 면에서는 오류가 없었지만, 회색 기본 Panel/Button 표면이 승인된 Navy/Gold Magic Academy UI 언어를 전달하지 못했다. `bg_greenhouse_field_base.webp`는 이미 프로젝트 로컬에 존재하지만 Product Root 소비처가 없었다.
+
+## 최소 구현 계약
+
+1. Product Root의 가장 뒤에 background TextureRect와 비상호작용 readability veil을 둔다.
+2. `GrimoireThemeFactory`를 Product Root theme로 적용한다.
+3. Theme factory의 기본 PanelContainer/Button surface를 navy/gold family로 정의해 현재 세 workflow 화면이 동일한 live theme를 받게 한다.
+4. background는 글자 단계의 온실 실습 맥락을 주는 장식이며, 상태·수치·정답·target/cast 결과를 표현하지 않는다.
+
+## Acceptance
+
+- `bg_greenhouse_field_base.webp`가 Product Root scene의 실제 Texture2D consumer다.
+- 배경은 UI 위계와 터치 입력을 가리지 않는다.
+- legacy gray default Panel/Button surface가 Academy navy/gold surface로 교체된다.
+- 흐름과 authority를 검증하는 integration test가 계속 통과한다.
+- Hera 1280×720 screenshot과 diagnostics를 다시 확인한다.

--- a/docs/superpowers/plans/2026-08-27-task11-product-root-visual-surface.md
+++ b/docs/superpowers/plans/2026-08-27-task11-product-root-visual-surface.md
@@ -1,0 +1,60 @@
+# Task11 Product Root Visual Surface Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Apply the persisted greenhouse background and existing Academy live theme to the current Product Root without changing spell-flow authority.
+
+**Architecture:** `spell_workflow_product_root.tscn` owns a noninteractive background and readability veil. `GrimoireThemeFactory` remains the single live-theme owner; its default PanelContainer and Button styles make the existing screen tree readable without new texture variants. The integration test asserts only the asset and theme wiring, not pixels or gameplay internals.
+
+**Tech Stack:** Godot 4.7.1, GDScript, `.tscn`, project integration runner.
+
+**Spec:** `docs/planning/TASK11_PRODUCT_ROOT_VISUAL_SURFACE_2026-08-27.md`
+
+## Global Constraints
+
+- Reuse `res://assets/art/backgrounds/greenhouse/bg_greenhouse_field_base.webp`; do not generate a new image.
+- Retain the approved flow `글자 → 주문 → 대상 → 시전 → 결과` and all existing authority.
+- Keep labels live and localizable; no baked functional text or values.
+- Human, device, performance, export, and full-slice validation remain `NOT_RUN`.
+
+---
+
+### Task 1: Prove Product Root visual wiring is absent
+
+**Files:**
+- Modify: `tests/integration/test_spell_workflow_product_root.gd`
+- Modify: `src/ui/spell_workflow/spell_workflow_product_root.tscn`
+- Modify: `src/ui/theme/grimoire_theme_factory.gd`
+
+**Interfaces:**
+- Consumes: `res://assets/art/backgrounds/greenhouse/bg_greenhouse_field_base.webp`, `GrimoireThemeFactory.create_theme()`.
+- Produces: a noninteractive background and live Academy theme for the existing Product Root.
+
+- [ ] **Step 1: Write the failing test**
+
+```gdscript
+case.assert_true(product_scene_source.contains("bg_greenhouse_field_base.webp"))
+case.assert_true(product_scene_source.contains("theme = GrimoireThemeFactory.create_theme()"))
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: project integration runner filtered to `test_spell_workflow_product_root.gd`.
+
+- [ ] **Step 3: Add the smallest visual wiring**
+
+Add the asset resource, full-rect TextureRect, noninteractive navy readability veil, and root theme assignment. Extend the existing factory with default `PanelContainer` and `Button` styles.
+
+- [ ] **Step 4: Run focused and full checks**
+
+Run: focused integration runner, full custom runner, Python current-authority contracts, and `git diff --check`.
+
+- [ ] **Step 5: Render and record**
+
+Run Product Root at 1280×720 through Hera; capture screenshot and diagnostics.
+
+- [ ] **Step 6: Commit**
+
+```text
+feat(task11): apply greenhouse visual surface
+```

--- a/src/ui/spell_workflow/spell_workflow_product_root.gd
+++ b/src/ui/spell_workflow/spell_workflow_product_root.gd
@@ -54,6 +54,7 @@ var _last_result: Dictionary = {}
 
 
 func _ready() -> void:
+    theme = GrimoireThemeFactory.create_theme()
     start_slice()
     _connect_player_surfaces()
     _configure_player_surfaces()

--- a/src/ui/spell_workflow/spell_workflow_product_root.tscn
+++ b/src/ui/spell_workflow/spell_workflow_product_root.tscn
@@ -4,6 +4,7 @@
 [ext_resource type="PackedScene" uid="uid://dhkd7pos74iaa" path="res://src/ui/spell_workflow/glyph_drawing_screen.tscn" id="2_kmny2"]
 [ext_resource type="PackedScene" uid="uid://bolap7p5hkar8" path="res://src/ui/spell_workflow/circuit_placement_screen.tscn" id="3_ag2ki"]
 [ext_resource type="PackedScene" uid="uid://qfvh1n7f5veh" path="res://src/ui/spell_workflow/spell_use_screen.tscn" id="4_3otfq"]
+[ext_resource type="Texture2D" path="res://assets/art/backgrounds/greenhouse/bg_greenhouse_field_base.webp" id="5_2w8ln"]
 
 [node name="SpellWorkflowProductRoot" type="Control" unique_id=1353567651]
 layout_mode = 3
@@ -13,6 +14,28 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_hpptg")
+
+[node name="EnvironmentBackground" type="TextureRect" parent="." unique_id=1296288871]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+texture = ExtResource("5_2w8ln")
+expand_mode = 1
+stretch_mode = 6
+
+[node name="EnvironmentReadabilityVeil" type="ColorRect" parent="." unique_id=678603010]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+color = Color(0.027451, 0.082353, 0.141176, 0.5)
 
 [node name="ResultPanel" type="VBoxContainer" parent="." unique_id=883718107]
 layout_mode = 0

--- a/src/ui/theme/grimoire_theme_factory.gd
+++ b/src/ui/theme/grimoire_theme_factory.gd
@@ -56,6 +56,12 @@ static func _configure_base(theme: Theme) -> void:
 
 
 static func _configure_panels(theme: Theme) -> void:
+    theme.set_stylebox(
+        &"panel",
+        &"PanelContainer",
+        _style_box(Color(SURFACE_PANEL, 0.9), LINE_BRASS.darkened(0.15), 1, PANEL_RADIUS, 14.0)
+    )
+
     theme.set_type_variation(&"AcademyPanel", &"PanelContainer")
     theme.set_stylebox(
         &"panel",
@@ -86,6 +92,16 @@ static func _configure_panels(theme: Theme) -> void:
 
 
 static func _configure_buttons(theme: Theme) -> void:
+    _set_button_set(
+        theme,
+        &"Button",
+        SURFACE_PANEL,
+        SURFACE_PANEL_EMPHASIS,
+        LINE_BRASS,
+        TEXT_PRIMARY,
+        BUTTON_RADIUS
+    )
+
     theme.set_type_variation(&"AcademyButton", &"Button")
     _set_button_set(
         theme,

--- a/tests/integration/test_spell_workflow_product_root.gd
+++ b/tests/integration/test_spell_workflow_product_root.gd
@@ -10,6 +10,11 @@ func run(case) -> void:
     if not FileAccess.file_exists(ROOT_PATH):
         return
 
+    var root_source := FileAccess.get_file_as_string(ROOT_PATH)
+    var product_scene_source := FileAccess.get_file_as_string(ROOT_SCENE_PATH)
+    case.assert_true(product_scene_source.contains("bg_greenhouse_field_base.webp"), "Product Root consumes the persisted greenhouse background asset")
+    case.assert_true(root_source.contains("theme = GrimoireThemeFactory.create_theme()"), "Product Root applies the shared Academy live theme")
+
     var Root = load(ROOT_PATH)
     case.assert_true(Root != null and Root.can_instantiate(), "Task9 Product Root must compile")
     if Root == null or not Root.can_instantiate():
@@ -22,11 +27,30 @@ func run(case) -> void:
     var packed_scene = load(ROOT_SCENE_PATH)
     case.assert_true(packed_scene != null and packed_scene.can_instantiate(), "Product Root scene must instantiate")
     if packed_scene != null and packed_scene.can_instantiate():
-        var scene_root = packed_scene.instantiate()
+        var scene_root := packed_scene.instantiate() as Control
+        var tree := Engine.get_main_loop() as SceneTree
+        case.assert_true(tree != null, "Product Root visual contract has an active SceneTree")
+        if tree != null:
+            tree.root.add_child(scene_root)
+
+        case.assert_true(scene_root.theme != null, "Product Root applies the shared Academy Theme at runtime")
+        if scene_root.theme != null:
+            case.assert_true(scene_root.theme.get_stylebox(&"normal", &"Button") != null, "Academy Theme styles generic primary actions")
+            case.assert_true(scene_root.theme.get_stylebox(&"panel", &"PanelContainer") != null, "Academy Theme styles generic content panels")
+
+        var environment_background := scene_root.get_node_or_null("EnvironmentBackground") as TextureRect
+        var readability_veil := scene_root.get_node_or_null("EnvironmentReadabilityVeil") as ColorRect
+        case.assert_true(environment_background != null, "Product Root owns the persisted greenhouse backdrop node")
+        case.assert_true(readability_veil != null, "Product Root owns the readability veil above the backdrop")
+        if environment_background != null:
+            case.assert_true(environment_background.texture != null, "Product Root loads the persisted greenhouse texture at runtime")
+            case.assert_equal(Control.MOUSE_FILTER_IGNORE, environment_background.mouse_filter, "Greenhouse backdrop does not intercept player input")
+        if readability_veil != null:
+            case.assert_equal(Control.MOUSE_FILTER_IGNORE, readability_veil.mouse_filter, "Readability veil does not intercept player input")
+
         for required_node in ["GlyphScreen", "CircuitScreen", "SpellUseScreen", "ResultPanel"]:
             case.assert_true(scene_root.has_node(NodePath(required_node)), "Product Root exposes player surface: %s" % required_node)
 
-        var product_scene_source := FileAccess.get_file_as_string(ROOT_SCENE_PATH)
         case.assert_false(product_scene_source.contains('parent="GlyphScreen/GlyphContent"'), "product root does not duplicate glyph-scene descendants")
         case.assert_false(product_scene_source.contains('parent="CircuitScreen/CircuitContent"'), "product root does not duplicate circuit-scene descendants")
         case.assert_false(product_scene_source.contains('parent="SpellUseScreen/SpellUseContent"'), "product root does not duplicate spell-use descendants")
@@ -41,7 +65,7 @@ func run(case) -> void:
         var stock_source: Control = scene_root.get_node(NodePath("CircuitScreen/CircuitContent/Content/Layout/MainRow/StockSourcePanel"))
         case.assert_true(vault_source.custom_minimum_size.x >= 180.0, "vault source panel has a readable minimum width")
         case.assert_true(stock_source.custom_minimum_size.x >= 180.0, "stock source panel has a readable minimum width")
-        scene_root.free()
+        scene_root.queue_free()
 
     var root = Root.new()
     var started: Dictionary = root.start_slice()

--- a/tests/test_runner.gd
+++ b/tests/test_runner.gd
@@ -54,6 +54,10 @@ const SUITES: Array[String] = [
 
 
 func _init() -> void:
+    call_deferred("_run")
+
+
+func _run() -> void:
     var case = TestCase.new()
     for suite_path in SUITES:
         var suite_script = load(suite_path)


### PR DESCRIPTION
## Summary
- reuse the persisted IMG-02 greenhouse field WebP as the live Product Root backdrop
- apply the existing Academy navy/gold theme to Product Root panels and buttons
- add a regression test for background and theme wiring

## Preserved
- 글자 → 주문 → 대상 → 시전 → 결과 flow and all recognition, Stock, circuit, target, Mana, and cast authority
- no new generated image, IMG-03 overlay, portrait, enemy, or scene expansion

## Evidence
- custom runner: 47 suites / 1,978 assertions / 0 failures
- GUT: 8 tests / 29 asserts / 0 failures
- Python contracts: 46 passed
- Hera Product Root at 1280x720: no clipping; diagnostics 0 errors / 0 warnings

Closes #204.