### PR TITLE
docs: reconcile canon, experience, and visual audit

### DIFF
--- a/START_HERE.md
+++ b/START_HERE.md
@@ -56,6 +56,13 @@ task8_remote_product_pr: 190
 task9_product_commit: db038a4fd964ca037bfe97f6aee5d0cc7d0daf93
 task9_product_pr: 192
 task9_status: MERGED_MAIN_AUTOMATED_VERTICAL_SLICE_READY
+post_task9_main_readback: 6377cbcf31958fc2b3215d7a9603dfa5f0199c04
+post_task9_corrections:
+  task10_ui_hierarchy: PR_197_MERGED_MAIN
+  task11_visual_surface: PR_205_MERGED_MAIN
+  task12_direct_glyph_input: PR_208_MERGED_MAIN
+  task13_result_receipt: PR_210_MERGED_MAIN
+greenhouse_spirit_idle_seed: PR_217_PROJECT_ASSET_APPROVED_IMPLEMENTATION_PENDING
 open_pr_state_authority: LIVE_GITHUB_READBACK_REQUIRED
 component_sheet_pr151: MERGED_MAIN_VERIFIED
 gut_status: GUT_FORMALLY_ADOPTED
@@ -81,7 +88,7 @@ android_device: NOT_RUN
 
 `v4.8 r5.4 / GM-CONTRACT-V4-8-BINDING-01`이 현재 프로젝트 실행 계약이다. v4.5 이하 binding은 역사 provenance로 보존하며 current authority로 사용하지 않는다. Base의 과거 SHA도 영구 authority가 아니고 새 실질 work unit마다 latest completed Base `main`과 필요한 owner를 다시 읽는다.
 
-2026-08-26 사용자는 `GM-SPELL-WORKFLOW-UI-V2-01`의 **플레이어 노출 흐름 간략화**와 후속 Task8·Task9 Godot 제품 구현을 승인했다. Task9 Product Root는 PR #192로 `db038a4` main에 병합됐으며, 현재 자동화 완료 상태는 `MERGED_MAIN_AUTOMATED_VERTICAL_SLICE_READY`다. 다음 게이트는 사람·플레이어·기기·성능·출시 검증을 과장하지 않는 `TASK9_USER_VERTICAL_SLICE_VALIDATION_PENDING`이다.
+2026-08-26 사용자는 `GM-SPELL-WORKFLOW-UI-V2-01`의 **플레이어 노출 흐름 간략화**와 후속 Task8·Task9 Godot 제품 구현을 승인했다. Task9 Product Root는 PR #192로 `db038a4` main에 병합됐고, 후속 PR #197/#205/#208/#210은 UI hierarchy, Academy visual surface, 직접 글자 입력 안내, 결과 영수증 표시만 교정했다. 2026-08-28 live `main`은 `6377cbcf31958fc2b3215d7a9603dfa5f0199c04`이며 다음 게이트는 사람·플레이어·기기·성능·출시 검증을 과장하지 않는 `TASK9_USER_VERTICAL_SLICE_VALIDATION_PENDING`이다.
 
 ## Workspace authority
 

--- a/docs/ACTIVE_CONTEXT.md
+++ b/docs/ACTIVE_CONTEXT.md
@@ -65,6 +65,15 @@ task10_ui_hierarchy_issue: 196
 task10_ui_hierarchy_pr: 197
 task10_ui_hierarchy_merge_commit: 9eca31c52f06ce59afeacea9959075987ffb16ab
 task10_ui_hierarchy_status: MERGED_MAIN_RUNTIME_UI_HIERARCHY_REPAIRED
