### PR TITLE
chore(godot): ignore nonruntime temporary renders

### DIFF
--- a/tests/test_runner.gd
+++ b/tests/test_runner.gd
@@ -4,6 +4,7 @@ const TestCase = preload("res://tests/test_case.gd")
 
 const SUITES: Array[String] = [
     "res://tests/unit/test_artifact_recovery_scanner_boundary.gd",
+    "res://tests/unit/test_tmp_scanner_boundary.gd",
     "res://tests/unit/test_spell_workflow_background_uid.gd",
     "res://tests/unit/test_glyph_resource_types.gd",
     "res://tests/unit/test_glyph_catalog.gd",

--- a/tests/unit/test_tmp_scanner_boundary.gd
+++ b/tests/unit/test_tmp_scanner_boundary.gd
@@ -1,0 +1,11 @@
+# Rendered planning evidence must not be scanned as game resources.
+extends RefCounted
+
+const TMP_IGNORE_PATH := "res://tmp/.gdignore"
+
+
+func run(case) -> void:
+    case.assert_true(
+        FileAccess.file_exists(TMP_IGNORE_PATH),
+        "temporary planning renders must be excluded from Godot resource scanning"
+    )


### PR DESCRIPTION
## Problem
Godot scanned 200 nonruntime PDF-rendering artifacts under `tmp/` (about 21.2 MiB, including 93 generated `.import` files) during fresh project imports. No active game code, scene, data resource, or project configuration references `res://tmp/`.

## Change
- Preserve the temporary planning evidence on disk and in Git.
- Add `tmp/.gdignore` so Godot excludes this nonruntime directory from import and export scanning.
- Add and register a regression test that protects the scanner boundary.

## Evidence
- Red: the new boundary test failed before the marker existed.
- Green: Godot 4.7.1 runner: 51 suites, 2,055 assertions, 0 failures.
- Runtime: product main scene exit 0; engine-error lines 0; no `tmp/` entry in the global class cache.

## Scope / follow-up
No temporary render was deleted. A separate retention audit must map each source render to its canonical PDF before any size-reclamation deletion is considered.