### PR TITLE
fix(ui): refresh product background resource UID

### DIFF
--- a/src/ui/spell_workflow/spell_workflow_product_root.tscn
+++ b/src/ui/spell_workflow/spell_workflow_product_root.tscn
@@ -5,7 +5,7 @@
 [ext_resource type="PackedScene" uid="uid://dhkd7pos74iaa" path="res://src/ui/spell_workflow/glyph_drawing_screen.tscn" id="2_kmny2"]
 [ext_resource type="PackedScene" uid="uid://bolap7p5hkar8" path="res://src/ui/spell_workflow/circuit_placement_screen.tscn" id="3_ag2ki"]
 [ext_resource type="PackedScene" uid="uid://qfvh1n7f5veh" path="res://src/ui/spell_workflow/spell_use_screen.tscn" id="4_3otfq"]
-[ext_resource type="Texture2D" uid="uid://duso5wqwacnym" path="res://assets/art/backgrounds/greenhouse/bg_greenhouse_field_base.webp" id="5_2w8ln"]
+[ext_resource type="Texture2D" uid="uid://dt6j1nhjykbx1" path="res://assets/art/backgrounds/greenhouse/bg_greenhouse_field_base.webp" id="5_2w8ln"]
 
 [node name="SpellWorkflowProductRoot" type="Control" unique_id=1353567651]
 layout_mode = 3

--- a/tests/test_runner.gd
+++ b/tests/test_runner.gd
@@ -4,6 +4,7 @@ const TestCase = preload("res://tests/test_case.gd")
 
 const SUITES: Array[String] = [
     "res://tests/unit/test_artifact_recovery_scanner_boundary.gd",
+    "res://tests/unit/test_spell_workflow_background_uid.gd",
     "res://tests/unit/test_glyph_resource_types.gd",
     "res://tests/unit/test_glyph_catalog.gd",
     "res://tests/unit/test_glyph_source_loadout.gd",

--- a/tests/unit/test_spell_workflow_background_uid.gd
+++ b/tests/unit/test_spell_workflow_background_uid.gd
@@ -1,0 +1,18 @@
+extends RefCounted
+
+const PRODUCT_ROOT_PATH := "res://src/ui/spell_workflow/spell_workflow_product_root.tscn"
+const GREENHOUSE_BACKGROUND_PATH := "res://assets/art/backgrounds/greenhouse/bg_greenhouse_field_base.webp"
+
+
+func run(case) -> void:
+    var expected_uid := ResourceUID.id_to_text(ResourceLoader.get_resource_uid(GREENHOUSE_BACKGROUND_PATH))
+    case.assert_true(not expected_uid.is_empty(), "greenhouse background must have a Godot resource UID")
+    if expected_uid.is_empty():
+        return
+
+    var scene_text := FileAccess.get_file_as_string(PRODUCT_ROOT_PATH)
+    var expected_reference := 'uid="%s" path="%s"' % [expected_uid, GREENHOUSE_BACKGROUND_PATH]
+    case.assert_true(
+        scene_text.contains(expected_reference),
+        "product root background reference must use the current greenhouse asset UID"
+    )


### PR DESCRIPTION
## Problem
The product-root scene referenced the greenhouse background with an obsolete Godot resource UID. Godot could fall back to the file path, but emitted an invalid-UID warning each time the root loaded.

## Change
- Refresh the Texture2D UID in `spell_workflow_product_root.tscn` from the current imported asset metadata.
- Add a unit regression that compares the scene reference with the asset's runtime UID.
- Register the test in the project runner.

## Evidence
- Red: the new UID test failed before the scene change.
- Green: Godot 4.7.1 runner: 50 suites, 2,054 assertions, 0 failures.
- Runtime: main scene exit 0; product-root background invalid-UID warning count 0; engine-error line count 0.

## Scope
This is a single-resource-reference integrity repair. It intentionally does not sweep the remaining independent legacy UID warnings.