+current_main_readback: 6377cbcf31958fc2b3215d7a9603dfa5f0199c04
+task11_visual_surface_pr: 205
+task11_visual_surface_status: MERGED_MAIN_BACKGROUND_AND_ACADEMY_THEME_BOUND
+task12_direct_glyph_input_pr: 208
+task12_direct_glyph_input_status: MERGED_MAIN_CLARIFICATION
+task13_result_receipt_pr: 210
+task13_result_receipt_status: MERGED_MAIN_RECEIPT_PAYLOAD_RENDERED
+greenhouse_spirit_idle_seed_pr: 217
+greenhouse_spirit_idle_seed_status: PROJECT_ASSET_APPROVED_IMPLEMENTATION_PENDING
 open_pr_state_authority: LIVE_GITHUB_READBACK_REQUIRED
 component_sheet_pr151: MERGED_MAIN_VERIFIED
 preserved_runtime_decision: GM-STAR-CIRCUIT-MASTERY-BALANCE-01
@@ -121,6 +130,10 @@ android_device: NOT_RUN
 
 - Task9/Godot 제품 구현: **MERGED_MAIN_AUTOMATED_VERTICAL_SLICE_READY**
 - Task10/UI hierarchy repair: **MERGED_MAIN_RUNTIME_UI_HIERARCHY_REPAIRED** — product root duplicate descendants were removed; glyph actions and circuit source-panel sizing were repaired. The English-safe shared spell-use copy baseline remains in force until the Korean font gate.
+- Task11/Product Root visual surface: **MERGED_MAIN** — `bg_greenhouse_field_base.webp`와 Academy theme가 Product Root에 실제 연결됐다. 이는 첫 세션 Field/Dialogue/Battle Scene binding이나 Human visual validation이 아니다.
+- Task12/direct glyph input: **MERGED_MAIN** — 직접 쓴 글자 입력의 player-facing 설명만 보완했다.
+- Task13/result receipt: **MERGED_MAIN** — 실제 result payload의 대상·사용 마력·결과 문장을 Result Panel에 표시한다. 새 경제·전투·보상 authority는 추가하지 않았다.
+- PR #217 greenhouse spirit idle seed: **PROJECT_ASSET_APPROVED_IMPLEMENTATION_PENDING** — 투명 PNG와 provenance는 존재하지만 battle Scene binding·Godot import·runtime evidence는 아직 없다.
 - 다음 게이트: **TASK9_USER_VERTICAL_SLICE_VALIDATION_PENDING**
 - 이미지 생성: **NOT_REQUESTED_AFTER_PLAYER_FLOW_APPROVAL**
 - Google Sheet 신규 canon write: **FORBIDDEN / MIGRATION_ONLY**

--- a/docs/DOCUMENTATION_MAP.md
+++ b/docs/DOCUMENTATION_MAP.md
@@ -13,7 +13,9 @@ runtime_validation: AUTOMATED_HEADLESS_PASS
 
 ## 시작 경로
 
-`AGENTS → START_HERE → ACTIVE_CONTEXT → DEVELOPMENT_GATES → CURRENT_CONFIRMED_DECISIONS → Runtime Main Sync03 → GR-TEST-033 Main Sync05 → Runtime·Tests`.
+`AGENTS → START_HERE → ACTIVE_CONTEXT → active v4.8 binding → player-facing spell-flow revision → current Product Root/validation evidence → Runtime·Tests`.
+
+`CURRENT_CONFIRMED_DECISIONS.md`, `CURRENT_UNRESOLVED_GATES.md`, and `CANON_SYNC_STATE.json` are v4.5-era historical compatibility snapshots; they are discovery inputs, not current state writers. The current canon/fun/visual audit is `docs/planning/audits/2026-08-28-grimoire-canon-fun-visual-audit.md`.
 
 ## Godot
 

