### PR TITLE
docs: sync greenhouse spirit asset seed

### DIFF
--- a/docs/planning/visual/GRIMOIRE_IMAGE_GOAL_QUEUE_2026-08-26.json
+++ b/docs/planning/visual/GRIMOIRE_IMAGE_GOAL_QUEUE_2026-08-26.json
@@ -158,7 +158,13 @@
       "required_packets": ["idle_unstable", "pressure_telegraph_attack", "surge_environment_telegraph_attack", "instability_reaction_calm_resolve"],
       "frame_cap": 50,
       "planned_export": "512x512 PNG RGBA frames",
-      "status": "BLOCKED_BY_BATTLE_CONSUMER_SCENE"
+      "existing_asset_seed": {
+        "asset_id": "enemy_greenhouse_spirit_idle_unstable",
+        "path": "assets/art/enemies/greenhouse_spirit/enemy_greenhouse_spirit_idle_unstable.png",
+        "manifest": "assets/manifests/enemy_greenhouse_spirit_idle_unstable.json",
+        "status": "PROJECT_ASSET_APPROVED_IMPLEMENTATION_PENDING"
+      },
+      "status": "PARTIAL_ASSET_SEED_READY_BATTLE_CONSUMER_SCENE_PENDING"
     },
     {
       "order": 7,

--- a/docs/planning/visual/GRIMOIRE_VISUAL_PRODUCTION_CHECKLIST_2026-08-26.json
+++ b/docs/planning/visual/GRIMOIRE_VISUAL_PRODUCTION_CHECKLIST_2026-08-26.json
@@ -143,7 +143,14 @@
       "runtime_format": "512x512 PNG RGBA frames",
       "count_cap": 50,
       "clips": ["idle_unstable", "telegraph_pressure", "attack_pressure", "telegraph_surge", "attack_surge", "telegraph_environment", "attack_environment", "instability_reaction", "calm_resolve"],
-      "production_policy": "불안정도 변화는 전체 Body Variant 증식보다 Overlay/Material/VFX 우선"
+      "existing_asset_seed": {
+        "asset_id": "enemy_greenhouse_spirit_idle_unstable",
+        "path": "assets/art/enemies/greenhouse_spirit/enemy_greenhouse_spirit_idle_unstable.png",
+        "manifest": "assets/manifests/enemy_greenhouse_spirit_idle_unstable.json",
+        "status": "PROJECT_ASSET_APPROVED_IMPLEMENTATION_PENDING"
+      },
+      "production_policy": "불안정도 변화는 전체 Body Variant 증식보다 Overlay/Material/VFX 우선",
+      "production_readiness": "IDLE_UNSTABLE_ASSET_SEED_READY; battle Scene, remaining clips, Godot import, and runtime evidence remain pending"
     },
     {
       "asset_group_id": "GR-RA-10-REUSABLE-VFX",


### PR DESCRIPTION
Closes #216

Updates the current image goal queue and runtime production checklist to reference the merged idle/unstable asset seed from #215. Keeps battle-scene binding, remaining state clips, Godot import, runtime evidence, and release-rights review pending.