### PR TITLE
fix(task12): clarify direct glyph input

### DIFF
--- a/src/ui/spell_workflow/glyph_drawing_screen.tscn
+++ b/src/ui/spell_workflow/glyph_drawing_screen.tscn
@@ -48,7 +48,7 @@ layout_mode = 2
 
 [node name="CanvasHint" type="Label" parent="WritingCanvas/WritingContent" unique_id=992261367]
 layout_mode = 2
-text = "여기에 문양을 그립니다."
+text = "마우스 드래그 또는 터치로 문양을 그립니다."
 horizontal_alignment = 1
 vertical_alignment = 1
 

--- a/tests/integration/test_glyph_drawing_workflow_screen.gd
+++ b/tests/integration/test_glyph_drawing_workflow_screen.gd
@@ -70,6 +70,8 @@ func run(case) -> void:
             case.assert_true(action.custom_minimum_size.y >= 48.0, "%s height is touch safe" % action_name)
     case.assert_true(screen.has_node(NodePath("IncidentStatusCard/Content/Urgency")), "status card exposes urgency")
     case.assert_true(screen.has_node(NodePath("IncidentStatusCard/Content/TouchHint")), "status card explains its touch affordance")
+    var canvas_hint = screen.get_node_or_null(NodePath("WritingCanvas/WritingContent/CanvasHint")) as Label
+    case.assert_true(canvas_hint != null and canvas_hint.text.contains("드래그") and canvas_hint.text.contains("터치"), "writing canvas tells players to use mouse drag or touch")
     case.assert_true(FileAccess.file_exists("res://src/ui/spell_workflow/components/incident_explanation_overlay.tscn"), "incident overlay scene exists")
     _assert_recognition_glyph_visual(case, screen)
     _assert_explicit_save_replays_once(case, screen)

--- a/tests/integration/test_glyph_stroke_canvas.gd
+++ b/tests/integration/test_glyph_stroke_canvas.gd
@@ -24,6 +24,11 @@ func run(case) -> void:
     case.assert_equal(1, submitted.size(), "explicit submit returns the collected stroke payload")
     canvas.clear_strokes()
     case.assert_equal(0, canvas.stroke_count(), "clear removes retry strokes")
+
+    canvas._gui_input(_screen_touch(Vector2(8, 8), true))
+    canvas._gui_input(_screen_drag(Vector2(40, 40)))
+    canvas._gui_input(_screen_touch(Vector2(64, 64), false))
+    case.assert_equal(1, canvas.stroke_count(), "touch drag stores one valid separate stroke")
     canvas.free()
 
 
@@ -37,5 +42,20 @@ func _mouse_button(position: Vector2, pressed: bool) -> InputEventMouseButton:
 
 func _mouse_motion(position: Vector2) -> InputEventMouseMotion:
     var event := InputEventMouseMotion.new()
+    event.position = position
+    return event
+
+
+func _screen_touch(position: Vector2, pressed: bool) -> InputEventScreenTouch:
+    var event := InputEventScreenTouch.new()
+    event.index = 0
+    event.position = position
+    event.pressed = pressed
+    return event
+
+
+func _screen_drag(position: Vector2) -> InputEventScreenDrag:
+    var event := InputEventScreenDrag.new()
+    event.index = 0
     event.position = position
     return event


### PR DESCRIPTION
Closes #207\n\n## Goal\nMake the existing direct writing affordance explicit for mouse drag and touch, without changing recognition, resource, or cast rules.\n\n## Validation\n- Godot custom runner: 47 suites / 1989 assertions / 0 failures\n- Authority contracts: 46 tests passed\n- Runtime screenshot and UI tree checked at 1280x720\n\n## Scope\n- Writing canvas instruction\n- Mouse/touch regression coverage