--- a/docs/planning/audits/2026-08-28-grimoire-canon-fun-visual-audit.md
+++ b/docs/planning/audits/2026-08-28-grimoire-canon-fun-visual-audit.md
@@ -1,0 +1,123 @@
+# GRIMOIRE 정본·핵심 경험·시각 이해 감사 — 2026-08-28
+
+```yaml
+issue: 218
+audit_mode: FRESH_READ_CANON_FUN_VISUAL
+project_main: 6377cbcf31958fc2b3215d7a9603dfa5f0199c04
+project_main_subject: "docs: sync greenhouse spirit asset seed (#217)"
+base_main: 7cfc75d607d1ed4d0f8323d4389e64da93df00c8
+base_main_subject: "docs: close BCP-2026-046 as implemented (#767)"
+read_at: 2026-08-28
+scope: DOCUMENTATION_AND_HUMAN_CANON_RECONCILIATION_ONLY
+runtime_or_product_mutation: false
+```
+
+## 권위와 fresh-read 범위
+
+| Source | Exact identity | 판정 |
+| --- | --- | --- |
+| Project GitHub completed `main` | `6377cbcf31958fc2b3215d7a9603dfa5f0199c04` | CURRENT repository/runtime truth |
+| Base completed `main` | `7cfc75d607d1ed4d0f8323d4389e64da93df00c8` | CURRENT shared-workflow source; project pin v9.4.3 is compatibility input only |
+| Open PR #187 | Draft, `5fe76b4663eb31fc07d2c97d60d53f2911de5c91` | HISTORICAL/DUPLICATE_WORK candidate; Task8 screen is already consumed by Task9 on current `main`; READ_ONLY |
+| Open PR #166 | Draft, `d7d2dc94f68c94ff624836493a3ed054da7ec3d1` | HISTORICAL other-workstream; README-only; READ_ONLY |
+| Repository front doors | `AGENTS.md`, `START_HERE.md`, `docs/ACTIVE_CONTEXT.md`, v4.8 binding | CURRENT authority chain |
+| Notion human canon | GRIMOIRE Home and its Direction, Magic, Visual, Flow, Asset, Production owners | CURRENT only where readback agrees with current repository state; stale projections are listed below |
+| Runtime/code/data/Scene/test | `project.godot`, Product Root, Task6/7/8 screens, Coordinator, assets/manifests, integration tests | CURRENT implementation evidence |
+
+## Classification
+
+### CURRENT
+
+- `GM-SPELL-WORKFLOW-UI-V2-01` player wording: **글자 → 주문 → 대상 → 시전**; the internal `FIVE_POINT_STAR`, typed glyph resources, explicit preview, and exactly-once commit remain protected.
+- Product Root is `res://src/ui/spell_workflow/spell_workflow_product_root.tscn`; its implemented bounded flow is write/recognise/save → circuit preview/prepare → two explicit target alternatives → two-step cast → result receipt.
+- Task9 (PR #192), Task10 (#197), Task11 (#205), Task12 (#208), and Task13 (#210) are merged. Task11 binds the greenhouse field background and Academy theme; Task13 renders the authoritative result receipt/target/mana payload.
+- Six glyph PNGs are current Product Root consumers via `glyph_visual_resolver.gd`. The greenhouse field background is a current Product Root Texture2D consumer.
+- Visual direction `GM-VISUAL-DIRECTION-20260825-01` is approved style-only reference: Soft Storybook Cel 2D Hybrid, navy/aged gold, glasshouse night depth, warm lantern contrast, restrained blue-to-violet magic. It is not character/world/UI-content canon or a runtime asset.
+
+### HISTORICAL / SUPERSEDED
+
+- v4.5 `CURRENT_CONFIRMED_DECISIONS.md`, `CURRENT_UNRESOLVED_GATES.md`, and `CANON_SYNC_STATE.json` retain useful provenance/compatibility literals but cannot state current execution gates.
+- Old Task8 preservation/reconciliation handoffs retain provenance only. The live current `main` has Task8's thin screen integrated through Task9; draft PR #187 must not be treated as the accepted frontier.
+- The 46-minute Frostbloom Flow Map remains approved planning input, but is not proof of a completed playable first session or a current runtime implementation map.
+
+### CONFLICT / FIX NOW
+
+1. Notion Production Handoff still says visual work is the current boundary and product implementation must not start. This conflicts with merged Product Root work. It must be replaced with an historical boundary plus the current validation gate.
+2. The Notion Visual Asset Coverage page contains older readbacks that describe Task8/Task9 as absent or pending next work. Its current header must point to the repository's current merged reality and preserve old paragraphs as provenance.
+3. Repository front-door projections ended at Task10 even though Task11–13 and PR #217 are merged. This audit updates `START_HERE.md` and `docs/ACTIVE_CONTEXT.md` without promoting any unrun evidence.
+
+### UNKNOWN_UNVERIFIED
+
+- Fresh local Godot headless execution was unavailable because no `godot` command was present.
+- No GRIMOIRE Godot editor session was connected; only other projects were listed. There is no new live runtime observation in this audit.
+- Human usability, player experience, mobile device, performance, Windows/Android export, release rights, and full vertical-slice validation remain `NOT_RUN`.
+- The greenhouse spirit idle/unstable PNG is `PROJECT_ASSET_APPROVED_IMPLEMENTATION_PENDING`: file/provenance exist; Godot import, Battle Scene binding, and runtime consumption are not verified.
+
+## Recalculated current work
+
+| Item | State | Evidence ceiling |
+| --- | --- | --- |
+| Current project goal | Make learned magical letters into deliberate situation-changing spells, then turn observed consequences into knowledge for the next problem. | CURRENT design intent; player appeal untested |
+| Accepted frontier | Product Root automated vertical slice plus post-Task9 presentation corrections; next gate is user vertical-slice validation. | Automated/repository evidence only |
+| Work 5 position | **5/5: validation and decision gate entered**, not passed. Design and bounded Product Root are connected; human/player proof remains pending. | Human gate NOT_RUN |
+| Active playable slice | Safe greenhouse practicum: one recognised `HEAT` glyph, a prepared spell, `WARD` or `FLOWER`, explicit two-step cast, result receipt, restart. | Code/test evidence, not a full Frostbloom session |
+| Visual/audio | Glyph set and one background are Product Root consumers; Academy live theme is bound. No approved audio runtime consumer/readback. | Visual runtime completeness and audio proof NOT_PROVEN |
+
+## Player experience trace
+
+```text
+Player promise
+→ understand a magical letter's meaning and deliberately compose a spell
+→ decide what to preserve or stabilise under constraints
+→ see target, cost, and consequence before committing
+→ receive an explainable result/side effect record
+→ learn what to try differently in the next situation
+```
+
+The current Product Root proves only the skeleton of this trace. The full promise needs the Frostbloom situation, instability/environment consequences, Grimoire reflection, and human observation before it can be claimed as fun, clear, or memorable.
+
+## Core classification
+
+| Candidate | Class | Evidence |
+| --- | --- | --- |
+| Learning a glyph meaning and using it to make a contextual spell | PROJECT_CORE | Home, player-facing decision, product flow |
+| Explicit compose → preview → target → cast transaction | PROJECT_CORE | v2 decision, Coordinator, Product Root tests |
+| Consequence/side-effect explanation recorded as next knowledge | PROJECT_CORE, currently PARTIAL in runtime | Home/Frostbloom canon; Product Root receipt is a thin first proof |
+| FIVE_POINT_STAR and typed resource accounting | CORE_SUPPORT / TECHNICAL_FOUNDATION | approved balance decision and existing services |
+| Result receipt, Academy theme, glyph/background assets | MVP_SUPPORT / PRESENTATION_SHELL | Task11/13, scene/asset consumers |
+| Full 46-minute Frostbloom session, combat, investigation, meta progression | APPROVED PLANNED CORE EXPRESSION, implementation UNVERIFIED | Flow Map/Frostbloom planning; not current runtime |
+
+## Evidence-based SWOT
+
+| Statement | Class | Evidence / confidence | Player impact | Disposition / next validation |
+| --- | --- | --- | --- | --- |
+| Direct writing plus deliberate, exactly-once casting gives the player visible authorship rather than a one-click spell list. | STRENGTH | Product Root, Coordinator, tests; VERIFIED for mechanics, PARTIAL for appeal | High potential ownership | PROTECT; observe whether players understand why each confirmation exists |
+| The first playable root offers two valid targets but not yet a meaningful visible trade-off with different felt consequences. | WEAKNESS | Task9 target payload/tests; VERIFIED | Choice may read as cosmetic | IMPROVE; user test must ask players to predict and explain their target choice |
+| Frostbloom's nonlethal instability/environment resolution can differentiate the game from damage-first fantasy combat. | OPPORTUNITY | Battle Rules/Frostbloom planning; PARTIAL | Could make responsibility and learning memorable | TEST; build only the smallest situation evidence after user validation |
+| The current UI/root is a bounded practicum rather than the whole learning→situation→record loop. | THREAT | Product Root non-scope; VERIFIED | Players may not see the selling point in one short flow | MITIGATE; validate core comprehension before expanding asset/content production |
+| Visual grammar is coherent at reference level, but the generated board and assets do not prove mobile readability or screen-level consistency. | WEAKNESS | approved reference + current asset bindings; PARTIAL | Style could mask unclear decisions | TEST; actual 1280×720/phone-size user observation with live UI |
+
+## Visual planning board
+
+`PROJECT_CORE_SCENE_VISUAL_BOARD` was generated once in this audit as `GENERATED_EXPLORATION` for project-understanding review. It is not committed, not an Asset Library record, not a runtime asset, and not a design approval.
+
+| Panel | Intended screen/scene | Player goal / choice | Current evidence | Unresolved |
+| --- | --- | --- | --- | --- |
+| 01 | Main/title invitation | Enter a magical-learning space | visual direction only | title/menu information architecture |
+| 02 | First glyph practicum | Write/recognise a meaningful glyph | Task6/Product Root | onboarding language and recognition confidence |
+| 03 | Spell composition | Make a complete spell with one main and optional auxiliaries | Task7/Product Root | completed-spell naming grammar |
+| 04 | Greenhouse situation | choose a target, inspect final preview, explicitly cast | Task8/Task9 structure | visible trade-off/consequence design |
+| 05 | Result/Grimoire reflection | understand what changed and carry knowledge forward | Task13 receipt + planned Grimoire | persistent record, reward, failure-learning loop |
+
+Adversarial result: the board matches the lighting/material/style anchor, but it fails as a final design reference because it contains pseudo-text, an unapproved generic protagonist appearance, and does not make the two-target trade-off legible. Do not use it as a production prompt without a revised, user-approved brief.
+
+## Required order
+
+1. User vertical-slice validation of the current Product Root: comprehension, target-choice rationale, confirmation burden, result understanding, and desire to continue.
+2. Resolve the player-facing **target trade-off** contract before any Battle/first-session production asset batch.
+3. Update the full Frostbloom situation implementation contract from proven Product Root seams; preserve one-threat/one-situation production cap.
+4. Only then bind approved greenhouse-spirit asset and create missing runtime assets with consumer contracts.
+
+## Base promotion
+
+`NO_BASE_PROMOTION`: this audit's stale Task8/Task9/Task11 lineage and Notion projections are GRIMOIRE-specific. The reusable lesson is already covered by Base canonical-reference freshness and adversarial-review routes.


### PR DESCRIPTION
Closes #218\n\n## Scope\n- Reconcile repository and Notion projections with completed main through PR #217.\n- Record current/historical/conflict/unverified classifications and evidence ceiling.\n- Add the player-experience, SWOT, visual-board, and validation audit.\n\n## Exclusions\n- No Godot/runtime mutation, production asset batch, or change to other open PRs.\n- No claim of fresh Godot, device, performance, or human validation.\n\n## Validation\n- python tools/generate_project_operating_views.py --check\n- python -m unittest tests.test_base_v91_operating_contract tests.test_current_authority_reality_contract