### PR TITLE
fix(godot): ignore archived Task8 recovery sources

### DIFF
--- a/tests/test_runner.gd
+++ b/tests/test_runner.gd
@@ -3,6 +3,7 @@ extends SceneTree
 const TestCase = preload("res://tests/test_case.gd")
 
 const SUITES: Array[String] = [
+    "res://tests/unit/test_artifact_recovery_scanner_boundary.gd",
     "res://tests/unit/test_glyph_resource_types.gd",
     "res://tests/unit/test_glyph_catalog.gd",
     "res://tests/unit/test_glyph_source_loadout.gd",

--- a/tests/unit/test_artifact_recovery_scanner_boundary.gd
+++ b/tests/unit/test_artifact_recovery_scanner_boundary.gd
@@ -1,0 +1,11 @@
+# Task8 recovery evidence must stay outside Godot's active resource scan.
+extends RefCounted
+
+const RECOVERY_IGNORE_PATH := "res://artifacts/recovery/.gdignore"
+
+
+func run(case) -> void:
+    case.assert_true(
+        FileAccess.file_exists(RECOVERY_IGNORE_PATH),
+        "Task8 recovery evidence must be excluded from Godot resource scanning"
+    )


### PR DESCRIPTION
## Problem
Archived Task8 recovery snapshots contain historical GDScript copies with global `class_name` declarations. Godot scanned those evidence-only files and hid the live runtime classes, producing 25 cascading test failures on current main.

## Change
- Preserve the recovery archive and add `artifacts/recovery/.gdignore` so Godot does not import or scan it.
- Add a regression suite that requires the scan boundary.
- Register the suite in the project runner.

## Evidence
- Red: the new regression test failed before the marker existed.
- Green: Godot 4.7.1 headless runner: 49 suites, 2,052 assertions, 0 failures.
- Runtime start: product main scene exited 0 with no engine-error lines.

## Scope / non-goals
No archived evidence or runtime source was deleted. Human, device, performance, accessibility, export, and full-slice validation remain unrun.